### PR TITLE
fix: CodeRabbit feedback from PR #10 (cheap wins)

### DIFF
--- a/apps/server/src/features/questions/questions.repository.ts
+++ b/apps/server/src/features/questions/questions.repository.ts
@@ -72,7 +72,16 @@ export class QuestionsRepository {
       }
 
       const unseen = await this.db
-        .select()
+        .select({
+          id: question.id,
+          subjectId: question.subjectId,
+          content: question.content,
+          options: question.options,
+          correctOptionIndex: question.correctOptionIndex,
+          difficulty: question.difficulty,
+          requiresCalculation: question.requiresCalculation,
+          source: question.source,
+        })
         .from(question)
         .where(and(...conditions))
         .limit(limit - selected.length);

--- a/apps/server/src/features/sessions/sessions.route.ts
+++ b/apps/server/src/features/sessions/sessions.route.ts
@@ -83,10 +83,15 @@ export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
         params: z.object({
           id: z.coerce.number().int(),
         }),
-        body: z.object({
-          questionsAnswered: z.number().int().min(0),
-          questionsCorrect: z.number().int().min(0),
-        }),
+        body: z
+          .object({
+            questionsAnswered: z.number().int().min(0),
+            questionsCorrect: z.number().int().min(0),
+          })
+          .refine((data) => data.questionsCorrect <= data.questionsAnswered, {
+            message: "questionsCorrect cannot exceed questionsAnswered",
+            path: ["questionsCorrect"],
+          }),
       },
     },
     async (request) => {

--- a/apps/server/src/features/sessions/sessions.service.test.ts
+++ b/apps/server/src/features/sessions/sessions.service.test.ts
@@ -144,5 +144,21 @@ describe("SessionsService", () => {
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(ValidationError);
       expect(result._unsafeUnwrapErr().message).toBe("Session already completed");
     });
+
+    it("rejects when questionsCorrect exceeds questionsAnswered", async () => {
+      const result = await service.completeSession("user-1", 1, 5, 8);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ValidationError);
+      expect(result._unsafeUnwrapErr().message).toBe("Invalid session completion metrics");
+      expect(repo.findSessionById).not.toHaveBeenCalled();
+    });
+
+    it("rejects negative metrics", async () => {
+      const result = await service.completeSession("user-1", 1, -1, 0);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ValidationError);
+    });
   });
 });

--- a/apps/server/src/features/sessions/sessions.service.ts
+++ b/apps/server/src/features/sessions/sessions.service.ts
@@ -87,6 +87,16 @@ export class SessionsService {
       AppError
     >
   > {
+    if (
+      !Number.isInteger(questionsAnswered) ||
+      !Number.isInteger(questionsCorrect) ||
+      questionsAnswered < 0 ||
+      questionsCorrect < 0 ||
+      questionsCorrect > questionsAnswered
+    ) {
+      return err(new ValidationError("Invalid session completion metrics"));
+    }
+
     const session = await this.repo.findSessionById(sessionId);
     if (!session) {
       return err(new NotFoundError("Session not found"));

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,5 +4,9 @@ import { Pool } from "pg";
 
 import * as schema from "./schema";
 
-export const pool = new Pool({ connectionString: env.DATABASE_URL });
+export const pool = new Pool({
+  connectionString: env.DATABASE_URL,
+  connectionTimeoutMillis: 5_000,
+  idleTimeoutMillis: 30_000,
+});
 export const db = drizzle(pool, { schema });

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -10,7 +10,7 @@ export const env = createEnv({
     CORS_ORIGIN: z.url(),
     REDIS_URL: z.string().default("redis://localhost:6379"),
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
-    PORT: z.coerce.number().int().positive().default(3000),
+    PORT: z.coerce.number().int().min(1).max(65535).default(3000),
     RESEND_API_KEY: z.string().min(1),
     RESEND_FROM_EMAIL: z.email(),
     GOOGLE_CLIENT_ID: z.string().min(1),


### PR DESCRIPTION
## Summary

Applies 5 of CodeRabbit's findings from PR #10. Stacked on Phase 1B (#13) so the fixes flow through the whole stack.

| Fix | Severity | File | Lines |
|---|---|---|---|
| PORT range cap to 1-65535 | Minor | \`packages/env/src/server.ts\` | 1 |
| Pool connection timeouts (5s connect, 30s idle) | Major | \`packages/db/src/index.ts\` | 3 |
| questions.repository unseen branch explicit projection | Minor | \`apps/server/src/features/questions/questions.repository.ts\` | 9 |
| Session completion: \`questionsCorrect <= questionsAnswered\` route-layer Zod refine | Major | \`apps/server/src/features/sessions/sessions.route.ts\` | 7 |
| Session completion: defense-in-depth service-layer guard | Major | \`apps/server/src/features/sessions/sessions.service.ts\` | 9 |

## Skipped from CodeRabbit's feedback

- **\`db-helpers.ts sort()[0]\`** — already fixed in Phase 1A (commit \`25d6f49\`). CodeRabbit reviewed the snapshot at PR #10 opening before the Phase 1A fix landed.
- **DB CHECK constraints on user gamification columns** — deferred to Phase 2 lives-mechanic rework. Natural fit since that work already touches lives semantics + needs a corrective migration.

## Test plan

- [x] 2 new unit tests (negative metrics; questionsCorrect > questionsAnswered)
- [x] 70/70 unit tests pass (+2)
- [x] Zero non-test typecheck errors
- [x] No schema changes (no new migration)