### PR TITLE
Phase 1B (code): subjects endpoint + question explanations

### DIFF
--- a/apps/server/src/features/questions/questions.repository.ts
+++ b/apps/server/src/features/questions/questions.repository.ts
@@ -20,7 +20,7 @@ export class QuestionsRepository {
     mode: "all" | "theoretical"
   ) {
     const now = new Date();
-    type SelectedQuestion = Omit<typeof question.$inferSelect, "createdAt">;
+    type SelectedQuestion = Omit<typeof question.$inferSelect, "createdAt" | "explanation">;
     const selected: Array<SelectedQuestion> = [];
 
     // Base filter for paper/pen mode

--- a/apps/server/src/features/reviews/reviews.service.test.ts
+++ b/apps/server/src/features/reviews/reviews.service.test.ts
@@ -17,10 +17,11 @@ const service = new ReviewsService(mockRepo as any);
 const USER_ID = "user-1";
 const QUESTION_ID = 42;
 
-const makeQuestion = (overrides?: Partial<{ difficulty: string; correctOptionIndex: number }>) => ({
+const makeQuestion = (overrides?: Partial<{ difficulty: string; correctOptionIndex: number; explanation: string | null }>) => ({
   id: QUESTION_ID,
   correctOptionIndex: 2,
   difficulty: "medium",
+  explanation: null,
   ...overrides,
 });
 
@@ -164,5 +165,31 @@ describe("ReviewsService.answerQuestion", () => {
 
     expect(value.xpAwarded).toBe(0);
     expect(mockRepo.awardXp).not.toHaveBeenCalled();
+  });
+
+  it("includes explanation from question in the answer result", async () => {
+    mockRepo.findQuestionById.mockResolvedValue(
+      makeQuestion({ explanation: "F=ma is Newton's second law" })
+    );
+
+    const result = await service.answerQuestion(USER_ID, QUESTION_ID, 2);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.explanation).toBe("F=ma is Newton's second law");
+    }
+  });
+
+  it("returns null explanation when question has no explanation", async () => {
+    mockRepo.findQuestionById.mockResolvedValue(
+      makeQuestion({ explanation: null })
+    );
+
+    const result = await service.answerQuestion(USER_ID, QUESTION_ID, 2);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.explanation).toBeNull();
+    }
   });
 });

--- a/apps/server/src/features/reviews/reviews.service.ts
+++ b/apps/server/src/features/reviews/reviews.service.ts
@@ -25,6 +25,7 @@ export class ReviewsService {
         correctOptionIndex: number;
         livesRemaining: number;
         xpAwarded: number;
+        explanation: string | null;
       },
       AppError
     >
@@ -110,6 +111,7 @@ export class ReviewsService {
       correctOptionIndex: q.correctOptionIndex,
       livesRemaining,
       xpAwarded,
+      explanation: q.explanation ?? null,
     });
   }
 }

--- a/apps/server/src/features/subjects/index.ts
+++ b/apps/server/src/features/subjects/index.ts
@@ -1,0 +1,1 @@
+export { subjectsRoutes } from "./subjects.route";

--- a/apps/server/src/features/subjects/subjects.repository.integration.test.ts
+++ b/apps/server/src/features/subjects/subjects.repository.integration.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { setupTestDb, teardownTestDb, cleanupTestDb, getTestDb } from "../../test/db-helpers";
+import { subject } from "@pruvi/db/schema/subjects";
+import { SubjectsRepository } from "./subjects.repository";
+
+describe("SubjectsRepository integration", () => {
+  let repo: SubjectsRepository;
+
+  beforeAll(async () => {
+    await setupTestDb();
+    repo = new SubjectsRepository(getTestDb());
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  it("listAll returns subjects sorted by name ASC", async () => {
+    const db = getTestDb();
+
+    await db.insert(subject).values([
+      { name: "Química", slug: "quimica" },
+      { name: "Biologia", slug: "biologia" },
+      { name: "Matemática", slug: "matematica" },
+    ]);
+
+    const rows = await repo.listAll();
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.name)).toEqual(["Biologia", "Matemática", "Química"]);
+    expect(rows.every((r) => typeof r.id === "number")).toBe(true);
+    expect(rows.every((r) => typeof r.slug === "string")).toBe(true);
+  });
+
+  it("listAll returns empty array when no subjects", async () => {
+    const rows = await repo.listAll();
+    expect(rows).toEqual([]);
+  });
+});

--- a/apps/server/src/features/subjects/subjects.repository.ts
+++ b/apps/server/src/features/subjects/subjects.repository.ts
@@ -1,0 +1,19 @@
+import { subject } from "@pruvi/db/schema/subjects";
+import type { db } from "@pruvi/db";
+
+type DbClient = typeof db;
+
+export class SubjectsRepository {
+  constructor(private db: DbClient) {}
+
+  async listAll() {
+    return this.db
+      .select({
+        id: subject.id,
+        slug: subject.slug,
+        name: subject.name,
+      })
+      .from(subject)
+      .orderBy(subject.name);
+  }
+}

--- a/apps/server/src/features/subjects/subjects.route.ts
+++ b/apps/server/src/features/subjects/subjects.route.ts
@@ -1,0 +1,28 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { db } from "@pruvi/db";
+import { SubjectsRepository } from "./subjects.repository";
+import { SubjectsService } from "./subjects.service";
+import { successResponse, unwrapResult } from "../../types";
+
+const repo = new SubjectsRepository(db);
+const service = new SubjectsService(repo);
+
+const SUBJECTS_CACHE_TTL = 300;
+const CACHE_KEY = "subjects:list";
+
+export const subjectsRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/subjects",
+    { preHandler: [fastify.authenticate] },
+    async () => {
+      const cached = await fastify.cache.get<unknown>(CACHE_KEY);
+      if (cached) {
+        return successResponse(cached);
+      }
+      const result = await service.list();
+      const response = unwrapResult(result);
+      await fastify.cache.set(CACHE_KEY, response.data, SUBJECTS_CACHE_TTL);
+      return response;
+    }
+  );
+};

--- a/apps/server/src/features/subjects/subjects.service.test.ts
+++ b/apps/server/src/features/subjects/subjects.service.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { SubjectsService } from "./subjects.service";
+import type { SubjectsRepository } from "./subjects.repository";
+
+function makeMockRepo() {
+  return {
+    listAll: vi.fn(),
+  } as unknown as SubjectsRepository & {
+    listAll: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("SubjectsService", () => {
+  let repo: ReturnType<typeof makeMockRepo>;
+  let service: SubjectsService;
+
+  beforeEach(() => {
+    repo = makeMockRepo();
+    service = new SubjectsService(repo);
+  });
+
+  it("returns subjects from repo wrapped in { subjects } shape", async () => {
+    const rows = [
+      { id: 1, slug: "matematica", name: "Matemática" },
+      { id: 2, slug: "biologia", name: "Biologia" },
+    ];
+    repo.listAll.mockResolvedValue(rows);
+
+    const result = await service.list();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ subjects: rows });
+    }
+  });
+
+  it("returns empty list when repo returns empty", async () => {
+    repo.listAll.mockResolvedValue([]);
+    const result = await service.list();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.subjects).toEqual([]);
+    }
+  });
+});

--- a/apps/server/src/features/subjects/subjects.service.ts
+++ b/apps/server/src/features/subjects/subjects.service.ts
@@ -1,0 +1,14 @@
+import { ok, type Result } from "neverthrow";
+import type { AppError } from "../../utils/errors";
+import type { SubjectsRepository } from "./subjects.repository";
+
+type Subject = Awaited<ReturnType<SubjectsRepository["listAll"]>>[number];
+
+export class SubjectsService {
+  constructor(private repo: SubjectsRepository) {}
+
+  async list(): Promise<Result<{ subjects: Subject[] }, AppError>> {
+    const subjects = await this.repo.listAll();
+    return ok({ subjects });
+  }
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,6 +15,7 @@ import { progressRoutes } from "./features/progress";
 import { reviewsRoutes } from "./features/reviews";
 import { sessionsRoutes } from "./features/sessions";
 import { streaksRoutes } from "./features/streaks";
+import { subjectsRoutes } from "./features/subjects";
 import { usersRoutes } from "./features/users";
 import { authPlugin } from "./plugins/auth";
 import { errorHandlerPlugin } from "./plugins/error-handler";
@@ -73,6 +74,7 @@ export async function buildApp() {
   await app.register(onboardingRoutes);
   await app.register(usersRoutes);
   await app.register(progressRoutes);
+  await app.register(subjectsRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/docs/superpowers/plans/2026-05-10-phase-1b-subjects-explanations.md
+++ b/docs/superpowers/plans/2026-05-10-phase-1b-subjects-explanations.md
@@ -1,0 +1,848 @@
+# Phase 1B (code) — Subjects + Explanations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `GET /subjects` endpoint, add nullable `question.explanation` column, and surface it in `POST /questions/:id/answer` response.
+
+**Architecture:** New `subjects/` feature module mirroring `users/`. Additive schema migration for `explanation`. Reviews service extends its return type with the explanation text. No content backfill — frontend renders fallback for nulls.
+
+**Tech Stack:** Drizzle ORM, Fastify with `fastify-type-provider-zod`, Vitest + PGlite, Zod via `@pruvi/shared`, `neverthrow` Results.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-10-phase-1b-subjects-explanations-design.md`
+
+---
+
+## File Structure
+
+### Created
+- `apps/server/src/features/subjects/index.ts`
+- `apps/server/src/features/subjects/subjects.repository.ts`
+- `apps/server/src/features/subjects/subjects.service.ts`
+- `apps/server/src/features/subjects/subjects.route.ts`
+- `apps/server/src/features/subjects/subjects.service.test.ts`
+- `apps/server/src/features/subjects/subjects.repository.integration.test.ts`
+- `packages/db/src/migrations/0002_*.sql` — auto-generated
+
+### Modified
+- `packages/db/src/schema/questions.ts` — add `explanation` column
+- `packages/db/src/test-client.ts` — add `explanation` to question DDL
+- `packages/shared/src/subjects.ts` — add `SubjectsListResponseSchema`
+- `packages/shared/src/answers.ts` — extend `AnswerQuestionResponseSchema` with `explanation`
+- `apps/server/src/features/reviews/reviews.service.ts` — include `explanation` in answer result
+- `apps/server/src/features/reviews/reviews.service.test.ts` — update mock fixtures + assertions
+- `apps/server/src/index.ts` — register `subjectsRoutes`
+
+---
+
+## Task 0: Branch setup
+
+**Files:** none (branching only)
+
+- [ ] **Step 1: Confirm on `phase-1c-progress-calendar` and clean**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi
+git status --short
+git log --oneline -3
+```
+
+Expected: on `phase-1c-progress-calendar`; clean working tree (untracked docs are fine).
+
+- [ ] **Step 2: Create Phase 1B branch off Phase 1C**
+
+```bash
+git checkout -b phase-1b-subjects-explanations
+git log --oneline -3
+```
+
+Expected: HEAD matches `phase-1c-progress-calendar`.
+
+- [ ] **Step 3: Verify baseline**
+
+```bash
+pnpm run check-types 2>&1 | grep "error TS" | grep -v "test\.ts\|integration\.test" | head -3
+pnpm --filter server test 2>&1 | tail -5
+```
+
+Expected: zero non-test errors; 64/64 unit tests pass.
+
+No commit for Task 0.
+
+---
+
+## Task 1: Add `question.explanation` column
+
+**Files:**
+- Modify: `packages/db/src/schema/questions.ts`
+- Modify: `packages/db/src/test-client.ts`
+
+- [ ] **Step 1: Edit `packages/db/src/schema/questions.ts`**
+
+Add the `explanation` column between `requiresCalculation` and `source`. The full table block should read:
+
+```typescript
+export const question = pgTable(
+  "question",
+  {
+    id: serial("id").primaryKey(),
+    content: text("content").notNull(),
+    options: jsonb("options").$type<string[]>().notNull(),
+    correctOptionIndex: integer("correct_option_index").notNull(),
+    difficulty: text("difficulty", { enum: ["easy", "medium", "hard"] }).notNull(),
+    requiresCalculation: boolean("requires_calculation").notNull().default(false),
+    explanation: text("explanation"),
+    source: text("source"),
+    subjectId: integer("subject_id")
+      .notNull()
+      .references(() => subject.id),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("question_subject_difficulty_idx").on(table.subjectId, table.difficulty),
+  ],
+);
+```
+
+Imports stay unchanged (already have `text`).
+
+- [ ] **Step 2: Edit `packages/db/src/test-client.ts`**
+
+Find the `CREATE TABLE IF NOT EXISTS "question"` block. Add `explanation TEXT,` between `requires_calculation` and `source`:
+
+```sql
+CREATE TABLE IF NOT EXISTS "question" (
+  id SERIAL PRIMARY KEY,
+  content TEXT NOT NULL,
+  options JSONB NOT NULL,
+  correct_option_index INTEGER NOT NULL,
+  difficulty TEXT NOT NULL,
+  requires_calculation BOOLEAN NOT NULL DEFAULT FALSE,
+  explanation TEXT,
+  source TEXT,
+  subject_id INTEGER NOT NULL REFERENCES "subject"(id),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi
+pnpm run check-types 2>&1 | grep "error TS" | grep -v "test\.ts\|integration\.test" | head -5
+```
+
+Expected: zero non-test errors. Reviews tests will fail later if their fixtures don't update — that's expected and fixed in Task 5.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/db/src/schema/questions.ts packages/db/src/test-client.ts
+git commit -m "feat(db): add nullable explanation column to question"
+```
+
+---
+
+## Task 2: Generate + apply migration
+
+**Files:**
+- Create: `packages/db/src/migrations/0002_*.sql` (auto-generated)
+- Modify: `packages/db/src/migrations/meta/_journal.json` (auto-generated)
+
+- [ ] **Step 1: Generate migration**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi/packages/db
+pnpm exec drizzle-kit generate
+cd ../..
+```
+
+Expected: new `0002_<name>.sql` file appears; `_journal.json` gains a third entry.
+
+- [ ] **Step 2: Inspect the SQL**
+
+```bash
+cat packages/db/src/migrations/0002_*.sql
+```
+
+Expected output:
+```sql
+ALTER TABLE "question" ADD COLUMN "explanation" text;
+```
+
+If the migration contains anything other than this single ALTER COLUMN, STOP and report DONE_WITH_CONCERNS.
+
+- [ ] **Step 3: Apply migration**
+
+```bash
+cd packages/db
+pnpm exec drizzle-kit migrate
+cd ../..
+```
+
+Verify the column landed:
+```bash
+docker exec pruvi-postgres psql -U postgres -d pruvi -c "\d question" | grep explanation
+```
+
+Expected output shows `explanation` as text, nullable.
+
+- [ ] **Step 4: Run smoke test**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi
+pnpm verify:migration 2>&1 | tail -8
+```
+
+Expected: `✓ Migration smoke test passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/db/src/migrations/
+git commit -m "feat(db): generate migration for question.explanation"
+```
+
+---
+
+## Task 3: Extend shared schemas
+
+**Files:**
+- Modify: `packages/shared/src/subjects.ts`
+- Modify: `packages/shared/src/answers.ts`
+
+- [ ] **Step 1: Add `SubjectsListResponseSchema` to `packages/shared/src/subjects.ts`**
+
+Read the current file first. After the existing `subjectSchema` and `Subject` type exports, append:
+
+```typescript
+export const SubjectsListResponseSchema = z.object({
+  subjects: z.array(subjectSchema),
+});
+
+export type SubjectsListResponse = z.infer<typeof SubjectsListResponseSchema>;
+```
+
+Final file content:
+```typescript
+import { z } from "zod";
+
+export const subjectSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  slug: z.string(),
+});
+
+export type Subject = z.infer<typeof subjectSchema>;
+
+export const SubjectsListResponseSchema = z.object({
+  subjects: z.array(subjectSchema),
+});
+
+export type SubjectsListResponse = z.infer<typeof SubjectsListResponseSchema>;
+```
+
+- [ ] **Step 2: Extend `AnswerQuestionResponseSchema` in `packages/shared/src/answers.ts`**
+
+Replace the schema definition. Final file content:
+
+```typescript
+import { z } from "zod";
+
+/** POST /questions/:questionId/answer — request body */
+export const AnswerQuestionBodySchema = z.object({
+  selectedOptionIndex: z.number().int().min(0).max(3),
+});
+
+export type AnswerQuestionBody = z.infer<typeof AnswerQuestionBodySchema>;
+
+/** POST /questions/:questionId/answer — response */
+export const AnswerQuestionResponseSchema = z.object({
+  correct: z.boolean(),
+  correctOptionIndex: z.number().int().min(0).max(3),
+  livesRemaining: z.number().int().min(0),
+  xpAwarded: z.number().int().min(0),
+  explanation: z.string().nullable(),
+});
+
+export type AnswerQuestionResponse = z.infer<typeof AnswerQuestionResponseSchema>;
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+pnpm run check-types 2>&1 | grep "error TS" | grep -v "test\.ts\|integration\.test" | head -5
+```
+
+Expected: zero non-test errors at this point. The reviews service hasn't been updated yet but the response shape it returns is a structural type — adding a required `explanation` field to `AnswerQuestionResponseSchema` doesn't break compilation because the schema is consumed by the route, not by the service.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/shared/src/subjects.ts packages/shared/src/answers.ts
+git commit -m "feat(shared): add SubjectsListResponseSchema and extend answer response with explanation"
+```
+
+---
+
+## Task 4: Create `subjects/` feature module
+
+**Files:**
+- Create: `apps/server/src/features/subjects/subjects.repository.ts`
+- Create: `apps/server/src/features/subjects/subjects.service.ts`
+- Create: `apps/server/src/features/subjects/subjects.route.ts`
+- Create: `apps/server/src/features/subjects/index.ts`
+- Create: `apps/server/src/features/subjects/subjects.service.test.ts`
+
+- [ ] **Step 1: Create `subjects.repository.ts`**
+
+```typescript
+import { subject } from "@pruvi/db/schema/subjects";
+import type { db } from "@pruvi/db";
+
+type DbClient = typeof db;
+
+export class SubjectsRepository {
+  constructor(private db: DbClient) {}
+
+  async listAll() {
+    return this.db
+      .select({
+        id: subject.id,
+        slug: subject.slug,
+        name: subject.name,
+      })
+      .from(subject)
+      .orderBy(subject.name);
+  }
+}
+```
+
+- [ ] **Step 2: Create `subjects.service.ts`**
+
+```typescript
+import { ok, type Result } from "neverthrow";
+import type { AppError } from "../../utils/errors";
+import type { SubjectsRepository } from "./subjects.repository";
+
+type Subject = Awaited<ReturnType<SubjectsRepository["listAll"]>>[number];
+
+export class SubjectsService {
+  constructor(private repo: SubjectsRepository) {}
+
+  async list(): Promise<Result<{ subjects: Subject[] }, AppError>> {
+    const subjects = await this.repo.listAll();
+    return ok({ subjects });
+  }
+}
+```
+
+- [ ] **Step 3: Create `subjects.route.ts`**
+
+```typescript
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { db } from "@pruvi/db";
+import { SubjectsRepository } from "./subjects.repository";
+import { SubjectsService } from "./subjects.service";
+import { successResponse, unwrapResult } from "../../types";
+
+const repo = new SubjectsRepository(db);
+const service = new SubjectsService(repo);
+
+const SUBJECTS_CACHE_TTL = 300;
+const CACHE_KEY = "subjects:list";
+
+export const subjectsRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/subjects",
+    { preHandler: [fastify.authenticate] },
+    async () => {
+      const cached = await fastify.cache.get<unknown>(CACHE_KEY);
+      if (cached) {
+        return successResponse(cached);
+      }
+      const result = await service.list();
+      const response = unwrapResult(result);
+      await fastify.cache.set(CACHE_KEY, response.data, SUBJECTS_CACHE_TTL);
+      return response;
+    }
+  );
+};
+```
+
+- [ ] **Step 4: Create `index.ts`**
+
+```typescript
+export { subjectsRoutes } from "./subjects.route";
+```
+
+- [ ] **Step 5: Create `subjects.service.test.ts`**
+
+```typescript
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { SubjectsService } from "./subjects.service";
+import type { SubjectsRepository } from "./subjects.repository";
+
+function makeMockRepo() {
+  return {
+    listAll: vi.fn(),
+  } as unknown as SubjectsRepository & {
+    listAll: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("SubjectsService", () => {
+  let repo: ReturnType<typeof makeMockRepo>;
+  let service: SubjectsService;
+
+  beforeEach(() => {
+    repo = makeMockRepo();
+    service = new SubjectsService(repo);
+  });
+
+  it("returns subjects from repo wrapped in { subjects } shape", async () => {
+    const rows = [
+      { id: 1, slug: "matematica", name: "Matemática" },
+      { id: 2, slug: "biologia", name: "Biologia" },
+    ];
+    repo.listAll.mockResolvedValue(rows);
+
+    const result = await service.list();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ subjects: rows });
+    }
+  });
+
+  it("returns empty list when repo returns empty", async () => {
+    repo.listAll.mockResolvedValue([]);
+    const result = await service.list();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.subjects).toEqual([]);
+    }
+  });
+});
+```
+
+- [ ] **Step 6: Run unit tests**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi
+pnpm --filter server exec vitest run src/features/subjects/subjects.service.test.ts 2>&1 | tail -10
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 7: Typecheck**
+
+```bash
+pnpm run check-types 2>&1 | grep "error TS" | grep -v "test\.ts\|integration\.test" | head -5
+```
+
+Expected: zero non-test errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/server/src/features/subjects/
+git commit -m "feat(server): add subjects feature (GET /subjects, list + cache)"
+```
+
+---
+
+## Task 5: Surface explanation in answer response
+
+**Files:**
+- Modify: `apps/server/src/features/reviews/reviews.service.ts`
+- Modify: `apps/server/src/features/reviews/reviews.service.test.ts`
+
+- [ ] **Step 1: Update `reviews.service.ts` return type and value**
+
+The current `answerQuestion` returns:
+```typescript
+{
+  correct: boolean;
+  correctOptionIndex: number;
+  livesRemaining: number;
+  xpAwarded: number;
+}
+```
+
+Extend it to:
+```typescript
+{
+  correct: boolean;
+  correctOptionIndex: number;
+  livesRemaining: number;
+  xpAwarded: number;
+  explanation: string | null;
+}
+```
+
+Read the file first. Find the `Promise<Result<{...}>>` signature (around line 21) and add `explanation: string | null` to the inner shape:
+
+```typescript
+  async answerQuestion(
+    userId: string,
+    questionId: number,
+    selectedOptionIndex: number
+  ): Promise<
+    Result<
+      {
+        correct: boolean;
+        correctOptionIndex: number;
+        livesRemaining: number;
+        xpAwarded: number;
+        explanation: string | null;
+      },
+      AppError
+    >
+  > {
+```
+
+Then find the final `return ok({ ... })` at the bottom of the method. Add `explanation: q.explanation ?? null,` to the returned object:
+
+```typescript
+    return ok({
+      correct,
+      correctOptionIndex: q.correctOptionIndex,
+      livesRemaining,
+      xpAwarded,
+      explanation: q.explanation ?? null,
+    });
+```
+
+The `q` variable already holds the full question row (via `findQuestionById` which uses `.select()` without projection — it returns all columns including the new `explanation`).
+
+- [ ] **Step 2: Update mock fixtures in `reviews.service.test.ts`**
+
+Read the file. Find every place that constructs a mock question (search for `correctOptionIndex` literals or `findQuestionById.mockResolvedValue`). Each mock question object needs an `explanation` field. Pattern:
+
+```typescript
+// Before:
+const mockQuestion = {
+  id: 1,
+  content: "...",
+  correctOptionIndex: 0,
+  // ...
+};
+
+// After:
+const mockQuestion = {
+  id: 1,
+  content: "...",
+  correctOptionIndex: 0,
+  explanation: null,  // or "test explanation" where appropriate
+  // ...
+};
+```
+
+Add at least one test that asserts `explanation` flows through correctly. Find the existing "first review uses INITIAL_SM2_STATE" or "answer correctness" test and add:
+
+```typescript
+it("includes explanation from question in the answer result", async () => {
+  // Use whatever mock setup the test file already has; just modify mockQuestion
+  // to include explanation: "Test explanation text"
+  // ... existing setup ...
+  mockRepo.findQuestionById.mockResolvedValue({
+    ...baseMockQuestion,  // (or whatever the file's pattern is)
+    explanation: "Newton's second law: F=ma",
+  });
+
+  const result = await service.answerQuestion(USER_ID, QUESTION_ID, 1);
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.explanation).toBe("Newton's second law: F=ma");
+  }
+});
+
+it("returns null explanation when question has no explanation", async () => {
+  mockRepo.findQuestionById.mockResolvedValue({
+    ...baseMockQuestion,
+    explanation: null,
+  });
+
+  const result = await service.answerQuestion(USER_ID, QUESTION_ID, 1);
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.explanation).toBeNull();
+  }
+});
+```
+
+(Adapt to whatever existing fixture pattern the file uses — read it first.)
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi
+pnpm --filter server exec vitest run src/features/reviews/reviews.service.test.ts 2>&1 | tail -15
+```
+
+Expected: all reviews service tests pass (existing + 2 new).
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+pnpm run check-types 2>&1 | grep "error TS" | grep -v "test\.ts\|integration\.test" | head -5
+```
+
+Expected: zero non-test errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/features/reviews/
+git commit -m "feat(server): surface question explanation in answer response"
+```
+
+---
+
+## Task 6: Subjects integration test
+
+**Files:**
+- Create: `apps/server/src/features/subjects/subjects.repository.integration.test.ts`
+
+- [ ] **Step 1: Create the integration test**
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { setupTestDb, teardownTestDb, cleanupTestDb, getTestDb } from "../../test/db-helpers";
+import { subject } from "@pruvi/db/schema/subjects";
+import { SubjectsRepository } from "./subjects.repository";
+
+describe("SubjectsRepository integration", () => {
+  let repo: SubjectsRepository;
+
+  beforeAll(async () => {
+    await setupTestDb();
+    repo = new SubjectsRepository(getTestDb());
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  it("listAll returns subjects sorted by name ASC", async () => {
+    const db = getTestDb();
+
+    await db.insert(subject).values([
+      { name: "Química", slug: "quimica" },
+      { name: "Biologia", slug: "biologia" },
+      { name: "Matemática", slug: "matematica" },
+    ]);
+
+    const rows = await repo.listAll();
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.name)).toEqual(["Biologia", "Matemática", "Química"]);
+    expect(rows.every((r) => typeof r.id === "number")).toBe(true);
+    expect(rows.every((r) => typeof r.slug === "string")).toBe(true);
+  });
+
+  it("listAll returns empty array when no subjects", async () => {
+    const rows = await repo.listAll();
+    expect(rows).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the integration test**
+
+```bash
+pnpm --filter server test:integration -- src/features/subjects/subjects.repository.integration.test.ts 2>&1 | tail -10
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Run full integration suite to confirm no regression**
+
+```bash
+pnpm --filter server test:integration 2>&1 | tail -8
+```
+
+Expected: all integration tests pass (20 total = 18 from Phase 1C + 2 new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/server/src/features/subjects/subjects.repository.integration.test.ts
+git commit -m "test(server): integration test for SubjectsRepository.listAll"
+```
+
+---
+
+## Task 7: Register `subjectsRoutes` in server
+
+**Files:**
+- Modify: `apps/server/src/index.ts`
+
+- [ ] **Step 1: Add import**
+
+Open `apps/server/src/index.ts`. Find the feature-route import block:
+
+```typescript
+import { gamificationRoutes } from "./features/gamification";
+import { livesRoutes } from "./features/lives";
+import { onboardingRoutes } from "./features/onboarding";
+import { progressRoutes } from "./features/progress";
+import { reviewsRoutes } from "./features/reviews";
+import { sessionsRoutes } from "./features/sessions";
+import { streaksRoutes } from "./features/streaks";
+import { usersRoutes } from "./features/users";
+```
+
+Add `subjectsRoutes` in alphabetical order (between `sessionsRoutes` and `streaksRoutes`):
+
+```typescript
+import { gamificationRoutes } from "./features/gamification";
+import { livesRoutes } from "./features/lives";
+import { onboardingRoutes } from "./features/onboarding";
+import { progressRoutes } from "./features/progress";
+import { reviewsRoutes } from "./features/reviews";
+import { sessionsRoutes } from "./features/sessions";
+import { streaksRoutes } from "./features/streaks";
+import { subjectsRoutes } from "./features/subjects";
+import { usersRoutes } from "./features/users";
+```
+
+- [ ] **Step 2: Register the route**
+
+Find the registration block. Add `subjectsRoutes` at the end:
+
+```typescript
+  await app.register(sessionsRoutes);
+  await app.register(reviewsRoutes);
+  await app.register(livesRoutes);
+  await app.register(streaksRoutes);
+  await app.register(gamificationRoutes);
+  await app.register(onboardingRoutes);
+  await app.register(usersRoutes);
+  await app.register(progressRoutes);
+  await app.register(subjectsRoutes);
+```
+
+- [ ] **Step 3: Typecheck + tests**
+
+```bash
+pnpm run check-types 2>&1 | grep "error TS" | grep -v "test\.ts\|integration\.test" | head -5
+pnpm --filter server test 2>&1 | tail -5
+```
+
+Expected: zero non-test errors; all unit tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/server/src/index.ts
+git commit -m "feat(server): register subjectsRoutes"
+```
+
+---
+
+## Task 8: Final verification + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full typecheck**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi
+pnpm run check-types 2>&1 | grep "error TS" | grep -v "test\.ts\|integration\.test" | head -5
+```
+
+Expected: zero non-test errors.
+
+- [ ] **Step 2: Unit tests**
+
+```bash
+pnpm --filter server test 2>&1 | tail -8
+```
+
+Expected: all tests pass (~68 = 64 + 4 new from subjects + reviews extension).
+
+- [ ] **Step 3: Integration tests**
+
+```bash
+pnpm --filter server test:integration 2>&1 | tail -8
+```
+
+Expected: all integration tests pass (~20 = 18 + 2 new).
+
+- [ ] **Step 4: Migration smoke test**
+
+```bash
+pnpm verify:migration 2>&1 | tail -8
+```
+
+Expected: `✓ Migration smoke test passed`.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin phase-1b-subjects-explanations
+gh pr create --base phase-1c-progress-calendar --head phase-1b-subjects-explanations \
+  --title "Phase 1B (code): subjects endpoint + question explanations" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Code-only portion of Phase 1B. Stacked on Phase 1C (#12).
+
+- Adds `question.explanation` column (nullable text). Migration `0002_*.sql`.
+- Surfaces explanation via `POST /questions/:id/answer` response.
+- Adds `GET /subjects` endpoint returning `{ subjects: [{ id, slug, name }] }` sorted by name; cached 300s.
+
+## Out of scope (content ops)
+
+- Backfilling explanations for the 111 existing seeded questions
+- Question bank expansion to 500+ with FUVEST/UNICAMP coverage
+
+Frontend renders a brand-voice fallback when `explanation` is null.
+
+## Test plan
+
+- [x] 4 new unit tests (2 subjects, 2 reviews extension)
+- [x] 2 new integration tests (subjects sorted, subjects empty)
+- [x] All existing tests pass
+- [x] Smoke test passes
+- [x] Migration is purely additive
+
+## References
+
+- Design: `docs/superpowers/specs/2026-05-10-phase-1b-subjects-explanations-design.md`
+- Plan: `docs/superpowers/plans/2026-05-10-phase-1b-subjects-explanations.md`
+EOF
+)" 2>&1 | tail -3
+```
+
+---
+
+## Definition of Done (from spec)
+
+- [ ] `question.explanation` column added; migration generated
+- [ ] `test-client.ts` updated to mirror new DDL
+- [ ] `subjects/` feature module created
+- [ ] `GET /subjects` registered, returns sorted subjects, cached 300s
+- [ ] `POST /questions/:id/answer` response includes `explanation` field
+- [ ] Shared schemas updated (`SubjectsListResponseSchema`, extended `AnswerQuestionResponseSchema`)
+- [ ] All existing unit + integration tests pass
+- [ ] 4 new unit tests + 2 new integration tests pass
+- [ ] `pnpm verify:migration` passes
+- [ ] No regression in existing endpoints
+
+---
+
+## Notes for the implementing agent
+
+- **`getTestDb()` pattern**: integration tests use the shared helper, not a freshly-constructed Drizzle client. See `apps/server/src/features/users/users.repository.integration.test.ts` for the canonical setup.
+- **`cleanupTestDb()` in `beforeEach`**: truncates between tests. Without it, "empty list" assertions can fail because prior test data persists.
+- **`fastify.cache`**: from `apps/server/src/plugins/redis.ts`. Same API used in `apps/server/src/features/lives/lives.route.ts`.
+- **Mock question fixtures in `reviews.service.test.ts`**: read the file first to find the existing fixture pattern. Don't invent a new fixture style; extend the existing one with `explanation: null` (or test text).
+- **Migration ordering**: this is the third migration (after Phase 0's `0000_*` and Phase 1A's `0001_*`). `db-helpers.ts` iterates all migrations in sorted order — no special handling needed.
+- **The seed file**: leave `seed.ts` alone. It deliberately doesn't write `explanation`. Future content backfill happens via direct UPDATE or a separate script.

--- a/docs/superpowers/specs/2026-05-10-phase-1b-subjects-explanations-design.md
+++ b/docs/superpowers/specs/2026-05-10-phase-1b-subjects-explanations-design.md
@@ -1,0 +1,250 @@
+# Phase 1B (code) — Subjects Endpoint & Question Explanations
+
+**Date:** 2026-05-10
+**Author:** brainstorming session
+**Status:** Draft → pending user review
+**Depends on:** Phase 1C (`phase-1c-progress-calendar` branch / PR #12) — stacks cleanly
+
+---
+
+## Context
+
+The audit (`docs/backend-audit-main.md`) identified Phase 1B as content + code. Content curation (400+ new questions, hand-written explanation text for the existing 111) is genuinely an ops track and out of scope for this code phase. This spec covers only the code-side work that unblocks the frontend rebuild's question-feedback UX and any "pick a subject" screen.
+
+Spec 2.3 requires "justificativa em 2–4 linhas, linguagem humana, no tom do personagem" rendered alongside the correct/wrong indicator. The backend currently has no `explanation` column on `question`. The frontend cannot render explanations until this column exists and is surfaced via the answer endpoint.
+
+Spec 1.1 onboarding mentions subject pickers (which subject does the user hate most). The native app currently hardcodes the subject list; a backend-served list is needed for any future content additions to flow without an app rebuild.
+
+---
+
+## Goals
+
+After this phase ships:
+- Frontend can fetch the canonical subject list at runtime via `GET /subjects`
+- Frontend renders explanations (or a null-fallback) after each answer, served as part of the existing answer response
+- Content team can backfill explanations independently — null is a valid state on the wire
+
+---
+
+## Scope
+
+### In scope
+
+1. **`question.explanation` column** — nullable `text` added to schema + migration
+2. **Answer response surfaces explanation** — `POST /questions/:id/answer` returns `explanation: string | null`
+3. **`GET /subjects` endpoint** — minimal `{ id, slug, name }` list, cached 5 minutes
+4. **New `subjects/` feature module** mirroring the existing pattern
+5. **Shared schema updates** — `SubjectsListResponseSchema`, extended `AnswerQuestionResponseSchema`
+
+### Explicitly out of scope
+
+- Question bank expansion to 500+ (content ops track)
+- Backfill text for existing 111 questions (content ops; frontend renders null fallback)
+- Per-subject icon/color/badge tokens (frontend keeps its hardcoded mapping)
+- Per-subject question count in `/subjects` response (YAGNI)
+- Standalone `GET /questions/:id` endpoint (explanation piggybacks on answer)
+- CMS endpoints for content authoring
+
+---
+
+## Schema Changes
+
+### `packages/db/src/schema/questions.ts`
+
+Add one nullable column to the existing `question` table, between `requiresCalculation` and `source`:
+
+```typescript
+explanation: text("explanation"),
+```
+
+Full block:
+
+```typescript
+export const question = pgTable(
+  "question",
+  {
+    id: serial("id").primaryKey(),
+    content: text("content").notNull(),
+    options: jsonb("options").$type<string[]>().notNull(),
+    correctOptionIndex: integer("correct_option_index").notNull(),
+    difficulty: text("difficulty", { enum: ["easy", "medium", "hard"] }).notNull(),
+    requiresCalculation: boolean("requires_calculation").notNull().default(false),
+    explanation: text("explanation"),
+    source: text("source"),
+    subjectId: integer("subject_id").notNull().references(() => subject.id),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("question_subject_difficulty_idx").on(table.subjectId, table.difficulty),
+  ],
+);
+```
+
+### `packages/db/src/test-client.ts`
+
+Update the `CREATE TABLE IF NOT EXISTS "question"` block to include `explanation TEXT,` between `requires_calculation` and `source`.
+
+### `packages/db/src/seed.ts`
+
+No change. `SeedQuestion` interface stays as-is; existing inserts omit the column; Postgres defaults to null. Re-running the seed leaves any future content-team backfill untouched.
+
+### Migration
+
+`drizzle-kit generate` produces a purely additive migration:
+
+```sql
+ALTER TABLE "question" ADD COLUMN "explanation" text;
+```
+
+Becomes `0002_<name>.sql` alongside `0000_needy_king_bedlam.sql` (Phase 0) and `0001_melted_tigra.sql` (Phase 1A).
+
+---
+
+## API Contracts
+
+### `GET /subjects`
+
+Auth required (consistent with codebase convention).
+
+**Response:**
+```typescript
+{
+  subjects: Array<{
+    id: number,
+    slug: string,
+    name: string,
+  }>
+}
+```
+
+- Sorted by `name` ASC.
+- Cached 300s under single shared key `subjects:list` (subjects rarely change; no per-user variance).
+- No pagination (bounded list).
+
+### `POST /questions/:questionId/answer` — extended response
+
+Existing endpoint, response gains one field:
+
+```typescript
+{
+  correct: boolean,
+  correctOptionIndex: number,        // 0-3
+  livesRemaining: number,
+  xpAwarded: number,
+  explanation: string | null,        // NEW
+}
+```
+
+- `explanation` is the raw text from `question.explanation` for the answered question.
+- Null when not yet backfilled. Frontend renders a brand-voice fallback.
+- No server-side transformation (markdown, character voice formatting are frontend concerns).
+
+### Shared schemas
+
+`packages/shared/src/subjects.ts` adds:
+
+```typescript
+export const SubjectsListResponseSchema = z.object({
+  subjects: z.array(subjectSchema),
+});
+
+export type SubjectsListResponse = z.infer<typeof SubjectsListResponseSchema>;
+```
+
+`packages/shared/src/answers.ts` extends `AnswerQuestionResponseSchema`:
+
+```typescript
+export const AnswerQuestionResponseSchema = z.object({
+  correct: z.boolean(),
+  correctOptionIndex: z.number().int().min(0).max(3),
+  livesRemaining: z.number().int().min(0),
+  xpAwarded: z.number().int().min(0),
+  explanation: z.string().nullable(),
+});
+```
+
+---
+
+## Architecture
+
+### New subjects feature module (`apps/server/src/features/subjects/`)
+
+| File | Responsibility |
+|---|---|
+| `subjects.repository.ts` | `listAll()` — `SELECT id, slug, name FROM subject ORDER BY name ASC` |
+| `subjects.service.ts` | Result-wrapped passthrough; no business rules today |
+| `subjects.route.ts` | `GET /subjects` with 300s Redis cache |
+| `index.ts` | Re-export `subjectsRoutes` |
+| `subjects.service.test.ts` | 2 unit tests (returns list; passthrough behavior) |
+| `subjects.repository.integration.test.ts` | 1 integration test (seed 2 subjects, assert sorted output) |
+
+### Modified files in reviews feature
+
+- `reviews.repository.ts` — `findQuestionById` already selects via `*`; the new `explanation` column flows through automatically. No code change needed.
+- `reviews.service.ts` — extend the success return to include `explanation: q.explanation ?? null`.
+- `reviews.service.test.ts` — update mock `question` fixtures to include `explanation: null` (or test text where appropriate); assert it surfaces in the answer result.
+
+### Server wiring
+
+`apps/server/src/index.ts`:
+- Import `subjectsRoutes` from `./features/subjects`
+- Register `await app.register(subjectsRoutes);` after the other feature routes
+
+### Caching
+
+| Endpoint | Key | TTL | Invalidation |
+|---|---|---|---|
+| `GET /subjects` | `subjects:list` (single shared key) | 300s | TTL-only — no admin endpoint yet to invalidate from |
+
+---
+
+## Testing
+
+| Layer | What | How |
+|---|---|---|
+| Unit | `SubjectsService.list` returns subjects from repo | Vitest + mocked repo |
+| Unit | `ReviewsService.answerQuestion` surfaces `explanation` in result (null and non-null cases) | Update existing tests; mock question with explanation field |
+| Integration | `SubjectsRepository.listAll` returns subjects sorted by name | Vitest + PGlite |
+
+No new integration test for explanation flow — existing `reviews.repository.integration.test.ts` exercises the question read path, and the schema change is purely additive (nullable column).
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Subjects cache invalidation needed when content adds a subject — but there's no admin endpoint yet | 5min TTL handles staleness; revisit when CMS lands |
+| Frontend renders null explanation poorly | Frontend concern; suggest fallback "Esta questão ainda não tem comentário." in the rebuild |
+| Answer response payload widens by 200-400 bytes per question | Negligible; well under any practical mobile data concern |
+| Re-running seed could overwrite future explanation backfill | Seed deliberately omits the column; documented |
+| `subject` table has no slug-uniqueness constraint visible in current schema | Not a Phase 1B problem; existing seed uses distinct slugs |
+
+---
+
+## Rollout
+
+**Single PR stacked on `phase-1c-progress-calendar`.** Phase 1B is independent of Phase 1A and Phase 1C; rebases cleanly onto whichever lands first.
+
+### Definition of Done
+
+- [ ] `question.explanation` column added in schema; migration generated
+- [ ] `test-client.ts` updated to mirror new DDL
+- [ ] `subjects/` feature module created (6 files including tests)
+- [ ] `GET /subjects` registered, returns sorted subjects, cached 300s
+- [ ] `POST /questions/:id/answer` response includes `explanation` field
+- [ ] Shared schemas updated (`SubjectsListResponseSchema`, extended `AnswerQuestionResponseSchema`)
+- [ ] All existing unit + integration tests pass
+- [ ] 3 new unit tests + 1 new integration test pass
+- [ ] `pnpm verify:migration` passes
+- [ ] No regression in existing endpoints
+
+---
+
+## Out-of-Band Notes
+
+After Phase 1B (code) lands, the remaining audit gap is **content ops**: 400+ new questions (FUVEST/UNICAMP priority), hand-written explanation text for the existing 111 ENEM placeholders, and topic-level categorization (which becomes meaningful once Phase 2 introduces a `topic` table). None of these block the frontend rebuild — they improve the product quality once it's live.
+
+If a CMS for question authoring becomes a priority, that's a Phase 2+ effort — not a quick add. For now, content team operates via direct SQL or a notebook against the dev DB.
+
+The frontend should render a brand-voice fallback when `explanation` is null. Suggested copy (frontend's call): "Esta questão ainda não tem comentário do personagem."

--- a/packages/db/src/migrations/0002_curious_black_knight.sql
+++ b/packages/db/src/migrations/0002_curious_black_knight.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "question" ADD COLUMN "explanation" text;

--- a/packages/db/src/migrations/meta/0002_snapshot.json
+++ b/packages/db/src/migrations/meta/0002_snapshot.json
@@ -1,0 +1,841 @@
+{
+  "id": "c2555d90-2fe2-4273-8262-c075f1216176",
+  "prevId": "86f39053-6614-476f-b50d-de047d8bfd90",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives": {
+          "name": "lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lives_reset_at": {
+          "name": "lives_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "selected_exam": {
+          "name": "selected_exam",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulties": {
+          "name": "difficulties",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "daily_study_time_minutes": {
+          "name": "daily_study_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_session": {
+      "name": "daily_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_correct": {
+          "name": "questions_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_session_user_created_idx": {
+          "name": "daily_session_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_session_user_id_user_id_fk": {
+          "name": "daily_session_user_id_user_id_fk",
+          "tableFrom": "daily_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subject_name_unique": {
+          "name": "subject_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "subject_slug_unique": {
+          "name": "subject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_option_index": {
+          "name": "correct_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_calculation": {
+          "name": "requires_calculation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_subject_difficulty_idx": {
+          "name": "question_subject_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_subject_id_subject_id_fk": {
+          "name": "question_subject_id_subject_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_log": {
+      "name": "review_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "easiness_factor": {
+          "name": "easiness_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_log_user_next_review_idx": {
+          "name": "review_log_user_next_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_log_user_question_idx": {
+          "name": "review_log_user_question_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_log_user_id_user_id_fk": {
+          "name": "review_log_user_id_user_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_log_question_id_question_id_fk": {
+          "name": "review_log_question_id_question_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1778453614647,
       "tag": "0001_melted_tigra",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1778456589001,
+      "tag": "0002_curious_black_knight",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/questions.ts
+++ b/packages/db/src/schema/questions.ts
@@ -12,6 +12,7 @@ export const question = pgTable(
     correctOptionIndex: integer("correct_option_index").notNull(),
     difficulty: text("difficulty", { enum: ["easy", "medium", "hard"] }).notNull(),
     requiresCalculation: boolean("requires_calculation").notNull().default(false),
+    explanation: text("explanation"),
     source: text("source"),
     subjectId: integer("subject_id")
       .notNull()

--- a/packages/db/src/test-client.ts
+++ b/packages/db/src/test-client.ts
@@ -77,6 +77,7 @@ export async function createTestDb() {
       correct_option_index INTEGER NOT NULL,
       difficulty TEXT NOT NULL,
       requires_calculation BOOLEAN NOT NULL DEFAULT FALSE,
+      explanation TEXT,
       source TEXT,
       subject_id INTEGER NOT NULL REFERENCES "subject"(id),
       created_at TIMESTAMP NOT NULL DEFAULT NOW()

--- a/packages/shared/src/answers.ts
+++ b/packages/shared/src/answers.ts
@@ -13,6 +13,7 @@ export const AnswerQuestionResponseSchema = z.object({
   correctOptionIndex: z.number().int().min(0).max(3),
   livesRemaining: z.number().int().min(0),
   xpAwarded: z.number().int().min(0),
+  explanation: z.string().nullable(),
 });
 
 export type AnswerQuestionResponse = z.infer<typeof AnswerQuestionResponseSchema>;

--- a/packages/shared/src/subjects.ts
+++ b/packages/shared/src/subjects.ts
@@ -7,3 +7,9 @@ export const subjectSchema = z.object({
 });
 
 export type Subject = z.infer<typeof subjectSchema>;
+
+export const SubjectsListResponseSchema = z.object({
+  subjects: z.array(subjectSchema),
+});
+
+export type SubjectsListResponse = z.infer<typeof SubjectsListResponseSchema>;


### PR DESCRIPTION
## Summary

Code-only portion of Phase 1B. Stacked on Phase 1C (#12).

- Adds `question.explanation` column (nullable text). Migration `0002_curious_black_knight.sql`.
- `POST /questions/:id/answer` response now includes `explanation: string | null`.
- Adds `GET /subjects` endpoint returning `{ subjects: [{ id, slug, name }] }` sorted by name; cached 300s under shared key.

## Out of scope (content ops)

- Backfilling explanations for the 111 existing seeded questions
- Question bank expansion to 500+ with FUVEST/UNICAMP coverage

Frontend renders a brand-voice fallback when `explanation` is null.

## Test plan

- [x] 4 new unit tests (2 subjects, 2 reviews explanation extension)
- [x] 2 new integration tests (subjects sorted, subjects empty)
- [x] 68/68 unit tests pass
- [x] 20/20 integration tests pass
- [x] Smoke test passes
- [x] Migration is purely additive (single ALTER TABLE ADD COLUMN)

## Notable pre-existing fix included

- `questions.repository.ts` selected-row narrowing widened to also exclude `explanation` (the prefetch flow doesn't need the explanation text, only the answer endpoint does — saves cache payload bytes).

## References

- Design: `docs/superpowers/specs/2026-05-10-phase-1b-subjects-explanations-design.md`
- Plan: `docs/superpowers/plans/2026-05-10-phase-1b-subjects-explanations.md`