### PR TITLE
feat: core loop screens with Reanimated animations (Phase 3)

### DIFF
--- a/apps/native/app/(app)/(tabs)/index.tsx
+++ b/apps/native/app/(app)/(tabs)/index.tsx
@@ -1,15 +1,212 @@
-import { Text } from "react-native";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { Button, Spinner } from "heroui-native";
+import { Text, View } from "react-native";
+
+import { authClient } from "@/lib/auth-client";
+import { colors } from "@/lib/design-tokens";
+import { LivesBar } from "@/components/session/LivesBar";
 import { Screen } from "@/components/common/Screen";
+import { Skeleton } from "@/components/common/Skeleton";
+import { StreakBadge } from "@/components/gamification/StreakBadge";
+import {
+  useStartSession,
+  useTodaySession,
+} from "@/hooks/useSessionQuery";
+import { useLives } from "@/hooks/useLives";
+import { useStreaks } from "@/hooks/useStreaks";
+import { useXp } from "@/hooks/useXp";
 
 export default function HomeScreen() {
+  const { data: session } = authClient.useSession();
+  const todaySession = useTodaySession();
+  const lives = useLives();
+  const streaks = useStreaks();
+  const xp = useXp();
+  const startSession = useStartSession();
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const handleStart = () => {
+    startSession.mutate("all", {
+      onSuccess: (data) => {
+        queryClient.setQueryData(["session", "active", data.session.id], data);
+        router.push(`/session/${data.session.id}`);
+      },
+    });
+  };
+
+  const handleResume = (sessionId: number) => {
+    router.push(`/session/${sessionId}`);
+  };
+
+  const livesData = lives.data;
+  const noLives = livesData?.lives === 0;
+  const resetsAt = livesData?.resetsAt ? new Date(livesData.resetsAt) : null;
+  const livesCountdown = resetsAt ? formatCountdown(resetsAt) : null;
+
+  const activeSession = todaySession.data?.session ?? null;
+  const isCompleted = activeSession?.completedAt != null;
+  const buttonPending = startSession.isPending;
+
   return (
-    <Screen scrollable={false}>
-      <Text className="text-foreground text-xl font-semibold text-center mt-20">
-        Home
-      </Text>
-      <Text className="text-default-500 text-center mt-2">
-        Session entry point — wired in Phase 3
-      </Text>
+    <Screen>
+      <View style={{ paddingTop: 16, gap: 32 }}>
+        <View
+          style={{
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          {streaks.isLoading ? (
+            <Skeleton width={80} height={32} />
+          ) : (
+            <StreakBadge count={streaks.data?.currentStreak ?? 0} />
+          )}
+          {lives.isLoading ? (
+            <Skeleton width={140} height={24} />
+          ) : (
+            <LivesBar
+              livesRemaining={livesData?.lives ?? 0}
+              maxLives={livesData?.maxLives ?? 5}
+            />
+          )}
+        </View>
+
+        <View style={{ gap: 4 }}>
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "900",
+              letterSpacing: -0.6,
+              color: colors.text,
+            }}
+          >
+            Olá, {session?.user?.name ?? "estudante"}
+          </Text>
+          <Text
+            style={{
+              fontSize: 13,
+              fontWeight: "700",
+              color: colors.textMuted,
+            }}
+          >
+            Continue sua jornada
+          </Text>
+        </View>
+
+        {xp.isLoading ? (
+          <Skeleton width="100%" height={80} />
+        ) : xp.data ? (
+          <View
+            style={{
+              backgroundColor: "#FFFFFF",
+              borderRadius: 24,
+              borderWidth: 2,
+              borderColor: colors.border,
+              padding: 20,
+              gap: 8,
+            }}
+          >
+            <View
+              style={{
+                flexDirection: "row",
+                justifyContent: "space-between",
+              }}
+            >
+              <Text style={{ fontSize: 14, fontWeight: "900", color: colors.text }}>
+                Nível {xp.data.currentLevel}
+              </Text>
+              <Text style={{ fontSize: 14, fontWeight: "900", color: colors.primary }}>
+                {xp.data.totalXp} XP
+              </Text>
+            </View>
+            <Text style={{ fontSize: 12, fontWeight: "700", color: colors.textMuted }}>
+              Faltam {xp.data.xpForNextLevel} XP para o próximo nível
+            </Text>
+          </View>
+        ) : null}
+
+        <View
+          style={{
+            backgroundColor: "#FFFFFF",
+            borderRadius: 32,
+            borderWidth: 2,
+            borderColor: colors.border,
+            padding: 24,
+            gap: 12,
+          }}
+        >
+          {todaySession.isLoading ? (
+            <Skeleton width="100%" height={100} />
+          ) : isCompleted ? (
+            <>
+              <Text style={{ fontSize: 18, fontWeight: "900", color: colors.text }}>
+                Você está em dia!
+              </Text>
+              <Text style={{ fontSize: 13, fontWeight: "700", color: colors.textMuted }}>
+                {activeSession?.questionsCorrect ?? 0}/
+                {activeSession?.questionsAnswered ?? 0} corretas hoje. Volte
+                amanhã.
+              </Text>
+            </>
+          ) : activeSession ? (
+            <>
+              <Text style={{ fontSize: 18, fontWeight: "900", color: colors.text }}>
+                Sessão em andamento
+              </Text>
+              <Button
+                onPress={() => handleResume(activeSession.id)}
+                isDisabled={noLives}
+              >
+                <Button.Label>Continuar</Button.Label>
+              </Button>
+            </>
+          ) : (
+            <>
+              <Text style={{ fontSize: 18, fontWeight: "900", color: colors.text }}>
+                Sessão de hoje
+              </Text>
+              <Text style={{ fontSize: 13, fontWeight: "700", color: colors.textMuted }}>
+                10 questões prontas para você
+              </Text>
+              <Button onPress={handleStart} isDisabled={noLives || buttonPending}>
+                {buttonPending ? (
+                  <Spinner size="sm" color="default" />
+                ) : (
+                  <Button.Label>Começar</Button.Label>
+                )}
+              </Button>
+            </>
+          )}
+
+          {noLives && livesCountdown && (
+            <Text
+              style={{
+                fontSize: 12,
+                fontWeight: "700",
+                color: colors.danger,
+                textAlign: "center",
+              }}
+            >
+              Vidas voltam em {livesCountdown}
+            </Text>
+          )}
+        </View>
+      </View>
     </Screen>
   );
+}
+
+function formatCountdown(resetsAt: Date): string {
+  const now = new Date();
+  const diffMs = resetsAt.getTime() - now.getTime();
+  if (diffMs <= 0) return "0m";
+
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
 }

--- a/apps/native/app/(app)/session/[id].tsx
+++ b/apps/native/app/(app)/session/[id].tsx
@@ -1,18 +1,160 @@
-import { Text } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Button, Spinner } from "heroui-native";
+import { useEffect, useState } from "react";
+import { Text, View } from "react-native";
+
+import type { StartSessionResponse } from "@pruvi/shared";
+
+import { colors } from "@/lib/design-tokens";
+import { LivesBar } from "@/components/session/LivesBar";
+import { ProgressBar } from "@/components/session/ProgressBar";
+import { QuestionCard } from "@/components/session/QuestionCard";
 import { Screen } from "@/components/common/Screen";
+import { useAnswerQuestion } from "@/hooks/useSessionQuery";
+import { useLives } from "@/hooks/useLives";
+import { useGamificationStore } from "@/stores/gamificationStore";
+import { useSessionStore } from "@/stores/sessionStore";
+
+const ANSWER_ANIMATION_MS = 1200;
 
 export default function SessionScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const sessionId = Number(id);
+  const router = useRouter();
+
+  const { data: session } = useQuery<StartSessionResponse>({
+    queryKey: ["session", "active", sessionId],
+    queryFn: () => {
+      throw new Error("Session not loaded — return to home");
+    },
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  const lives = useLives();
+  const answerQuestion = useAnswerQuestion();
+
+  const currentQuestionIndex = useSessionStore((s) => s.currentQuestionIndex);
+  const selectedOptionIndex = useSessionStore((s) => s.selectedOptionIndex);
+  const answerState = useSessionStore((s) => s.answerState);
+  const livesRemaining = useSessionStore((s) => s.livesRemaining);
+  const sessionActions = useSessionStore((s) => s.actions);
+  const gamificationActions = useGamificationStore((s) => s.actions);
+
+  const [correctIndex, setCorrectIndex] = useState<number | null>(null);
+  const [correctCount, setCorrectCount] = useState(0);
+
+  useEffect(() => {
+    if (lives.data) {
+      sessionActions.reset(lives.data.lives);
+    }
+    return () => {
+      sessionActions.reset(5);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lives.data?.lives]);
+
+  if (!session) {
+    return (
+      <Screen scrollable={false}>
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center", gap: 16 }}>
+          <Text style={{ fontSize: 16, color: colors.text }}>
+            Sessão não encontrada.
+          </Text>
+          <Button onPress={() => router.replace("/(app)/(tabs)")}>
+            <Button.Label>Voltar ao início</Button.Label>
+          </Button>
+        </View>
+      </Screen>
+    );
+  }
+
+  const currentQuestion = session.questions[currentQuestionIndex];
+  const totalQuestions = session.questions.length;
+
+  if (!currentQuestion) {
+    return (
+      <Screen scrollable={false}>
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+          <Spinner size="lg" />
+        </View>
+      </Screen>
+    );
+  }
+
+  const handleAnswer = () => {
+    if (selectedOptionIndex === null) return;
+
+    answerQuestion.mutate(
+      { questionId: currentQuestion.id, selectedOptionIndex },
+      {
+        onSuccess: (res) => {
+          setCorrectIndex(res.correctOptionIndex);
+          sessionActions.setAnswerState(res.correct ? "correct" : "wrong");
+          sessionActions.setLivesRemaining(res.livesRemaining);
+          gamificationActions.addXP(res.xpAwarded);
+          const nextCorrectCount = correctCount + (res.correct ? 1 : 0);
+          if (res.correct) setCorrectCount(nextCorrectCount);
+
+          setTimeout(() => {
+            const isLastQuestion = currentQuestionIndex === totalQuestions - 1;
+            const noLivesLeft = res.livesRemaining === 0;
+
+            if (isLastQuestion || noLivesLeft) {
+              router.replace({
+                pathname: "/session/result",
+                params: {
+                  sessionId: String(sessionId),
+                  questionCount: String(currentQuestionIndex + 1),
+                  correctCount: String(nextCorrectCount),
+                },
+              });
+            } else {
+              setCorrectIndex(null);
+              sessionActions.nextQuestion();
+            }
+          }, ANSWER_ANIMATION_MS);
+        },
+      },
+    );
+  };
+
+  const buttonDisabled =
+    selectedOptionIndex === null ||
+    answerState !== "idle" ||
+    answerQuestion.isPending;
 
   return (
-    <Screen scrollable={false}>
-      <Text className="text-foreground text-xl font-semibold text-center mt-20">
-        Session {id}
-      </Text>
-      <Text className="text-default-500 text-center mt-2">
-        Active Q&A loop — wired in Phase 3
-      </Text>
+    <Screen>
+      <View style={{ gap: 24, paddingVertical: 16 }}>
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 16,
+          }}
+        >
+          <ProgressBar total={totalQuestions} completed={currentQuestionIndex} />
+          <LivesBar livesRemaining={livesRemaining} />
+        </View>
+
+        <QuestionCard
+          question={currentQuestion}
+          selectedIndex={selectedOptionIndex}
+          answerState={answerState}
+          correctIndex={correctIndex}
+          onSelect={sessionActions.selectOption}
+        />
+
+        <Button onPress={handleAnswer} isDisabled={buttonDisabled}>
+          {answerQuestion.isPending ? (
+            <Spinner size="sm" color="default" />
+          ) : (
+            <Button.Label>Responder</Button.Label>
+          )}
+        </Button>
+      </View>
     </Screen>
   );
 }

--- a/apps/native/app/(app)/session/result.tsx
+++ b/apps/native/app/(app)/session/result.tsx
@@ -1,15 +1,91 @@
-import { Text } from "react-native";
+import { useQueryClient } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Button, Spinner } from "heroui-native";
+import { Text, View } from "react-native";
+
+import { CharacterAvatar } from "@/components/gamification/CharacterAvatar";
+import { StreakBadge } from "@/components/gamification/StreakBadge";
+import { XPCounter } from "@/components/gamification/XPCounter";
 import { Screen } from "@/components/common/Screen";
+import { colors } from "@/lib/design-tokens";
+import { useCompleteSession } from "@/hooks/useSessionQuery";
+import { useStreaks } from "@/hooks/useStreaks";
+import { useGamificationStore } from "@/stores/gamificationStore";
 
 export default function SessionResultScreen() {
+  const { sessionId, questionCount, correctCount } = useLocalSearchParams<{
+    sessionId: string;
+    questionCount: string;
+    correctCount: string;
+  }>();
+
+  const qCount = Number(questionCount ?? 0);
+  const cCount = Number(correctCount ?? 0);
+  const accuracy = qCount > 0 ? Math.round((cCount / qCount) * 100) : 0;
+
+  const pendingXP = useGamificationStore((s) => s.pendingXP);
+  const gamificationActions = useGamificationStore((s) => s.actions);
+  const streaks = useStreaks();
+  const completeSession = useCompleteSession();
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const expression: "happy" | "neutral" | "sad" =
+    accuracy >= 70 ? "happy" : accuracy >= 40 ? "neutral" : "sad";
+
+  const handleContinue = () => {
+    completeSession.mutate(
+      { id: Number(sessionId), questionCount: qCount, correctCount: cCount },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ["session", "today"] });
+          queryClient.invalidateQueries({ queryKey: ["streaks"] });
+          queryClient.invalidateQueries({ queryKey: ["xp"] });
+          queryClient.invalidateQueries({ queryKey: ["lives"] });
+          gamificationActions.flush();
+          router.replace("/(app)/(tabs)");
+        },
+      },
+    );
+  };
+
   return (
-    <Screen scrollable={false}>
-      <Text className="text-foreground text-xl font-semibold text-center mt-20">
-        Session Result
-      </Text>
-      <Text className="text-default-500 text-center mt-2">
-        XP breakdown — wired in Phase 3
-      </Text>
+    <Screen>
+      <View style={{ alignItems: "center", paddingTop: 40, gap: 24 }}>
+        <CharacterAvatar expression={expression} size={80} />
+
+        <XPCounter earnedXP={pendingXP} />
+
+        <View style={{ alignItems: "center", gap: 4 }}>
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "900",
+              letterSpacing: -0.6,
+              color: colors.text,
+            }}
+          >
+            {cCount}/{qCount} corretas
+          </Text>
+          <Text style={{ fontSize: 18, fontWeight: "700", color: colors.textMuted }}>
+            {accuracy}% de acerto
+          </Text>
+        </View>
+
+        {streaks.data && <StreakBadge count={streaks.data.currentStreak} />}
+
+        <Button
+          onPress={handleContinue}
+          isDisabled={completeSession.isPending}
+          style={{ marginTop: 24, alignSelf: "stretch" }}
+        >
+          {completeSession.isPending ? (
+            <Spinner size="sm" color="default" />
+          ) : (
+            <Button.Label>Continuar</Button.Label>
+          )}
+        </Button>
+      </View>
     </Screen>
   );
 }

--- a/apps/native/components/gamification/CharacterAvatar.tsx
+++ b/apps/native/components/gamification/CharacterAvatar.tsx
@@ -1,0 +1,46 @@
+import { Ionicons } from "@expo/vector-icons";
+import { View } from "react-native";
+
+import { colors } from "@/lib/design-tokens";
+
+export type AvatarExpression = "neutral" | "happy" | "sad";
+
+interface Props {
+  expression: AvatarExpression;
+  size?: number;
+}
+
+export function CharacterAvatar({ expression, size = 80 }: Props) {
+  const { iconName, color, opacity } = getAvatarAppearance(expression);
+  const containerSize = size + 20;
+
+  return (
+    <View
+      style={{
+        width: containerSize,
+        height: containerSize,
+        borderRadius: containerSize / 2,
+        backgroundColor: "#FFFFFF",
+        borderWidth: 2,
+        borderColor: colors.border,
+        alignItems: "center",
+        justifyContent: "center",
+        opacity,
+      }}
+    >
+      <Ionicons name={iconName} size={size} color={color} />
+    </View>
+  );
+}
+
+function getAvatarAppearance(expression: AvatarExpression) {
+  switch (expression) {
+    case "happy":
+      return { iconName: "happy" as const, color: colors.primary, opacity: 1 };
+    case "sad":
+      return { iconName: "sad-outline" as const, color: colors.textMuted, opacity: 1 };
+    case "neutral":
+    default:
+      return { iconName: "happy" as const, color: colors.text, opacity: 0.7 };
+  }
+}

--- a/apps/native/components/gamification/StreakBadge.tsx
+++ b/apps/native/components/gamification/StreakBadge.tsx
@@ -1,0 +1,55 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect } from "react";
+import { Text } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withSpring,
+} from "react-native-reanimated";
+
+import { colors, radii } from "@/lib/design-tokens";
+
+interface Props {
+  count: number;
+  animate?: boolean;
+}
+
+export function StreakBadge({ count, animate }: Props) {
+  const scale = useSharedValue(1);
+
+  useEffect(() => {
+    if (animate) {
+      scale.value = withSequence(
+        withSpring(1.2, { damping: 8, stiffness: 180 }),
+        withSpring(1, { damping: 10, stiffness: 180 }),
+      );
+    }
+  }, [animate, scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        {
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 6,
+          backgroundColor: colors.accentLight,
+          paddingHorizontal: 10,
+          paddingVertical: 6,
+          borderRadius: radii.sm,
+        },
+        animatedStyle,
+      ]}
+    >
+      <Ionicons name="flame" size={20} color={colors.accent} />
+      <Text style={{ fontWeight: "900", fontSize: 12, color: colors.accent }}>
+        {count}
+      </Text>
+    </Animated.View>
+  );
+}

--- a/apps/native/components/gamification/XPCounter.tsx
+++ b/apps/native/components/gamification/XPCounter.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { Text } from "react-native";
+import {
+  Easing,
+  runOnJS,
+  useAnimatedReaction,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+
+import { colors } from "@/lib/design-tokens";
+
+interface Props {
+  earnedXP: number;
+  durationMs?: number;
+}
+
+export function XPCounter({ earnedXP, durationMs = 1200 }: Props) {
+  const value = useSharedValue(0);
+  const [displayed, setDisplayed] = useState(0);
+
+  useEffect(() => {
+    value.value = withTiming(earnedXP, {
+      duration: durationMs,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [earnedXP, durationMs, value]);
+
+  useAnimatedReaction(
+    () => value.value,
+    (current) => {
+      runOnJS(setDisplayed)(Math.round(current));
+    },
+  );
+
+  return (
+    <Text style={{ fontSize: 48, fontWeight: "900", color: colors.primary }}>
+      +{displayed} XP
+    </Text>
+  );
+}

--- a/apps/native/components/session/LivesBar.tsx
+++ b/apps/native/components/session/LivesBar.tsx
@@ -1,0 +1,58 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect, useRef } from "react";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+
+import { colors } from "@/lib/design-tokens";
+
+interface Props {
+  livesRemaining: number;
+  maxLives?: number;
+}
+
+export function LivesBar({ livesRemaining, maxLives = 5 }: Props) {
+  const translateX = useSharedValue(0);
+  const previousLives = useRef(livesRemaining);
+
+  useEffect(() => {
+    if (livesRemaining < previousLives.current) {
+      translateX.value = withSequence(
+        withTiming(-8, { duration: 60, easing: Easing.linear }),
+        withTiming(8, { duration: 60, easing: Easing.linear }),
+        withTiming(-8, { duration: 60, easing: Easing.linear }),
+        withTiming(0, { duration: 60, easing: Easing.linear }),
+      );
+    }
+    previousLives.current = livesRemaining;
+  }, [livesRemaining, translateX]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        { flexDirection: "row", gap: 4, alignItems: "center" },
+        animatedStyle,
+      ]}
+    >
+      {Array.from({ length: maxLives }, (_, i) => {
+        const filled = i < livesRemaining;
+        return (
+          <Ionicons
+            key={i}
+            name={filled ? "heart" : "heart-outline"}
+            size={20}
+            color={filled ? colors.accent : colors.surface}
+          />
+        );
+      })}
+    </Animated.View>
+  );
+}

--- a/apps/native/components/session/OptionButton.tsx
+++ b/apps/native/components/session/OptionButton.tsx
@@ -1,0 +1,142 @@
+import { memo, useEffect } from "react";
+import { Pressable, Text, View } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
+
+import { colors, radii } from "@/lib/design-tokens";
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+export type OptionButtonState = "idle" | "selected" | "correct" | "wrong";
+
+interface Props {
+  letter: string;
+  text: string;
+  state: OptionButtonState;
+  onPress: () => void;
+  disabled: boolean;
+}
+
+function OptionButtonImpl({ letter, text, state, onPress, disabled }: Props) {
+  const scale = useSharedValue(1);
+  const translateX = useSharedValue(0);
+
+  useEffect(() => {
+    if (state === "correct") {
+      scale.value = withSequence(
+        withSpring(1.05, { damping: 6, stiffness: 180 }),
+        withSpring(1, { damping: 10, stiffness: 180 }),
+      );
+    }
+    if (state === "wrong") {
+      translateX.value = withSequence(
+        withTiming(-8, { duration: 60, easing: Easing.linear }),
+        withTiming(8, { duration: 60, easing: Easing.linear }),
+        withTiming(-8, { duration: 60, easing: Easing.linear }),
+        withTiming(0, { duration: 60, easing: Easing.linear }),
+      );
+    }
+  }, [state, scale, translateX]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }, { translateX: translateX.value }],
+  }));
+
+  const handlePressIn = () => {
+    if (!disabled) {
+      scale.value = withSpring(0.97, { damping: 12, stiffness: 300 });
+    }
+  };
+  const handlePressOut = () => {
+    if (!disabled) {
+      scale.value = withSpring(1, { damping: 12, stiffness: 300 });
+    }
+  };
+
+  const containerStyles = getContainerStyles(state);
+  const letterStyles = getLetterStyles(state);
+
+  return (
+    <AnimatedPressable
+      onPress={onPress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      disabled={disabled}
+      style={[
+        {
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 12,
+          padding: 16,
+          borderRadius: radii.md,
+          borderWidth: 2,
+          borderColor: containerStyles.borderColor,
+          backgroundColor: containerStyles.bg,
+        },
+        animatedStyle,
+      ]}
+    >
+      <View
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: radii.sm,
+          backgroundColor: letterStyles.bg,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Text style={{ fontWeight: "900", fontSize: 14, color: letterStyles.color }}>
+          {letter}
+        </Text>
+      </View>
+      <Text
+        style={{
+          flex: 1,
+          fontWeight: state === "selected" ? "900" : "700",
+          fontSize: 14,
+          lineHeight: 20,
+          color: colors.text,
+        }}
+      >
+        {text}
+      </Text>
+    </AnimatedPressable>
+  );
+}
+
+function getContainerStyles(state: OptionButtonState) {
+  switch (state) {
+    case "selected":
+      return { bg: colors.selectedBg, borderColor: colors.selectedBorder };
+    case "correct":
+      return { bg: colors.primaryLight, borderColor: colors.primary };
+    case "wrong":
+      return { bg: colors.dangerLight, borderColor: colors.danger };
+    case "idle":
+    default:
+      return { bg: "#FFFFFF", borderColor: colors.border };
+  }
+}
+
+function getLetterStyles(state: OptionButtonState) {
+  switch (state) {
+    case "selected":
+      return { bg: colors.selectedBorder, color: "#FFFFFF" };
+    case "correct":
+      return { bg: colors.primary, color: "#FFFFFF" };
+    case "wrong":
+      return { bg: colors.danger, color: "#FFFFFF" };
+    case "idle":
+    default:
+      return { bg: colors.surface, color: colors.textMuted };
+  }
+}
+
+export const OptionButton = memo(OptionButtonImpl);

--- a/apps/native/components/session/ProgressBar.tsx
+++ b/apps/native/components/session/ProgressBar.tsx
@@ -1,0 +1,45 @@
+import { View } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { useEffect } from "react";
+
+import { colors } from "@/lib/design-tokens";
+
+interface Props {
+  total: number;
+  completed: number;
+}
+
+export function ProgressBar({ total, completed }: Props) {
+  return (
+    <View style={{ flex: 1, flexDirection: "row", gap: 6, alignItems: "center" }}>
+      {Array.from({ length: total }, (_, i) => (
+        <Segment key={i} isComplete={i < completed} />
+      ))}
+    </View>
+  );
+}
+
+function Segment({ isComplete }: { isComplete: boolean }) {
+  const progress = useSharedValue(isComplete ? 1 : 0);
+
+  useEffect(() => {
+    progress.value = withTiming(isComplete ? 1 : 0, { duration: 300 });
+  }, [isComplete, progress]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: progress.value > 0.5 ? colors.primary : colors.surface,
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        { flex: 1, height: 6, borderRadius: 3 },
+        animatedStyle,
+      ]}
+    />
+  );
+}

--- a/apps/native/components/session/QuestionCard.tsx
+++ b/apps/native/components/session/QuestionCard.tsx
@@ -1,0 +1,86 @@
+import { useCallback } from "react";
+import { Text, View } from "react-native";
+
+import type { ClientQuestion } from "@pruvi/shared";
+
+import { colors } from "@/lib/design-tokens";
+
+import { OptionButton, type OptionButtonState } from "./OptionButton";
+
+interface Props {
+  question: ClientQuestion;
+  selectedIndex: number | null;
+  answerState: "idle" | "correct" | "wrong";
+  correctIndex: number | null;
+  onSelect: (index: number) => void;
+}
+
+const LETTERS = ["A", "B", "C", "D"];
+
+export function QuestionCard({
+  question,
+  selectedIndex,
+  answerState,
+  correctIndex,
+  onSelect,
+}: Props) {
+  const handleSelect = useCallback((index: number) => onSelect(index), [onSelect]);
+
+  return (
+    <View style={{ gap: 24 }}>
+      <Text
+        style={{
+          fontSize: 15,
+          lineHeight: 24,
+          fontWeight: "500",
+          color: colors.text,
+        }}
+      >
+        {question.body}
+      </Text>
+
+      <View style={{ gap: 12 }}>
+        {question.options.map((optionText, index) => {
+          const state = computeOptionState({
+            index,
+            selectedIndex,
+            answerState,
+            correctIndex,
+          });
+          const isDisabled = answerState !== "idle";
+
+          return (
+            <OptionButton
+              key={index}
+              letter={LETTERS[index] ?? String(index + 1)}
+              text={optionText}
+              state={state}
+              onPress={() => handleSelect(index)}
+              disabled={isDisabled}
+            />
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+function computeOptionState({
+  index,
+  selectedIndex,
+  answerState,
+  correctIndex,
+}: {
+  index: number;
+  selectedIndex: number | null;
+  answerState: "idle" | "correct" | "wrong";
+  correctIndex: number | null;
+}): OptionButtonState {
+  if (answerState !== "idle") {
+    if (correctIndex === index) return "correct";
+    if (selectedIndex === index && answerState === "wrong") return "wrong";
+    return "idle";
+  }
+  if (selectedIndex === index) return "selected";
+  return "idle";
+}

--- a/apps/native/lib/design-tokens.ts
+++ b/apps/native/lib/design-tokens.ts
@@ -1,0 +1,32 @@
+export const colors = {
+  primary: "#58CD04",
+  primaryLight: "rgba(88, 205, 4, 0.08)",
+  primaryGlow: "rgba(88, 205, 4, 0.3)",
+  accent: "#FF9600",
+  accentLight: "rgba(255, 150, 0, 0.1)",
+  danger: "#EF4444",
+  dangerLight: "rgba(239, 68, 68, 0.08)",
+  warning: "#F59E0B",
+  warningLight: "rgba(255, 150, 0, 0.06)",
+  text: "#2B2B2B",
+  textMuted: "#6B6B6B",
+  surface: "#F0F0F0",
+  border: "rgba(239, 236, 236, 0.5)",
+  selectedBg: "rgba(59, 130, 246, 0.05)",
+  selectedBorder: "#3B82F6",
+} as const;
+
+export const typography = {
+  heading900: { fontWeight: "900" as const, letterSpacing: -0.6 },
+  bodyBold700: { fontWeight: "700" as const },
+  bodyRegular500: { fontWeight: "500" as const },
+  uppercaseLabel: { fontWeight: "900" as const, letterSpacing: 1, textTransform: "uppercase" as const },
+} as const;
+
+export const radii = {
+  sm: 10,
+  md: 16,
+  lg: 20,
+  xl: 24,
+  xxl: 32,
+} as const;

--- a/docs/superpowers/plans/2026-04-16-phase3-core-loop-screens.md
+++ b/docs/superpowers/plans/2026-04-16-phase3-core-loop-screens.md
@@ -1,0 +1,1365 @@
+# Phase 3: Core Loop Screens — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the core study loop (Home → Active Session → Session Result) with Reanimated animations, transforming the app from navigation skeleton to working study product.
+
+**Architecture:** Bottom-up — design tokens first (foundation), then components (session + gamification) with Reanimated animations, then screens that compose them. Session data flows through TanStack Query cache (not Zustand) to respect server-state ownership. Zustand only holds ephemeral UI state like selected option index.
+
+**Tech Stack:** Expo Router v4, TanStack Query v5, Zustand v5, Reanimated v3, HeroUI Native, Tailwind/Uniwind, zod
+
+---
+
+### Task 1: Design tokens
+
+**Files:**
+- Create: `apps/native/lib/design-tokens.ts`
+
+- [ ] **Step 1: Create the tokens file**
+
+Create `apps/native/lib/design-tokens.ts`:
+
+```typescript
+export const colors = {
+  primary: "#58CD04",
+  primaryLight: "rgba(88, 205, 4, 0.08)",
+  primaryGlow: "rgba(88, 205, 4, 0.3)",
+  accent: "#FF9600",
+  accentLight: "rgba(255, 150, 0, 0.1)",
+  danger: "#EF4444",
+  dangerLight: "rgba(239, 68, 68, 0.08)",
+  warning: "#F59E0B",
+  warningLight: "rgba(255, 150, 0, 0.06)",
+  text: "#2B2B2B",
+  textMuted: "#6B6B6B",
+  surface: "#F0F0F0",
+  border: "rgba(239, 236, 236, 0.5)",
+  selectedBg: "rgba(59, 130, 246, 0.05)",
+  selectedBorder: "#3B82F6",
+} as const;
+
+export const typography = {
+  heading900: { fontWeight: "900" as const, letterSpacing: -0.6 },
+  bodyBold700: { fontWeight: "700" as const },
+  bodyRegular500: { fontWeight: "500" as const },
+  uppercaseLabel: { fontWeight: "900" as const, letterSpacing: 1, textTransform: "uppercase" as const },
+} as const;
+
+export const radii = {
+  sm: 10,
+  md: 16,
+  lg: 20,
+  xl: 24,
+  xxl: 32,
+} as const;
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep design-tokens | head -5`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/lib/design-tokens.ts
+git commit -m "feat(native): add design tokens module (colors, typography, radii)"
+```
+
+---
+
+### Task 2: OptionButton component
+
+**Files:**
+- Create: `apps/native/components/session/OptionButton.tsx`
+
+- [ ] **Step 1: Create OptionButton with animations**
+
+Create `apps/native/components/session/OptionButton.tsx`:
+
+```typescript
+import { memo, useEffect } from "react";
+import { Pressable, Text, View } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
+
+import { colors, radii } from "@/lib/design-tokens";
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+export type OptionButtonState = "idle" | "selected" | "correct" | "wrong";
+
+interface Props {
+  letter: string;
+  text: string;
+  state: OptionButtonState;
+  onPress: () => void;
+  disabled: boolean;
+}
+
+function OptionButtonImpl({ letter, text, state, onPress, disabled }: Props) {
+  const scale = useSharedValue(1);
+  const translateX = useSharedValue(0);
+
+  // Correct answer: bounce animation
+  useEffect(() => {
+    if (state === "correct") {
+      scale.value = withSequence(
+        withSpring(1.05, { damping: 6, stiffness: 180 }),
+        withSpring(1, { damping: 10, stiffness: 180 }),
+      );
+    }
+    if (state === "wrong") {
+      translateX.value = withSequence(
+        withTiming(-8, { duration: 60, easing: Easing.linear }),
+        withTiming(8, { duration: 60, easing: Easing.linear }),
+        withTiming(-8, { duration: 60, easing: Easing.linear }),
+        withTiming(0, { duration: 60, easing: Easing.linear }),
+      );
+    }
+  }, [state, scale, translateX]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }, { translateX: translateX.value }],
+  }));
+
+  const handlePressIn = () => {
+    if (!disabled) {
+      scale.value = withSpring(0.97, { damping: 12, stiffness: 300 });
+    }
+  };
+  const handlePressOut = () => {
+    if (!disabled) {
+      scale.value = withSpring(1, { damping: 12, stiffness: 300 });
+    }
+  };
+
+  const containerStyles = getContainerStyles(state);
+  const letterStyles = getLetterStyles(state);
+
+  return (
+    <AnimatedPressable
+      onPress={onPress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      disabled={disabled}
+      style={[
+        {
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 12,
+          padding: 16,
+          borderRadius: radii.md,
+          borderWidth: 2,
+          borderColor: containerStyles.borderColor,
+          backgroundColor: containerStyles.bg,
+        },
+        animatedStyle,
+      ]}
+    >
+      <View
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: radii.sm,
+          backgroundColor: letterStyles.bg,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Text style={{ fontWeight: "900", fontSize: 14, color: letterStyles.color }}>
+          {letter}
+        </Text>
+      </View>
+      <Text
+        style={{
+          flex: 1,
+          fontWeight: state === "selected" ? "900" : "700",
+          fontSize: 14,
+          lineHeight: 20,
+          color: colors.text,
+        }}
+      >
+        {text}
+      </Text>
+    </AnimatedPressable>
+  );
+}
+
+function getContainerStyles(state: OptionButtonState) {
+  switch (state) {
+    case "selected":
+      return { bg: colors.selectedBg, borderColor: colors.selectedBorder };
+    case "correct":
+      return { bg: colors.primaryLight, borderColor: colors.primary };
+    case "wrong":
+      return { bg: colors.dangerLight, borderColor: colors.danger };
+    case "idle":
+    default:
+      return { bg: "#FFFFFF", borderColor: colors.border };
+  }
+}
+
+function getLetterStyles(state: OptionButtonState) {
+  switch (state) {
+    case "selected":
+      return { bg: colors.selectedBorder, color: "#FFFFFF" };
+    case "correct":
+      return { bg: colors.primary, color: "#FFFFFF" };
+    case "wrong":
+      return { bg: colors.danger, color: "#FFFFFF" };
+    case "idle":
+    default:
+      return { bg: colors.surface, color: colors.textMuted };
+  }
+}
+
+export const OptionButton = memo(OptionButtonImpl);
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep OptionButton | head -5`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/components/session/OptionButton.tsx
+git commit -m "feat(native): add OptionButton with idle/selected/correct/wrong animations"
+```
+
+---
+
+### Task 3: QuestionCard component
+
+**Files:**
+- Create: `apps/native/components/session/QuestionCard.tsx`
+
+- [ ] **Step 1: Create QuestionCard**
+
+Create `apps/native/components/session/QuestionCard.tsx`:
+
+```typescript
+import { useCallback } from "react";
+import { Text, View } from "react-native";
+
+import type { ClientQuestion } from "@pruvi/shared";
+
+import { colors } from "@/lib/design-tokens";
+
+import { OptionButton, type OptionButtonState } from "./OptionButton";
+
+interface Props {
+  question: ClientQuestion;
+  selectedIndex: number | null;
+  answerState: "idle" | "correct" | "wrong";
+  correctIndex: number | null;
+  onSelect: (index: number) => void;
+}
+
+const LETTERS = ["A", "B", "C", "D"];
+
+export function QuestionCard({
+  question,
+  selectedIndex,
+  answerState,
+  correctIndex,
+  onSelect,
+}: Props) {
+  const handleSelect = useCallback((index: number) => onSelect(index), [onSelect]);
+
+  return (
+    <View style={{ gap: 24 }}>
+      <Text
+        style={{
+          fontSize: 15,
+          lineHeight: 24,
+          fontWeight: "500",
+          color: colors.text,
+        }}
+      >
+        {question.body}
+      </Text>
+
+      <View style={{ gap: 12 }}>
+        {question.options.map((optionText, index) => {
+          const state = computeOptionState({
+            index,
+            selectedIndex,
+            answerState,
+            correctIndex,
+          });
+          const isDisabled = answerState !== "idle";
+
+          return (
+            <OptionButton
+              key={index}
+              letter={LETTERS[index] ?? String(index + 1)}
+              text={optionText}
+              state={state}
+              onPress={() => handleSelect(index)}
+              disabled={isDisabled}
+            />
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+function computeOptionState({
+  index,
+  selectedIndex,
+  answerState,
+  correctIndex,
+}: {
+  index: number;
+  selectedIndex: number | null;
+  answerState: "idle" | "correct" | "wrong";
+  correctIndex: number | null;
+}): OptionButtonState {
+  // After answer: show correct in green, wrong selection in red
+  if (answerState !== "idle") {
+    if (correctIndex === index) return "correct";
+    if (selectedIndex === index && answerState === "wrong") return "wrong";
+    return "idle";
+  }
+  // Before answer: show selection
+  if (selectedIndex === index) return "selected";
+  return "idle";
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep QuestionCard | head -5`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/components/session/QuestionCard.tsx
+git commit -m "feat(native): add QuestionCard rendering body + 4 OptionButtons"
+```
+
+---
+
+### Task 4: LivesBar component
+
+**Files:**
+- Create: `apps/native/components/session/LivesBar.tsx`
+
+- [ ] **Step 1: Create LivesBar**
+
+Create `apps/native/components/session/LivesBar.tsx`:
+
+```typescript
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect, useRef } from "react";
+import { View } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+
+import { colors } from "@/lib/design-tokens";
+
+interface Props {
+  livesRemaining: number;
+  maxLives?: number;
+}
+
+export function LivesBar({ livesRemaining, maxLives = 5 }: Props) {
+  const translateX = useSharedValue(0);
+  const previousLives = useRef(livesRemaining);
+
+  useEffect(() => {
+    if (livesRemaining < previousLives.current) {
+      translateX.value = withSequence(
+        withTiming(-8, { duration: 60, easing: Easing.linear }),
+        withTiming(8, { duration: 60, easing: Easing.linear }),
+        withTiming(-8, { duration: 60, easing: Easing.linear }),
+        withTiming(0, { duration: 60, easing: Easing.linear }),
+      );
+    }
+    previousLives.current = livesRemaining;
+  }, [livesRemaining, translateX]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        { flexDirection: "row", gap: 4, alignItems: "center" },
+        animatedStyle,
+      ]}
+    >
+      {Array.from({ length: maxLives }, (_, i) => {
+        const filled = i < livesRemaining;
+        return (
+          <Ionicons
+            key={i}
+            name={filled ? "heart" : "heart-outline"}
+            size={20}
+            color={filled ? colors.accent : colors.surface}
+          />
+        );
+      })}
+    </Animated.View>
+  );
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep LivesBar | head -5`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/components/session/LivesBar.tsx
+git commit -m "feat(native): add LivesBar with shake animation on life lost"
+```
+
+---
+
+### Task 5: ProgressBar component
+
+**Files:**
+- Create: `apps/native/components/session/ProgressBar.tsx`
+
+- [ ] **Step 1: Create ProgressBar**
+
+Create `apps/native/components/session/ProgressBar.tsx`:
+
+```typescript
+import { View } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { useEffect } from "react";
+
+import { colors } from "@/lib/design-tokens";
+
+interface Props {
+  total: number;
+  completed: number;
+}
+
+export function ProgressBar({ total, completed }: Props) {
+  return (
+    <View style={{ flex: 1, flexDirection: "row", gap: 6, alignItems: "center" }}>
+      {Array.from({ length: total }, (_, i) => (
+        <Segment key={i} isComplete={i < completed} />
+      ))}
+    </View>
+  );
+}
+
+function Segment({ isComplete }: { isComplete: boolean }) {
+  const progress = useSharedValue(isComplete ? 1 : 0);
+
+  useEffect(() => {
+    progress.value = withTiming(isComplete ? 1 : 0, { duration: 300 });
+  }, [isComplete, progress]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: progress.value > 0.5 ? colors.primary : colors.surface,
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        { flex: 1, height: 6, borderRadius: 3 },
+        animatedStyle,
+      ]}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep ProgressBar | head -5`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/components/session/ProgressBar.tsx
+git commit -m "feat(native): add segmented ProgressBar with animated fills"
+```
+
+---
+
+### Task 6: XPCounter component
+
+**Files:**
+- Create: `apps/native/components/gamification/XPCounter.tsx`
+
+- [ ] **Step 1: Create XPCounter**
+
+Create `apps/native/components/gamification/XPCounter.tsx`:
+
+```typescript
+import { useEffect, useState } from "react";
+import { Text } from "react-native";
+import {
+  Easing,
+  runOnJS,
+  useAnimatedReaction,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+
+import { colors } from "@/lib/design-tokens";
+
+interface Props {
+  earnedXP: number;
+  durationMs?: number;
+}
+
+export function XPCounter({ earnedXP, durationMs = 1200 }: Props) {
+  const value = useSharedValue(0);
+  const [displayed, setDisplayed] = useState(0);
+
+  useEffect(() => {
+    value.value = withTiming(earnedXP, {
+      duration: durationMs,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [earnedXP, durationMs, value]);
+
+  useAnimatedReaction(
+    () => value.value,
+    (current) => {
+      runOnJS(setDisplayed)(Math.round(current));
+    },
+  );
+
+  return (
+    <Text style={{ fontSize: 48, fontWeight: "900", color: colors.primary }}>
+      +{displayed} XP
+    </Text>
+  );
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep XPCounter | head -5`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/components/gamification/XPCounter.tsx
+git commit -m "feat(native): add animated XPCounter using useAnimatedReaction"
+```
+
+---
+
+### Task 7: StreakBadge component
+
+**Files:**
+- Create: `apps/native/components/gamification/StreakBadge.tsx`
+
+- [ ] **Step 1: Create StreakBadge**
+
+Create `apps/native/components/gamification/StreakBadge.tsx`:
+
+```typescript
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect } from "react";
+import { Text } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withSpring,
+} from "react-native-reanimated";
+
+import { colors, radii } from "@/lib/design-tokens";
+
+interface Props {
+  count: number;
+  animate?: boolean;
+}
+
+export function StreakBadge({ count, animate }: Props) {
+  const scale = useSharedValue(1);
+
+  useEffect(() => {
+    if (animate) {
+      scale.value = withSequence(
+        withSpring(1.2, { damping: 8, stiffness: 180 }),
+        withSpring(1, { damping: 10, stiffness: 180 }),
+      );
+    }
+  }, [animate, scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        {
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 6,
+          backgroundColor: colors.accentLight,
+          paddingHorizontal: 10,
+          paddingVertical: 6,
+          borderRadius: radii.sm,
+        },
+        animatedStyle,
+      ]}
+    >
+      <Ionicons name="flame" size={20} color={colors.accent} />
+      <Text style={{ fontWeight: "900", fontSize: 12, color: colors.accent }}>
+        {count}
+      </Text>
+    </Animated.View>
+  );
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep StreakBadge | head -5`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/components/gamification/StreakBadge.tsx
+git commit -m "feat(native): add StreakBadge with bounce animation on streak extension"
+```
+
+---
+
+### Task 8: CharacterAvatar component
+
+**Files:**
+- Create: `apps/native/components/gamification/CharacterAvatar.tsx`
+
+- [ ] **Step 1: Create CharacterAvatar**
+
+Create `apps/native/components/gamification/CharacterAvatar.tsx`:
+
+```typescript
+import { Ionicons } from "@expo/vector-icons";
+import { View } from "react-native";
+
+import { colors } from "@/lib/design-tokens";
+
+export type AvatarExpression = "neutral" | "happy" | "sad";
+
+interface Props {
+  expression: AvatarExpression;
+  size?: number;
+}
+
+export function CharacterAvatar({ expression, size = 80 }: Props) {
+  const { iconName, color, opacity } = getAvatarAppearance(expression);
+  const containerSize = size + 20;
+
+  return (
+    <View
+      style={{
+        width: containerSize,
+        height: containerSize,
+        borderRadius: containerSize / 2,
+        backgroundColor: "#FFFFFF",
+        borderWidth: 2,
+        borderColor: colors.border,
+        alignItems: "center",
+        justifyContent: "center",
+        opacity,
+      }}
+    >
+      <Ionicons name={iconName} size={size} color={color} />
+    </View>
+  );
+}
+
+function getAvatarAppearance(expression: AvatarExpression) {
+  switch (expression) {
+    case "happy":
+      return { iconName: "happy" as const, color: colors.primary, opacity: 1 };
+    case "sad":
+      return { iconName: "sad-outline" as const, color: colors.textMuted, opacity: 1 };
+    case "neutral":
+    default:
+      return { iconName: "happy" as const, color: colors.text, opacity: 0.7 };
+  }
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep CharacterAvatar | head -5`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/components/gamification/CharacterAvatar.tsx
+git commit -m "feat(native): add CharacterAvatar with 3 Ionicons expression states"
+```
+
+---
+
+### Task 9: Home screen wiring
+
+**Files:**
+- Modify: `apps/native/app/(app)/(tabs)/index.tsx`
+
+- [ ] **Step 1: Replace placeholder with wired home screen**
+
+Replace the entire contents of `apps/native/app/(app)/(tabs)/index.tsx` with:
+
+```typescript
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { Button, Spinner } from "heroui-native";
+import { Text, View } from "react-native";
+
+import { authClient } from "@/lib/auth-client";
+import { colors } from "@/lib/design-tokens";
+import { LivesBar } from "@/components/session/LivesBar";
+import { Screen } from "@/components/common/Screen";
+import { Skeleton } from "@/components/common/Skeleton";
+import { StreakBadge } from "@/components/gamification/StreakBadge";
+import {
+  useStartSession,
+  useTodaySession,
+} from "@/hooks/useSessionQuery";
+import { useLives } from "@/hooks/useLives";
+import { useStreaks } from "@/hooks/useStreaks";
+import { useXp } from "@/hooks/useXp";
+
+export default function HomeScreen() {
+  const { data: session } = authClient.useSession();
+  const todaySession = useTodaySession();
+  const lives = useLives();
+  const streaks = useStreaks();
+  const xp = useXp();
+  const startSession = useStartSession();
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const handleStart = () => {
+    startSession.mutate("all", {
+      onSuccess: (data) => {
+        queryClient.setQueryData(["session", "active", data.session.id], data);
+        router.push(`/session/${data.session.id}`);
+      },
+    });
+  };
+
+  const handleResume = (sessionId: number) => {
+    router.push(`/session/${sessionId}`);
+  };
+
+  const livesData = lives.data;
+  const noLives = livesData?.lives === 0;
+  const resetsAt = livesData?.resetsAt ? new Date(livesData.resetsAt) : null;
+  const livesCountdown = resetsAt ? formatCountdown(resetsAt) : null;
+
+  const activeSession = todaySession.data?.session ?? null;
+  const isCompleted = activeSession?.completedAt != null;
+  const buttonPending = startSession.isPending;
+
+  return (
+    <Screen>
+      <View style={{ paddingTop: 16, gap: 32 }}>
+        {/* Header */}
+        <View
+          style={{
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          {streaks.isLoading ? (
+            <Skeleton width={80} height={32} />
+          ) : (
+            <StreakBadge count={streaks.data?.currentStreak ?? 0} />
+          )}
+          {lives.isLoading ? (
+            <Skeleton width={140} height={24} />
+          ) : (
+            <LivesBar
+              livesRemaining={livesData?.lives ?? 0}
+              maxLives={livesData?.maxLives ?? 5}
+            />
+          )}
+        </View>
+
+        {/* Greeting */}
+        <View style={{ gap: 4 }}>
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "900",
+              letterSpacing: -0.6,
+              color: colors.text,
+            }}
+          >
+            Olá, {session?.user?.name ?? "estudante"}
+          </Text>
+          <Text
+            style={{
+              fontSize: 13,
+              fontWeight: "700",
+              color: colors.textMuted,
+            }}
+          >
+            Continue sua jornada
+          </Text>
+        </View>
+
+        {/* XP / Level card */}
+        {xp.isLoading ? (
+          <Skeleton width="100%" height={80} />
+        ) : xp.data ? (
+          <View
+            style={{
+              backgroundColor: "#FFFFFF",
+              borderRadius: 24,
+              borderWidth: 2,
+              borderColor: colors.border,
+              padding: 20,
+              gap: 8,
+            }}
+          >
+            <View
+              style={{
+                flexDirection: "row",
+                justifyContent: "space-between",
+              }}
+            >
+              <Text style={{ fontSize: 14, fontWeight: "900", color: colors.text }}>
+                Nível {xp.data.currentLevel}
+              </Text>
+              <Text style={{ fontSize: 14, fontWeight: "900", color: colors.primary }}>
+                {xp.data.totalXp} XP
+              </Text>
+            </View>
+            <Text style={{ fontSize: 12, fontWeight: "700", color: colors.textMuted }}>
+              Faltam {xp.data.xpForNextLevel} XP para o próximo nível
+            </Text>
+          </View>
+        ) : null}
+
+        {/* Today's session card */}
+        <View
+          style={{
+            backgroundColor: "#FFFFFF",
+            borderRadius: 32,
+            borderWidth: 2,
+            borderColor: colors.border,
+            padding: 24,
+            gap: 12,
+          }}
+        >
+          {todaySession.isLoading ? (
+            <Skeleton width="100%" height={100} />
+          ) : isCompleted ? (
+            <>
+              <Text style={{ fontSize: 18, fontWeight: "900", color: colors.text }}>
+                Você está em dia!
+              </Text>
+              <Text style={{ fontSize: 13, fontWeight: "700", color: colors.textMuted }}>
+                {activeSession?.questionsCorrect ?? 0}/
+                {activeSession?.questionsAnswered ?? 0} corretas hoje. Volte
+                amanhã.
+              </Text>
+            </>
+          ) : activeSession ? (
+            <>
+              <Text style={{ fontSize: 18, fontWeight: "900", color: colors.text }}>
+                Sessão em andamento
+              </Text>
+              <Button
+                onPress={() => handleResume(activeSession.id)}
+                isDisabled={noLives}
+              >
+                <Button.Label>Continuar</Button.Label>
+              </Button>
+            </>
+          ) : (
+            <>
+              <Text style={{ fontSize: 18, fontWeight: "900", color: colors.text }}>
+                Sessão de hoje
+              </Text>
+              <Text style={{ fontSize: 13, fontWeight: "700", color: colors.textMuted }}>
+                10 questões prontas para você
+              </Text>
+              <Button onPress={handleStart} isDisabled={noLives || buttonPending}>
+                {buttonPending ? (
+                  <Spinner size="sm" color="default" />
+                ) : (
+                  <Button.Label>Começar</Button.Label>
+                )}
+              </Button>
+            </>
+          )}
+
+          {noLives && livesCountdown && (
+            <Text
+              style={{
+                fontSize: 12,
+                fontWeight: "700",
+                color: colors.danger,
+                textAlign: "center",
+              }}
+            >
+              Vidas voltam em {livesCountdown}
+            </Text>
+          )}
+        </View>
+      </View>
+    </Screen>
+  );
+}
+
+function formatCountdown(resetsAt: Date): string {
+  const now = new Date();
+  const diffMs = resetsAt.getTime() - now.getTime();
+  if (diffMs <= 0) return "0m";
+
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep -E "\(tabs\)/index|error TS" | grep -v _legacy | head -10`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/app/\(app\)/\(tabs\)/index.tsx
+git commit -m "feat(native): wire home screen to session/lives/streak/xp queries"
+```
+
+---
+
+### Task 10: Active Session screen wiring
+
+**Files:**
+- Modify: `apps/native/app/(app)/session/[id].tsx`
+
+- [ ] **Step 1: Replace placeholder with Q&A loop**
+
+Replace the entire contents of `apps/native/app/(app)/session/[id].tsx` with:
+
+```typescript
+import { useQuery } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Button, Spinner } from "heroui-native";
+import { useEffect, useState } from "react";
+import { Text, View } from "react-native";
+
+import type { StartSessionResponse } from "@pruvi/shared";
+
+import { colors } from "@/lib/design-tokens";
+import { LivesBar } from "@/components/session/LivesBar";
+import { ProgressBar } from "@/components/session/ProgressBar";
+import { QuestionCard } from "@/components/session/QuestionCard";
+import { Screen } from "@/components/common/Screen";
+import { useAnswerQuestion } from "@/hooks/useSessionQuery";
+import { useLives } from "@/hooks/useLives";
+import { useGamificationStore } from "@/stores/gamificationStore";
+import { useSessionStore } from "@/stores/sessionStore";
+
+const ANSWER_ANIMATION_MS = 1200;
+
+export default function SessionScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const sessionId = Number(id);
+  const router = useRouter();
+
+  // Read the session + questions from TanStack Query cache (populated by Home screen)
+  const { data: session } = useQuery<StartSessionResponse>({
+    queryKey: ["session", "active", sessionId],
+    queryFn: () => {
+      throw new Error("Session not loaded — return to home");
+    },
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  const lives = useLives();
+  const answerQuestion = useAnswerQuestion();
+
+  const currentQuestionIndex = useSessionStore((s) => s.currentQuestionIndex);
+  const selectedOptionIndex = useSessionStore((s) => s.selectedOptionIndex);
+  const answerState = useSessionStore((s) => s.answerState);
+  const livesRemaining = useSessionStore((s) => s.livesRemaining);
+  const sessionActions = useSessionStore((s) => s.actions);
+  const gamificationActions = useGamificationStore((s) => s.actions);
+
+  const [correctIndex, setCorrectIndex] = useState<number | null>(null);
+  const [correctCount, setCorrectCount] = useState(0);
+
+  // Seed the store with current lives on mount; cleanup on unmount
+  useEffect(() => {
+    if (lives.data) {
+      sessionActions.reset(lives.data.lives);
+    }
+    return () => {
+      sessionActions.reset(5);
+    };
+    // Only run when lives first resolve
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lives.data?.lives]);
+
+  if (!session) {
+    return (
+      <Screen scrollable={false}>
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center", gap: 16 }}>
+          <Text style={{ fontSize: 16, color: colors.text }}>
+            Sessão não encontrada.
+          </Text>
+          <Button onPress={() => router.replace("/(app)/(tabs)")}>
+            <Button.Label>Voltar ao início</Button.Label>
+          </Button>
+        </View>
+      </Screen>
+    );
+  }
+
+  const currentQuestion = session.questions[currentQuestionIndex];
+  const totalQuestions = session.questions.length;
+
+  if (!currentQuestion) {
+    return (
+      <Screen scrollable={false}>
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+          <Spinner size="lg" />
+        </View>
+      </Screen>
+    );
+  }
+
+  const handleAnswer = () => {
+    if (selectedOptionIndex === null) return;
+
+    answerQuestion.mutate(
+      { questionId: currentQuestion.id, selectedOptionIndex },
+      {
+        onSuccess: (res) => {
+          setCorrectIndex(res.correctOptionIndex);
+          sessionActions.setAnswerState(res.correct ? "correct" : "wrong");
+          sessionActions.setLivesRemaining(res.livesRemaining);
+          gamificationActions.addXP(res.xpAwarded);
+          const nextCorrectCount = correctCount + (res.correct ? 1 : 0);
+          if (res.correct) setCorrectCount(nextCorrectCount);
+
+          setTimeout(() => {
+            const isLastQuestion = currentQuestionIndex === totalQuestions - 1;
+            const noLivesLeft = res.livesRemaining === 0;
+
+            if (isLastQuestion || noLivesLeft) {
+              router.replace({
+                pathname: "/session/result",
+                params: {
+                  sessionId: String(sessionId),
+                  questionCount: String(currentQuestionIndex + 1),
+                  correctCount: String(nextCorrectCount),
+                },
+              });
+            } else {
+              setCorrectIndex(null);
+              sessionActions.nextQuestion();
+            }
+          }, ANSWER_ANIMATION_MS);
+        },
+      },
+    );
+  };
+
+  const buttonDisabled =
+    selectedOptionIndex === null ||
+    answerState !== "idle" ||
+    answerQuestion.isPending;
+
+  return (
+    <Screen>
+      <View style={{ gap: 24, paddingVertical: 16 }}>
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 16,
+          }}
+        >
+          <ProgressBar total={totalQuestions} completed={currentQuestionIndex} />
+          <LivesBar livesRemaining={livesRemaining} />
+        </View>
+
+        <QuestionCard
+          question={currentQuestion}
+          selectedIndex={selectedOptionIndex}
+          answerState={answerState}
+          correctIndex={correctIndex}
+          onSelect={sessionActions.selectOption}
+        />
+
+        <Button onPress={handleAnswer} isDisabled={buttonDisabled}>
+          {answerQuestion.isPending ? (
+            <Spinner size="sm" color="default" />
+          ) : (
+            <Button.Label>Responder</Button.Label>
+          )}
+        </Button>
+      </View>
+    </Screen>
+  );
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep -E "session/\[id\]|error TS" | grep -v _legacy | head -10`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/app/\(app\)/session/\[id\].tsx
+git commit -m "feat(native): wire active session Q&A loop with answer mutation and animations"
+```
+
+---
+
+### Task 11: Session Result screen wiring
+
+**Files:**
+- Modify: `apps/native/app/(app)/session/result.tsx`
+
+- [ ] **Step 1: Replace placeholder with result screen**
+
+Replace the entire contents of `apps/native/app/(app)/session/result.tsx` with:
+
+```typescript
+import { useQueryClient } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Button, Spinner } from "heroui-native";
+import { Text, View } from "react-native";
+
+import { CharacterAvatar } from "@/components/gamification/CharacterAvatar";
+import { StreakBadge } from "@/components/gamification/StreakBadge";
+import { XPCounter } from "@/components/gamification/XPCounter";
+import { Screen } from "@/components/common/Screen";
+import { colors } from "@/lib/design-tokens";
+import { useCompleteSession } from "@/hooks/useSessionQuery";
+import { useStreaks } from "@/hooks/useStreaks";
+import { useGamificationStore } from "@/stores/gamificationStore";
+
+export default function SessionResultScreen() {
+  const { sessionId, questionCount, correctCount } = useLocalSearchParams<{
+    sessionId: string;
+    questionCount: string;
+    correctCount: string;
+  }>();
+
+  const qCount = Number(questionCount ?? 0);
+  const cCount = Number(correctCount ?? 0);
+  const accuracy = qCount > 0 ? Math.round((cCount / qCount) * 100) : 0;
+
+  const pendingXP = useGamificationStore((s) => s.pendingXP);
+  const gamificationActions = useGamificationStore((s) => s.actions);
+  const streaks = useStreaks();
+  const completeSession = useCompleteSession();
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const expression: "happy" | "neutral" | "sad" =
+    accuracy >= 70 ? "happy" : accuracy >= 40 ? "neutral" : "sad";
+
+  const handleContinue = () => {
+    completeSession.mutate(
+      { id: Number(sessionId), questionCount: qCount, correctCount: cCount },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ["session", "today"] });
+          queryClient.invalidateQueries({ queryKey: ["streaks"] });
+          queryClient.invalidateQueries({ queryKey: ["xp"] });
+          queryClient.invalidateQueries({ queryKey: ["lives"] });
+          gamificationActions.flush();
+          router.replace("/(app)/(tabs)");
+        },
+      },
+    );
+  };
+
+  return (
+    <Screen>
+      <View style={{ alignItems: "center", paddingTop: 40, gap: 24 }}>
+        <CharacterAvatar expression={expression} size={80} />
+
+        <XPCounter earnedXP={pendingXP} />
+
+        <View style={{ alignItems: "center", gap: 4 }}>
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "900",
+              letterSpacing: -0.6,
+              color: colors.text,
+            }}
+          >
+            {cCount}/{qCount} corretas
+          </Text>
+          <Text style={{ fontSize: 18, fontWeight: "700", color: colors.textMuted }}>
+            {accuracy}% de acerto
+          </Text>
+        </View>
+
+        {streaks.data && <StreakBadge count={streaks.data.currentStreak} />}
+
+        <Button
+          onPress={handleContinue}
+          isDisabled={completeSession.isPending}
+          style={{ marginTop: 24, alignSelf: "stretch" }}
+        >
+          {completeSession.isPending ? (
+            <Spinner size="sm" color="default" />
+          ) : (
+            <Button.Label>Continuar</Button.Label>
+          )}
+        </Button>
+      </View>
+    </Screen>
+  );
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep -E "session/result|error TS" | grep -v _legacy | head -10`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/native/app/\(app\)/session/result.tsx
+git commit -m "feat(native): wire session result screen with XP counter and complete mutation"
+```
+
+---
+
+### Task 12: Full verification
+
+- [ ] **Step 1: Full TypeScript check**
+
+Run: `cd apps/native && npx tsc --noEmit 2>&1 | grep -v _legacy | grep -v "app/modal.tsx" | grep -v "\+not-found" | head -20`
+Expected: No errors.
+
+- [ ] **Step 2: Verify file structure**
+
+Run: `cd apps/native && find components lib -type f -name "*.ts" -o -name "*.tsx" 2>/dev/null | sort`
+
+Expected output (partial list, should include):
+```
+components/common/Screen.tsx
+components/common/Skeleton.tsx
+components/gamification/CharacterAvatar.tsx
+components/gamification/StreakBadge.tsx
+components/gamification/XPCounter.tsx
+components/session/LivesBar.tsx
+components/session/OptionButton.tsx
+components/session/ProgressBar.tsx
+components/session/QuestionCard.tsx
+lib/api-client.ts
+lib/auth-client.ts
+lib/design-tokens.ts
+```
+
+- [ ] **Step 3: Verify screens are wired**
+
+Run: `cd apps/native && grep -l "useTodaySession\|useStartSession\|useAnswerQuestion\|useCompleteSession" app/\(app\)/`
+Expected: Returns all three screen files (`(tabs)/index.tsx`, `session/[id].tsx`, `session/result.tsx`).
+
+- [ ] **Step 4: Expo metro bundler smoke test**
+
+Run: `cd apps/native && npx expo export --platform web --output-dir /tmp/expo-phase3-test 2>&1 | tail -20`
+Expected: Successful export with "Exported" message. (If Expo's web export is too slow, this can be skipped — the TypeScript check is the primary gate.)
+
+- [ ] **Step 5: Document manual test plan**
+
+The following cannot be automated — document for manual QA:
+
+```
+Manual QA steps:
+1. Login/register — should land on Home with placeholder data
+2. Home screen:
+   - StreakBadge renders with 0 count (new user)
+   - LivesBar shows 5 filled hearts
+   - Greeting shows user name
+   - XP card shows "Nível 1" and "0 XP"
+   - "Sessão de hoje" card shows "Começar" button
+3. Tap "Começar" — should navigate to /session/:id
+4. Active Session:
+   - ProgressBar shows 10 empty segments
+   - LivesBar shows 5 hearts
+   - Question renders with 4 options (A/B/C/D)
+   - Tap an option — it animates scale down on press, becomes blue-bordered
+   - Tap "Responder" — the button shows spinner briefly
+   - On correct: selected option turns green, bounces, next question appears after ~1.2s
+   - On wrong: option turns red, shakes; LivesBar hearts shake; life decrements
+5. After 10 questions OR lives = 0 → navigate to result screen
+6. Result screen:
+   - CharacterAvatar renders (happy/neutral/sad based on accuracy)
+   - XPCounter animates from 0 to earned XP
+   - Accuracy % renders
+   - StreakBadge shows current streak (likely 1 after first session)
+   - Tap "Continuar" — navigates back to home with updated stats
+7. Kill + reopen app — session persists, land back on home
+```
+
+---
+
+### Summary of all files changed
+
+| Task | File | Change |
+|------|------|--------|
+| 1 | `apps/native/lib/design-tokens.ts` | Create |
+| 2 | `apps/native/components/session/OptionButton.tsx` | Create |
+| 3 | `apps/native/components/session/QuestionCard.tsx` | Create |
+| 4 | `apps/native/components/session/LivesBar.tsx` | Create |
+| 5 | `apps/native/components/session/ProgressBar.tsx` | Create |
+| 6 | `apps/native/components/gamification/XPCounter.tsx` | Create |
+| 7 | `apps/native/components/gamification/StreakBadge.tsx` | Create |
+| 8 | `apps/native/components/gamification/CharacterAvatar.tsx` | Create |
+| 9 | `apps/native/app/(app)/(tabs)/index.tsx` | Modify (replace placeholder) |
+| 10 | `apps/native/app/(app)/session/[id].tsx` | Modify (replace placeholder) |
+| 11 | `apps/native/app/(app)/session/result.tsx` | Modify (replace placeholder) |
+
+**11 file changes. 8 new, 3 modified.**

--- a/docs/superpowers/specs/2026-04-16-phase3-core-loop-screens-design.md
+++ b/docs/superpowers/specs/2026-04-16-phase3-core-loop-screens-design.md
@@ -1,0 +1,469 @@
+# Phase 3: Core Loop Screens
+
+> Design spec for wiring Home → Active Session → Session Result with Reanimated animations. This phase makes the app a working study product.
+
+## Context
+
+Phases 0-2 complete (PRs #2, #3, #4). The native app has:
+- Full service layer + TanStack Query hooks + Zustand stores for session state and gamification signals
+- Common components: `Screen`, `Skeleton`
+- Placeholder screens at `(app)/(tabs)/index.tsx`, `(app)/session/[id].tsx`, `(app)/session/result.tsx`
+- Archived legacy screens in `_legacy/` with rich visual design system (colors, typography, spacing)
+
+Phase 3 replaces the three placeholders with real UI driving the core study loop: user starts a session, answers questions with animated feedback, sees XP earned on the result screen, returns to home with updated stats.
+
+## Scope
+
+- Build 7 components (4 session + 3 gamification) with Reanimated animations
+- Wire 3 screens (Home, Active Session, Session Result)
+- Extract legacy design tokens (colors, typography, radii) into a shared module
+- End-to-end study loop works against real backend
+
+**Not in scope** (deferred to later phases):
+- Weekly activity chart, AI analysis card, subject breakdown on home (need Phase 4 backend endpoints)
+- Detailed explanations / stats on result screen (need Phase 4+ backend)
+- Character mascot illustrations (Ionicons placeholder)
+- Pixel-perfect Figma recreation — Phase 3 ships a functional study loop with consistent design tokens; polish in later phases
+
+## Design Decisions
+
+1. **Scope:** Minimal core loop, reuse legacy design tokens only. Phase 3 goal is working study app, not visual perfection.
+2. **Question storage:** TanStack Query cache via `queryClient.setQueryData(["session", "active", id], response)`. Respects architecture rule: server state in TanStack Query, not Zustand.
+3. **CharacterAvatar:** Ionicons faces (`happy`, `happy-outline`, `sad-outline`) — no illustration work needed.
+4. **Design tokens:** New `lib/design-tokens.ts` file exports colors, typography, radii constants extracted from legacy screens. All new components use these — consistent brand, no magic numbers.
+5. **Animations:** All animations via Reanimated worklets on UI thread. Zero `setState` in animation callbacks. Use `useSharedValue` + `useAnimatedStyle`. For text counters, use `useAnimatedReaction` + `runOnJS` since Reanimated can't directly interpolate text.
+
+## Changes
+
+### 1. Design Tokens (`lib/design-tokens.ts`)
+
+```typescript
+export const colors = {
+  primary: "#58CD04",
+  primaryLight: "rgba(88, 205, 4, 0.08)",
+  primaryGlow: "rgba(88, 205, 4, 0.3)",
+  accent: "#FF9600",
+  accentLight: "rgba(255, 150, 0, 0.1)",
+  danger: "#EF4444",
+  dangerLight: "rgba(239, 68, 68, 0.08)",
+  warning: "#F59E0B",
+  warningLight: "rgba(255, 150, 0, 0.06)",
+  text: "#2B2B2B",
+  textMuted: "#6B6B6B",
+  surface: "#F0F0F0",
+  border: "rgba(239, 236, 236, 0.5)",
+} as const;
+
+export const typography = {
+  heading900: { fontWeight: "900" as const, letterSpacing: -0.6 },
+  bodyBold700: { fontWeight: "700" as const },
+  bodyRegular500: { fontWeight: "500" as const },
+  uppercaseLabel: { fontWeight: "900" as const, letterSpacing: 1, textTransform: "uppercase" as const },
+} as const;
+
+export const radii = { sm: 10, md: 16, lg: 20, xl: 24, xxl: 32 } as const;
+```
+
+### 2. Session Components (`components/session/`)
+
+**`QuestionCard.tsx`** — Dumb component, no animations of its own.
+
+```typescript
+interface Props {
+  question: ClientQuestion;
+  selectedIndex: number | null;
+  answerState: "idle" | "correct" | "wrong";
+  correctIndex: number | null; // null until answered
+  onSelect: (index: number) => void;
+}
+```
+
+- Renders question body (fontSize 15, fontWeight 500, lineHeight 24, color `colors.text`)
+- Maps `question.options` (from Zod schema — `string[]`) to vertical stack of `OptionButton`
+- Gap 12px between options
+- Letter labels generated: "A", "B", "C", "D"
+
+**`OptionButton.tsx`** — `memo()`'d, Reanimated animations.
+
+```typescript
+interface Props {
+  letter: string;           // "A" | "B" | "C" | "D"
+  text: string;
+  state: "idle" | "selected" | "correct" | "wrong";
+  onPress: () => void;
+  disabled: boolean;
+}
+```
+
+Visual states (from legacy reference):
+- **Idle:** white bg, border `colors.border`, letter box `colors.surface` + `colors.textMuted` text
+- **Selected:** bg `rgba(59, 130, 246, 0.05)`, border `#3B82F6`, letter box `#3B82F6` + white text
+- **Correct:** bg `colors.primaryLight`, border `colors.primary`, letter box `colors.primary` + white text
+- **Wrong:** bg `colors.dangerLight`, border `colors.danger`, letter box `colors.danger` + white text
+
+Animations via `useSharedValue` + `useAnimatedStyle`:
+- **Press:** scale `withSpring(0.97)` on press-in, `withSpring(1)` on press-out
+- **Correct (state changes to 'correct'):** `withSequence(withSpring(1.05, { damping: 6 }), withSpring(1))`
+- **Wrong (state changes to 'wrong'):** translateX `withSequence(withTiming(-8, {duration: 60}), withTiming(8, {duration: 60}), withTiming(-8, {duration: 60}), withTiming(0, {duration: 60}))`
+
+Use `useCallback` on `onPress` in parent so memo works.
+
+**`LivesBar.tsx`** — Row of 5 heart Ionicons.
+
+```typescript
+interface Props {
+  livesRemaining: number; // 0-5
+  maxLives?: number;      // default 5
+}
+```
+
+- 5 `Ionicons` hearts in a flex row, gap 4px
+- Filled hearts: `heart` icon, color `colors.accent`
+- Empty hearts: `heart-outline` icon, color `colors.surface`
+- On `livesRemaining` decrease (track via `useEffect` + ref of previous value): shake entire bar via `translateX` `withSequence(-8, 8, -8, 0)` over 240ms
+
+**`ProgressBar.tsx`** — Segmented (one bar per question).
+
+```typescript
+interface Props {
+  total: number;      // total questions
+  completed: number;  // questions answered
+}
+```
+
+- Flex row of `total` segments, gap 6px
+- Each segment: height 6px, `borderRadius: 3`, flex 1
+- Completed segments: `colors.primary`
+- Incomplete: `colors.surface`
+- Width transition animated via `useAnimatedStyle` (each segment independently animates background color via `withTiming`)
+
+### 3. Gamification Components (`components/gamification/`)
+
+**`XPCounter.tsx`** — Animated number counter.
+
+```typescript
+interface Props {
+  earnedXP: number;
+  durationMs?: number; // default 1200
+}
+```
+
+Implementation:
+```typescript
+const value = useSharedValue(0);
+const [displayed, setDisplayed] = useState(0);
+
+useEffect(() => {
+  value.value = withTiming(earnedXP, {
+    duration: durationMs ?? 1200,
+    easing: Easing.out(Easing.cubic),
+  });
+}, [earnedXP]);
+
+useAnimatedReaction(
+  () => value.value,
+  (current) => {
+    runOnJS(setDisplayed)(Math.round(current));
+  },
+);
+
+return <Text style={{ fontSize: 48, fontWeight: "900", color: colors.primary }}>+{displayed} XP</Text>;
+```
+
+**`StreakBadge.tsx`** — Flame icon + count.
+
+```typescript
+interface Props {
+  count: number;
+  animate?: boolean;  // flip true to trigger bounce
+}
+```
+
+- Flex row: `<Ionicons name="flame" color={colors.accent} size={20} />` + text
+- Background: `colors.accentLight`, `borderRadius: radii.sm`, padding 6/10
+- Text: `{count}`, fontWeight 900, fontSize 12, color `colors.accent`
+- On `animate` flips true: scale `withSequence(withSpring(1.2), withSpring(1))`
+
+**`CharacterAvatar.tsx`** — Ionicons face.
+
+```typescript
+interface Props {
+  expression: "neutral" | "happy" | "sad";
+  size?: number; // default 80
+}
+```
+
+- Circular container: `width=height=size+20`, `borderRadius: size`, bg white, border `colors.border`, 2px
+- Icon:
+  - `happy` → `Ionicons name="happy"`, color `colors.primary`
+  - `neutral` → `Ionicons name="happy"` with 70% opacity, color `colors.text`
+  - `sad` → `Ionicons name="sad-outline"`, color `colors.textMuted`
+- Icon size: `size`
+
+### 4. Home Screen (`app/(app)/(tabs)/index.tsx`)
+
+Replace placeholder with:
+
+```
+Layout (top to bottom):
+- Header row: StreakBadge (left) + LivesBar (right), padded 16px
+- Greeting block: "Olá, {user name from session}"
+  - Font: heading900 + fontSize 24
+  - Subtitle: "Continue sua jornada" (bodyBold700 + fontSize 13 + colors.textMuted)
+- XP/Level card:
+  - Shows current level + XP + progress bar to next level
+  - From useXp(): { totalXp, currentLevel, xpForNextLevel }
+- Today's session state card:
+  - If useTodaySession().data.session === null → "Start Session" button
+  - If session exists && !completedAt → "Resume Session" button  
+  - If session exists && completedAt → "Você está em dia! Volte amanhã" + today's accuracy
+- Zero lives state:
+  - If useLives().data.lives === 0 → disable Start Session + show countdown "Lives reset in Xh Ym"
+  - Compute remaining time from useLives().data.resetsAt
+```
+
+Start Session flow:
+```typescript
+const startSession = useStartSession();
+const queryClient = useQueryClient();
+const router = useRouter();
+
+const handleStart = () => {
+  startSession.mutate("all", {
+    onSuccess: (data) => {
+      queryClient.setQueryData(["session", "active", data.session.id], data);
+      router.push(`/session/${data.session.id}`);
+    },
+  });
+};
+```
+
+While queries loading → show `Skeleton` placeholders (from Phase 1 component).
+
+### 5. Active Session (`app/(app)/session/[id].tsx`)
+
+Replace placeholder. Flow:
+
+```typescript
+export default function SessionScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const sessionId = Number(id);
+
+  // Read session from TanStack Query cache (populated by Home screen)
+  const { data: session } = useQuery({
+    queryKey: ["session", "active", sessionId],
+    queryFn: () => { throw new Error("Session not loaded"); },
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  const lives = useLives();
+  const answerQuestion = useAnswerQuestion();
+
+  const {
+    currentQuestionIndex,
+    selectedOptionIndex,
+    answerState,
+    livesRemaining,
+    actions,
+  } = useSessionStore();
+
+  const gamificationActions = useGamificationStore((s) => s.actions);
+
+  // Track correctIndex separately (not in sessionStore — only known after answer)
+  const [correctIndex, setCorrectIndex] = useState<number | null>(null);
+  const [correctCount, setCorrectCount] = useState(0);
+
+  // Initialize lives on mount
+  useEffect(() => {
+    if (lives.data) {
+      actions.reset(lives.data.lives);
+    }
+    return () => actions.reset(5); // Cleanup on unmount
+  }, [lives.data]);
+
+  // Error state: no session in cache
+  if (!session) {
+    return (
+      <Screen scrollable={false}>
+        <Text>Session not found. Return to home.</Text>
+        <Button onPress={() => router.replace("/(app)/(tabs)")}>Back</Button>
+      </Screen>
+    );
+  }
+
+  const currentQuestion = session.questions[currentQuestionIndex];
+  const totalQuestions = session.questions.length;
+
+  const handleAnswer = () => {
+    if (selectedOptionIndex === null) return;
+    answerQuestion.mutate(
+      { questionId: currentQuestion.id, selectedOptionIndex },
+      {
+        onSuccess: (res) => {
+          setCorrectIndex(res.correctOptionIndex);
+          actions.setAnswerState(res.correct ? "correct" : "wrong");
+          actions.setLivesRemaining(res.livesRemaining);
+          gamificationActions.addXP(res.xpAwarded);
+          if (res.correct) setCorrectCount((c) => c + 1);
+
+          // After 1200ms animation, advance
+          setTimeout(() => {
+            const isLastQuestion = currentQuestionIndex === totalQuestions - 1;
+            const noLivesLeft = res.livesRemaining === 0;
+
+            if (isLastQuestion || noLivesLeft) {
+              router.replace({
+                pathname: "/session/result",
+                params: {
+                  sessionId: String(sessionId),
+                  questionCount: String(currentQuestionIndex + 1),
+                  correctCount: String(correctCount + (res.correct ? 1 : 0)),
+                },
+              });
+            } else {
+              setCorrectIndex(null);
+              actions.nextQuestion();
+            }
+          }, 1200);
+        },
+      },
+    );
+  };
+
+  return (
+    <Screen scrollable={false}>
+      <View style={{ flexDirection: "row", padding: 16, gap: 16 }}>
+        <ProgressBar total={totalQuestions} completed={currentQuestionIndex} />
+        <LivesBar livesRemaining={livesRemaining} />
+      </View>
+
+      <QuestionCard
+        question={currentQuestion}
+        selectedIndex={selectedOptionIndex}
+        answerState={answerState}
+        correctIndex={correctIndex}
+        onSelect={actions.selectOption}
+      />
+
+      <Button
+        onPress={handleAnswer}
+        isDisabled={selectedOptionIndex === null || answerState !== "idle" || answerQuestion.isPending}
+      >
+        <Button.Label>Responder</Button.Label>
+      </Button>
+    </Screen>
+  );
+}
+```
+
+Button disabled while: no selection, already answered (awaiting animation), mutation in flight.
+
+### 6. Session Result (`app/(app)/session/result.tsx`)
+
+Replace placeholder. Flow:
+
+```typescript
+export default function SessionResultScreen() {
+  const { sessionId, questionCount, correctCount } = useLocalSearchParams<{
+    sessionId: string;
+    questionCount: string;
+    correctCount: string;
+  }>();
+
+  const qCount = Number(questionCount);
+  const cCount = Number(correctCount);
+  const accuracy = qCount > 0 ? Math.round((cCount / qCount) * 100) : 0;
+
+  const pendingXP = useGamificationStore((s) => s.pendingXP);
+  const gamificationActions = useGamificationStore((s) => s.actions);
+  const streaks = useStreaks();
+  const completeSession = useCompleteSession();
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const expression = accuracy >= 70 ? "happy" : accuracy >= 40 ? "neutral" : "sad";
+
+  const handleContinue = () => {
+    completeSession.mutate(
+      { id: Number(sessionId), questionCount: qCount, correctCount: cCount },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ["session", "today"] });
+          queryClient.invalidateQueries({ queryKey: ["streaks"] });
+          queryClient.invalidateQueries({ queryKey: ["xp"] });
+          queryClient.invalidateQueries({ queryKey: ["lives"] });
+          gamificationActions.flush();
+          router.replace("/(app)/(tabs)");
+        },
+      },
+    );
+  };
+
+  return (
+    <Screen>
+      <View style={{ alignItems: "center", paddingTop: 40, gap: 24 }}>
+        <CharacterAvatar expression={expression} size={80} />
+
+        <XPCounter earnedXP={pendingXP} />
+
+        <Text style={{ fontSize: 24, fontWeight: "900", color: colors.text }}>
+          {cCount}/{qCount} corretas
+        </Text>
+
+        <Text style={{ fontSize: 18, fontWeight: "700", color: colors.textMuted }}>
+          {accuracy}% de acerto
+        </Text>
+
+        {streaks.data && (
+          <StreakBadge count={streaks.data.currentStreak} />
+        )}
+
+        <Button
+          onPress={handleContinue}
+          isDisabled={completeSession.isPending}
+          style={{ marginTop: 24 }}
+        >
+          <Button.Label>Continuar</Button.Label>
+        </Button>
+      </View>
+    </Screen>
+  );
+}
+```
+
+Use `router.replace` (not `push`) so back button doesn't return to the finished result.
+
+## Exit Criteria
+
+1. `npx tsc --noEmit` passes (outside `_legacy/` files)
+2. Full flow works against backend: sign in → home → start session → answer questions → see result → back to home with updated stats
+3. Wrong answer triggers `OptionButton` shake + `LivesBar` shake simultaneously
+4. Correct answer triggers `OptionButton` green bounce
+5. XP counter animates from 0 to earned value on result screen
+6. Lives countdown displays when `lives === 0` on home
+7. Session state resets on screen unmount (no state bleed if user navigates away mid-session)
+8. All animations run on UI thread (no jank, verified by interaction feel)
+
+## Files Changed
+
+**New (8):**
+| File | Purpose |
+|------|---------|
+| `apps/native/lib/design-tokens.ts` | Shared colors/typography/radii |
+| `apps/native/components/session/QuestionCard.tsx` | Question text + 4 OptionButtons |
+| `apps/native/components/session/OptionButton.tsx` | Animated option with 4 states |
+| `apps/native/components/session/LivesBar.tsx` | Heart icons with shake on loss |
+| `apps/native/components/session/ProgressBar.tsx` | Segmented progress |
+| `apps/native/components/gamification/XPCounter.tsx` | Animated number counter |
+| `apps/native/components/gamification/StreakBadge.tsx` | Flame + count with bounce |
+| `apps/native/components/gamification/CharacterAvatar.tsx` | Ionicons face with 3 expressions |
+
+**Modified (3):**
+| File | Change |
+|------|--------|
+| `apps/native/app/(app)/(tabs)/index.tsx` | Replace placeholder with wired home |
+| `apps/native/app/(app)/session/[id].tsx` | Replace placeholder with Q&A loop |
+| `apps/native/app/(app)/session/result.tsx` | Replace placeholder with result screen |
+
+**11 files total.**


### PR DESCRIPTION
## Summary
- **Design tokens (`lib/design-tokens.ts`):** Shared colors, typography, radii extracted from legacy screens. Single source of truth for visual language (`#58CD04` primary green, `#FF9600` accent orange, fontWeight 900/700/500 scale, radii sm-xxl).
- **Session components (4):** `QuestionCard` (renders body + 4 OptionButtons), `OptionButton` (memo'd, animates idle→selected→correct/wrong with Reanimated worklets), `LivesBar` (5 hearts, horizontal shake when livesRemaining decreases), `ProgressBar` (segmented with animated fills per question).
- **Gamification components (3):** `XPCounter` (animated spring counter 0→earnedXP using `useAnimatedReaction` + `runOnJS`), `StreakBadge` (flame + count with bounce on extension), `CharacterAvatar` (Ionicons face with neutral/happy/sad states).
- **Home screen wired:** Header with StreakBadge + LivesBar, greeting, XP card (Nível + XP + remaining to next level), today's session card (Start/Resume/Completed states), zero lives countdown. Uses `useTodaySession`, `useLives`, `useStreaks`, `useXp`.
- **Active Session wired:** Reads session + questions from TanStack Query cache via `useQuery` (seeded by home via `setQueryData`). Q&A loop via `sessionStore`. Tap option → `selectOption`, tap "Responder" → `useAnswerQuestion` mutation. Correct: green bounce + `gamificationStore.addXP`. Wrong: red shake + `LivesBar` shake + `setLivesRemaining`. Auto-advance after 1.2s. Navigates to result on last question OR zero lives.
- **Session Result wired:** CharacterAvatar (happy/neutral/sad by accuracy), animated XPCounter from pendingXP, accuracy %, StreakBadge. "Continuar" calls `useCompleteSession`, invalidates all dependent queries, flushes gamification store, replaces route to home.

## Test Plan
- [ ] `cd apps/native && npx tsc --noEmit` — zero errors outside `_legacy/`, `modal.tsx`, `+not-found.tsx`
- [ ] Full study flow against backend: sign in → home → "Começar" → answer 10 questions → see result → "Continuar" → home with updated streak/XP
- [ ] Wrong answer triggers OptionButton shake + LivesBar shake simultaneously
- [ ] Correct answer triggers OptionButton green bounce + letter box turns green
- [ ] XPCounter animates from 0 to total earned XP on result screen
- [ ] Zero lives: home disables "Começar" and shows countdown to `resetsAt`
- [ ] Session state resets on screen unmount (navigate away mid-session → no state bleed)
- [ ] All animations feel smooth (60fps, no jank) — verified by interaction

## Notes
- **Scope per spec (not in this PR):** Weekly activity chart, AI analysis card, subject breakdown on home (all need Phase 4 backend endpoints). Detailed explanations/stats on result screen (Phase 4+). Pixel-perfect legacy recreation deferred.
- **Key design choices:**
  - Session questions stored in TanStack Query cache via `setQueryData(["session", "active", id])` — respects architecture's state-ownership rule (server state not in Zustand)
  - Animations via Reanimated worklets, zero `setState` in animation callbacks. `useAnimatedReaction` + `runOnJS` bridges animated values to React state (XPCounter pattern)
  - `OptionButton` memo'd, `useCallback` on onSelect in parent — ensures memo actually works
  - All components consume the new `design-tokens.ts` — no magic numbers scattered across files
- **Based on:** `feature/phase2-service-layer` (PR #4). Merge PRs #3 → #4 → this in order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented complete home dashboard displaying session status, lives, streaks, and experience points
  * Added interactive study sessions with animated answer feedback showing correctness states
  * Included gamification features: experience point counters, streak badges, and character avatars with expression-based feedback
  * Integrated lives management system with countdown timers for life resets
  * Added session results screen with accuracy tracking and streak updates

* **Documentation**
  * Added Phase 3 core study loop implementation guide
  * Added design specifications for core study features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->