### PR TITLE
feat: phase 2b — push notifications (Expo)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -25,6 +25,7 @@
     "bullmq": "^5.71.0",
     "dotenv": "catalog:",
     "drizzle-orm": "^0.45.1",
+    "expo-server-sdk": "^6.1.0",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.1.0",
     "fastify-type-provider-zod": "^6.1.0",

--- a/apps/server/src/features/notifications/dispatcher.test.ts
+++ b/apps/server/src/features/notifications/dispatcher.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { Dispatcher } from "./dispatcher";
+
+function makeDeps(over: any = {}) {
+  return {
+    tokensService: { listTokensForUser: vi.fn().mockResolvedValue(["ExponentPushToken[a]"]) },
+    prefsRepo: { get: vi.fn().mockResolvedValue({ notificationHour: 19, streakRemindersEnabled: true, achievementNotificationsEnabled: true }) },
+    sweepRepo: {
+      findEligibleForStreakReminder: vi.fn().mockResolvedValue([
+        { userId: "u1", token: "ExponentPushToken[u1]" },
+        { userId: "u2", token: "ExponentPushToken[u2]" },
+      ]),
+    },
+    sendQueue: { add: vi.fn().mockResolvedValue(undefined) },
+    ...over,
+  };
+}
+
+describe("Dispatcher.sendAchievementNotification", () => {
+  it("bails when achievement_notifications_enabled is false", async () => {
+    const deps = makeDeps({
+      prefsRepo: {
+        get: vi.fn().mockResolvedValue({ notificationHour: 19, streakRemindersEnabled: true, achievementNotificationsEnabled: false }),
+      },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.sendAchievementNotification("u", "7-day-streak");
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("bails when user has no tokens", async () => {
+    const deps = makeDeps({
+      tokensService: { listTokensForUser: vi.fn().mockResolvedValue([]) },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.sendAchievementNotification("u", "7-day-streak");
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("enqueues a send job for a 7-day streak", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.sendAchievementNotification("u", "7-day-streak");
+    expect(deps.sendQueue.add).toHaveBeenCalledTimes(1);
+    const [, payload] = deps.sendQueue.add.mock.calls[0];
+    expect(payload.tokens).toEqual(["ExponentPushToken[a]"]);
+    expect(payload.title).toMatch(/7/);
+  });
+
+  it("includes the subtopic name in the mastery achievement body", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.sendAchievementNotification("u", "quase-mestre", { subtopicName: "Membrana" });
+    const [, payload] = deps.sendQueue.add.mock.calls[0];
+    expect(payload.body).toContain("Membrana");
+  });
+});
+
+describe("Dispatcher.dispatchStreakReminder", () => {
+  it("calls the eligibility query with hour and enqueues a send per chunk", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.dispatchStreakReminder({ brtHour: 19, variant: "primary" });
+    expect(deps.sweepRepo.findEligibleForStreakReminder).toHaveBeenCalledWith(19);
+    expect(deps.sendQueue.add).toHaveBeenCalledTimes(1);
+    const [, payload] = deps.sendQueue.add.mock.calls[0];
+    expect(payload.tokens).toEqual(["ExponentPushToken[u1]", "ExponentPushToken[u2]"]);
+  });
+
+  it("late variant queries hour minus 2 modulo 24", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.dispatchStreakReminder({ brtHour: 1, variant: "late" });
+    expect(deps.sweepRepo.findEligibleForStreakReminder).toHaveBeenCalledWith(23);
+  });
+
+  it("does nothing when no eligible users", async () => {
+    const deps = makeDeps({
+      sweepRepo: { findEligibleForStreakReminder: vi.fn().mockResolvedValue([]) },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.dispatchStreakReminder({ brtHour: 19, variant: "primary" });
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/features/notifications/dispatcher.ts
+++ b/apps/server/src/features/notifications/dispatcher.ts
@@ -1,0 +1,81 @@
+import type { Queue } from "bullmq";
+import {
+  streakReminderPrimary,
+  streakReminderLate,
+  streakMilestone,
+  masteryAchievement,
+  type PushPayload,
+} from "./templates";
+import type { TokensService } from "./tokens.service";
+import type { PreferencesRepository } from "./preferences.repository";
+import { EXPO_BATCH_SIZE } from "./push.client";
+
+export type AchievementKind = "7-day-streak" | "30-day-streak" | "quase-mestre";
+
+export type SendJobData = {
+  tokens: string[];
+  title: string;
+  body: string;
+  data?: Record<string, unknown>;
+};
+
+export type SweepRepoLike = {
+  findEligibleForStreakReminder(brtHour: number): Promise<Array<{ userId: string; token: string }>>;
+};
+
+export type DispatcherDeps = {
+  tokensService: TokensService;
+  prefsRepo: PreferencesRepository;
+  sweepRepo: SweepRepoLike;
+  sendQueue: Queue<SendJobData>;
+};
+
+export class Dispatcher {
+  constructor(private deps: DispatcherDeps) {}
+
+  async sendAchievementNotification(
+    userId: string,
+    kind: AchievementKind,
+    vars?: { subtopicName?: string },
+  ): Promise<void> {
+    const prefs = await this.deps.prefsRepo.get(userId);
+    if (!prefs?.achievementNotificationsEnabled) return;
+
+    const tokens = await this.deps.tokensService.listTokensForUser(userId);
+    if (tokens.length === 0) return;
+
+    let payload: PushPayload;
+    if (kind === "7-day-streak") payload = streakMilestone(7);
+    else if (kind === "30-day-streak") payload = streakMilestone(30);
+    else payload = masteryAchievement(vars?.subtopicName ?? "");
+
+    for (let i = 0; i < tokens.length; i += EXPO_BATCH_SIZE) {
+      const chunk = tokens.slice(i, i + EXPO_BATCH_SIZE);
+      await this.deps.sendQueue.add("send", {
+        tokens: chunk,
+        title: payload.title,
+        body: payload.body,
+        data: { kind },
+      });
+    }
+  }
+
+  async dispatchStreakReminder(opts: { brtHour: number; variant: "primary" | "late" }): Promise<void> {
+    const targetHour = opts.variant === "late" ? (opts.brtHour - 2 + 24) % 24 : opts.brtHour;
+    const eligible = await this.deps.sweepRepo.findEligibleForStreakReminder(targetHour);
+    if (eligible.length === 0) return;
+
+    const payload = opts.variant === "late" ? streakReminderLate() : streakReminderPrimary();
+    const tokens = eligible.map((r) => r.token);
+
+    for (let i = 0; i < tokens.length; i += EXPO_BATCH_SIZE) {
+      const chunk = tokens.slice(i, i + EXPO_BATCH_SIZE);
+      await this.deps.sendQueue.add("send", {
+        tokens: chunk,
+        title: payload.title,
+        body: payload.body,
+        data: { kind: `streak-${opts.variant}` },
+      });
+    }
+  }
+}

--- a/apps/server/src/features/notifications/index.ts
+++ b/apps/server/src/features/notifications/index.ts
@@ -1,1 +1,2 @@
 export { tokensRoutes } from "./tokens.route";
+export { preferencesRoutes } from "./preferences.route";

--- a/apps/server/src/features/notifications/index.ts
+++ b/apps/server/src/features/notifications/index.ts
@@ -1,0 +1,1 @@
+export { tokensRoutes } from "./tokens.route";

--- a/apps/server/src/features/notifications/notifications.sweep.integration.test.ts
+++ b/apps/server/src/features/notifications/notifications.sweep.integration.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { setupTestDb, getTestDb, teardownTestDb, cleanupTestDb } from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { pushToken } from "@pruvi/db/schema/push-tokens";
+import { dailySession } from "@pruvi/db/schema/daily-sessions";
+import { SweepRepository } from "./sweep.repository";
+
+const db = getTestDb();
+const repo = new SweepRepository(db);
+
+beforeAll(async () => { await setupTestDb(); });
+afterAll(async () => { await teardownTestDb(); });
+beforeEach(async () => { await cleanupTestDb(); });
+
+describe("SweepRepository.findEligibleForStreakReminder", () => {
+  it("returns user with hour match + token + reminders enabled + no completed session today", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19, streakRemindersEnabled: true });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([{ userId: "u1", token: "ExponentPushToken[u1]" }]);
+  });
+
+  it("skips users with streakRemindersEnabled = false", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19, streakRemindersEnabled: false });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([]);
+  });
+
+  it("skips users whose hour doesn't match", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 20 });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([]);
+  });
+
+  it("skips users who have a completed session today", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19 });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    await db.insert(dailySession).values({ userId: "u1", status: "completed" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([]);
+  });
+
+  it("includes users with an active (incomplete) session today", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19 });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    await db.insert(dailySession).values({ userId: "u1", status: "active" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows.map((r) => r.userId)).toEqual(["u1"]);
+  });
+
+  it("returns one row per (user, token) pair when user has multiple devices", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19 });
+    await db.insert(pushToken).values([
+      { userId: "u1", token: "ExponentPushToken[a]", platform: "ios" },
+      { userId: "u1", token: "ExponentPushToken[b]", platform: "android" },
+    ]);
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows.map((r) => r.token).sort()).toEqual(["ExponentPushToken[a]", "ExponentPushToken[b]"]);
+  });
+
+  it("skips users with no push tokens", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19 });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([]);
+  });
+});

--- a/apps/server/src/features/notifications/preferences.repository.ts
+++ b/apps/server/src/features/notifications/preferences.repository.ts
@@ -1,0 +1,43 @@
+import { eq } from "drizzle-orm";
+import { user } from "@pruvi/db/schema/auth";
+import type { db } from "@pruvi/db";
+
+type DbClient = typeof db;
+
+export type PrefsRow = {
+  notificationHour: number;
+  streakRemindersEnabled: boolean;
+  achievementNotificationsEnabled: boolean;
+};
+
+export type PrefsPatch = Partial<PrefsRow>;
+
+export class PreferencesRepository {
+  constructor(private db: DbClient) {}
+
+  async get(userId: string): Promise<PrefsRow | null> {
+    const [row] = await this.db
+      .select({
+        notificationHour: user.notificationHour,
+        streakRemindersEnabled: user.streakRemindersEnabled,
+        achievementNotificationsEnabled: user.achievementNotificationsEnabled,
+      })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async update(userId: string, patch: PrefsPatch): Promise<PrefsRow | null> {
+    const [row] = await this.db
+      .update(user)
+      .set(patch)
+      .where(eq(user.id, userId))
+      .returning({
+        notificationHour: user.notificationHour,
+        streakRemindersEnabled: user.streakRemindersEnabled,
+        achievementNotificationsEnabled: user.achievementNotificationsEnabled,
+      });
+    return row ?? null;
+  }
+}

--- a/apps/server/src/features/notifications/preferences.route.ts
+++ b/apps/server/src/features/notifications/preferences.route.ts
@@ -1,0 +1,42 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { UpdateNotificationPreferencesBodySchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { successResponse, unwrapResult } from "../../types";
+import { PreferencesRepository } from "./preferences.repository";
+import { PreferencesService } from "./preferences.service";
+
+const repo = new PreferencesRepository(db);
+const service = new PreferencesService(repo);
+
+const PREFS_TTL = 60;
+
+export const preferencesRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/users/me/notification-preferences",
+    { preHandler: [fastify.authenticate] },
+    async (request) => {
+      const cacheKey = `prefs:notif:${request.userId}`;
+      const cached = await fastify.cache.get<unknown>(cacheKey);
+      if (cached) return successResponse(cached);
+
+      const result = await service.get(request.userId);
+      const response = unwrapResult(result);
+      await fastify.cache.set(cacheKey, response.data, PREFS_TTL);
+      return response;
+    },
+  );
+
+  fastify.put(
+    "/users/me/notification-preferences",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { body: UpdateNotificationPreferencesBodySchema },
+    },
+    async (request) => {
+      const result = await service.update(request.userId, request.body);
+      const response = unwrapResult(result);
+      await fastify.cache.del(`prefs:notif:${request.userId}`);
+      return response;
+    },
+  );
+};

--- a/apps/server/src/features/notifications/preferences.service.test.ts
+++ b/apps/server/src/features/notifications/preferences.service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { PreferencesService } from "./preferences.service";
+
+function stubRepo(overrides: any = {}) {
+  return {
+    get: vi.fn().mockResolvedValue({
+      notificationHour: 19,
+      streakRemindersEnabled: true,
+      achievementNotificationsEnabled: true,
+    }),
+    update: vi.fn().mockImplementation(async (_userId: string, patch: any) => ({
+      notificationHour: patch.notificationHour ?? 19,
+      streakRemindersEnabled: patch.streakRemindersEnabled ?? true,
+      achievementNotificationsEnabled: patch.achievementNotificationsEnabled ?? true,
+    })),
+    ...overrides,
+  };
+}
+
+describe("PreferencesService.get", () => {
+  it("returns ok with prefs from repo", async () => {
+    const repo = stubRepo();
+    const service = new PreferencesService(repo as any);
+    const result = await service.get("u");
+    expect(result._unsafeUnwrap()).toMatchObject({
+      notificationHour: 19,
+      streakRemindersEnabled: true,
+      achievementNotificationsEnabled: true,
+    });
+  });
+
+  it("returns NotFoundError when repo returns null", async () => {
+    const repo = stubRepo({ get: vi.fn().mockResolvedValue(null) });
+    const service = new PreferencesService(repo as any);
+    const result = await service.get("u");
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("PreferencesService.update", () => {
+  it("applies partial patch", async () => {
+    const repo = stubRepo();
+    const service = new PreferencesService(repo as any);
+    const result = await service.update("u", { notificationHour: 20 });
+    expect(result._unsafeUnwrap().notificationHour).toBe(20);
+    expect(repo.update).toHaveBeenCalledWith("u", { notificationHour: 20 });
+  });
+
+  it("rejects an out-of-range hour", async () => {
+    const repo = stubRepo();
+    const service = new PreferencesService(repo as any);
+    const result = await service.update("u", { notificationHour: 25 });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("rejects a negative hour", async () => {
+    const repo = stubRepo();
+    const service = new PreferencesService(repo as any);
+    const result = await service.update("u", { notificationHour: -1 });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/apps/server/src/features/notifications/preferences.service.test.ts
+++ b/apps/server/src/features/notifications/preferences.service.test.ts
@@ -59,4 +59,12 @@ describe("PreferencesService.update", () => {
     const result = await service.update("u", { notificationHour: -1 });
     expect(result.isErr()).toBe(true);
   });
+
+  it("rejects an empty patch with ValidationError", async () => {
+    const repo = stubRepo();
+    const service = new PreferencesService(repo as any);
+    const result = await service.update("u", {});
+    expect(result.isErr()).toBe(true);
+    expect(repo.update).not.toHaveBeenCalled();
+  });
 });

--- a/apps/server/src/features/notifications/preferences.service.ts
+++ b/apps/server/src/features/notifications/preferences.service.ts
@@ -16,6 +16,9 @@ export class PreferencesService {
   }
 
   async update(userId: string, patch: PrefsPatch): Promise<Result<PrefsRow, AppError>> {
+    if (Object.keys(patch).length === 0) {
+      return err(new ValidationError("At least one preference field must be provided"));
+    }
     if (patch.notificationHour !== undefined) {
       if (
         !Number.isInteger(patch.notificationHour) ||

--- a/apps/server/src/features/notifications/preferences.service.ts
+++ b/apps/server/src/features/notifications/preferences.service.ts
@@ -1,0 +1,32 @@
+import { err, ok, type Result } from "neverthrow";
+import { NotFoundError, ValidationError, type AppError } from "../../utils/errors";
+import type {
+  PreferencesRepository,
+  PrefsPatch,
+  PrefsRow,
+} from "./preferences.repository";
+
+export class PreferencesService {
+  constructor(private repo: PreferencesRepository) {}
+
+  async get(userId: string): Promise<Result<PrefsRow, AppError>> {
+    const prefs = await this.repo.get(userId);
+    if (!prefs) return err(new NotFoundError("User not found"));
+    return ok(prefs);
+  }
+
+  async update(userId: string, patch: PrefsPatch): Promise<Result<PrefsRow, AppError>> {
+    if (patch.notificationHour !== undefined) {
+      if (
+        !Number.isInteger(patch.notificationHour) ||
+        patch.notificationHour < 0 ||
+        patch.notificationHour > 23
+      ) {
+        return err(new ValidationError("notificationHour must be 0–23"));
+      }
+    }
+    const updated = await this.repo.update(userId, patch);
+    if (!updated) return err(new NotFoundError("User not found"));
+    return ok(updated);
+  }
+}

--- a/apps/server/src/features/notifications/push.client.test.ts
+++ b/apps/server/src/features/notifications/push.client.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { PushClient, EXPO_BATCH_SIZE } from "./push.client";
+
+function makeExpoStub(overrides: any = {}) {
+  return {
+    sendPushNotificationsAsync: overrides.sendPushNotificationsAsync ?? vi.fn().mockResolvedValue([]),
+    isExpoPushToken: overrides.isExpoPushToken ?? vi.fn().mockReturnValue(true),
+    chunkPushNotifications: (msgs: unknown[]) => [msgs],
+  } as any;
+}
+
+describe("PushClient.sendBatch", () => {
+  it("returns empty tickets when no tokens provided", async () => {
+    const expo = makeExpoStub();
+    const client = new PushClient(expo);
+    const tickets = await client.sendBatch([], { title: "x", body: "y" });
+    expect(tickets).toEqual([]);
+    expect(expo.sendPushNotificationsAsync).not.toHaveBeenCalled();
+  });
+
+  it("calls Expo with a properly shaped message per token", async () => {
+    const sendMock = vi.fn().mockResolvedValue([{ status: "ok", id: "t1" }]);
+    const expo = makeExpoStub({ sendPushNotificationsAsync: sendMock });
+    const client = new PushClient(expo);
+    await client.sendBatch(["ExponentPushToken[a]", "ExponentPushToken[b]"], {
+      title: "T",
+      body: "B",
+    });
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const messages = sendMock.mock.calls[0]?.[0];
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ to: "ExponentPushToken[a]", title: "T", body: "B" });
+  });
+
+  it("filters out invalid tokens via isExpoPushToken", async () => {
+    const expo = makeExpoStub({
+      isExpoPushToken: vi.fn((t: string) => t.startsWith("ExponentPushToken")),
+    });
+    const client = new PushClient(expo);
+    await client.sendBatch(["ExponentPushToken[a]", "bogus"], { title: "T", body: "B" });
+    const messages = expo.sendPushNotificationsAsync.mock.calls[0]?.[0];
+    expect(messages).toHaveLength(1);
+  });
+});
+
+describe("PushClient.pruneTokensFromTickets", () => {
+  it("returns tokens whose ticket has DeviceNotRegistered detail", () => {
+    const client = new PushClient(makeExpoStub());
+    const tokens = ["ExponentPushToken[a]", "ExponentPushToken[b]"];
+    const tickets = [
+      { status: "ok", id: "t1" },
+      { status: "error", message: "x", details: { error: "DeviceNotRegistered" } },
+    ];
+    const pruned = client.pruneTokensFromTickets(tokens, tickets as any);
+    expect(pruned).toEqual(["ExponentPushToken[b]"]);
+  });
+});
+
+describe("constants", () => {
+  it("EXPO_BATCH_SIZE is 100", () => {
+    expect(EXPO_BATCH_SIZE).toBe(100);
+  });
+});

--- a/apps/server/src/features/notifications/push.client.ts
+++ b/apps/server/src/features/notifications/push.client.ts
@@ -1,0 +1,51 @@
+import type { ExpoPushMessage, ExpoPushTicket } from "expo-server-sdk";
+import type { PushPayload } from "./templates";
+
+export const EXPO_BATCH_SIZE = 100;
+
+/**
+ * Minimal Expo client interface to allow easy stubbing in tests.
+ * The real expo-server-sdk Expo class satisfies this via static + instance methods,
+ * but tests can inject a plain object with the same shape.
+ */
+interface ExpoLike {
+  sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]>;
+  isExpoPushToken(token: unknown): boolean;
+}
+
+export class PushClient {
+  constructor(private expo: ExpoLike) {}
+
+  async sendBatch(
+    tokens: string[],
+    payload: PushPayload,
+    data?: Record<string, unknown>,
+  ): Promise<ExpoPushTicket[]> {
+    if (tokens.length === 0) return [];
+
+    const valid = tokens.filter((t) => this.expo.isExpoPushToken(t));
+    if (valid.length === 0) return [];
+
+    const messages: ExpoPushMessage[] = valid.map((to) => ({
+      to,
+      title: payload.title,
+      body: payload.body,
+      data,
+      sound: "default" as const,
+    }));
+
+    return this.expo.sendPushNotificationsAsync(messages);
+  }
+
+  pruneTokensFromTickets(tokens: string[], tickets: ExpoPushTicket[]): string[] {
+    const out: string[] = [];
+    for (let i = 0; i < tickets.length; i++) {
+      const ticket = tickets[i];
+      const token = tokens[i];
+      if (ticket && ticket.status === "error" && ticket.details?.error === "DeviceNotRegistered" && token) {
+        out.push(token);
+      }
+    }
+    return out;
+  }
+}

--- a/apps/server/src/features/notifications/sweep.repository.ts
+++ b/apps/server/src/features/notifications/sweep.repository.ts
@@ -21,7 +21,9 @@ export class SweepRepository {
         )
     `);
     // pg returns { rows: [...] }; PGlite returns the array directly. Handle both.
-    const rows: Array<{ user_id: string; token: string }> = (result as any).rows ?? (result as any);
+    const rows: Array<{ user_id: string; token: string }> = Array.isArray(result)
+      ? (result as Array<{ user_id: string; token: string }>)
+      : (result as { rows: Array<{ user_id: string; token: string }> }).rows;
     return rows.map((r) => ({ userId: r.user_id, token: r.token }));
   }
 }

--- a/apps/server/src/features/notifications/sweep.repository.ts
+++ b/apps/server/src/features/notifications/sweep.repository.ts
@@ -1,0 +1,27 @@
+import { sql } from "drizzle-orm";
+import type { db } from "@pruvi/db";
+
+type DbClient = typeof db;
+
+export class SweepRepository {
+  constructor(private db: DbClient) {}
+
+  async findEligibleForStreakReminder(brtHour: number): Promise<Array<{ userId: string; token: string }>> {
+    const result = await this.db.execute(sql`
+      SELECT u.id AS user_id, pt.token AS token
+      FROM "user" u
+      JOIN "push_token" pt ON pt.user_id = u.id
+      WHERE u.streak_reminders_enabled = TRUE
+        AND u.notification_hour = ${brtHour}
+        AND NOT EXISTS (
+          SELECT 1 FROM "daily_session" ds
+          WHERE ds.user_id = u.id
+            AND ds.status = 'completed'
+            AND (ds.created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo')::date = (NOW() AT TIME ZONE 'America/Sao_Paulo')::date
+        )
+    `);
+    // pg returns { rows: [...] }; PGlite returns the array directly. Handle both.
+    const rows: Array<{ user_id: string; token: string }> = (result as any).rows ?? (result as any);
+    return rows.map((r) => ({ userId: r.user_id, token: r.token }));
+  }
+}

--- a/apps/server/src/features/notifications/templates.test.ts
+++ b/apps/server/src/features/notifications/templates.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  streakReminderPrimary,
+  streakReminderLate,
+  streakMilestone,
+  masteryAchievement,
+  type PushPayload,
+} from "./templates";
+
+describe("notification templates", () => {
+  it("streakReminderPrimary returns non-empty PT-BR payload", () => {
+    const p = streakReminderPrimary();
+    expect(p.title).toMatch(/Pruvi/);
+    expect(p.body.length).toBeGreaterThan(0);
+  });
+
+  it("streakReminderLate references risk to streak", () => {
+    const p = streakReminderLate();
+    expect(p.title.toLowerCase()).toContain("streak");
+  });
+
+  it("streakMilestone(7) and (30) produce different bodies", () => {
+    const a = streakMilestone(7);
+    const b = streakMilestone(30);
+    expect(a.title).toMatch(/7/);
+    expect(b.title).toMatch(/30/);
+    expect(a.body).not.toEqual(b.body);
+  });
+
+  it("masteryAchievement includes the subtopic name", () => {
+    const p = masteryAchievement("Membrana plasmática");
+    expect(p.body).toContain("Membrana plasmática");
+  });
+});

--- a/apps/server/src/features/notifications/templates.ts
+++ b/apps/server/src/features/notifications/templates.ts
@@ -1,0 +1,35 @@
+export type PushPayload = {
+  title: string;
+  body: string;
+};
+
+export function streakReminderPrimary(): PushPayload {
+  return {
+    title: "A Pruvi te esperou hoje 💛",
+    body: "Ainda dá tempo — 5 minutos é o suficiente.",
+  };
+}
+
+export function streakReminderLate(): PushPayload {
+  return {
+    title: "Seu streak está em risco",
+    body: "Uma sessão rápida segura o ritmo.",
+  };
+}
+
+export function streakMilestone(days: 7 | 30): PushPayload {
+  return {
+    title: `${days} dias de streak! 🔥`,
+    body:
+      days === 7
+        ? "Uma semana firme. Tá pegando o jeito."
+        : "Um mês. Isso é dedicação real.",
+  };
+}
+
+export function masteryAchievement(subtopicName: string): PushPayload {
+  return {
+    title: "Quase mestre! ⭐",
+    body: `Você está dominando ${subtopicName}.`,
+  };
+}

--- a/apps/server/src/features/notifications/tokens.repository.integration.test.ts
+++ b/apps/server/src/features/notifications/tokens.repository.integration.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { setupTestDb, getTestDb, teardownTestDb, cleanupTestDb } from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { pushToken } from "@pruvi/db/schema/push-tokens";
+import { TokensRepository } from "./tokens.repository";
+
+const db = getTestDb();
+const repo = new TokensRepository(db);
+
+const USER_A = "user_tokens_a";
+const USER_B = "user_tokens_b";
+
+beforeAll(async () => {
+  await setupTestDb();
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  await cleanupTestDb();
+  await db.insert(user).values([
+    { id: USER_A, name: "A", email: `${USER_A}@x.com` },
+    { id: USER_B, name: "B", email: `${USER_B}@x.com` },
+  ]);
+});
+
+describe("TokensRepository.upsert", () => {
+  it("inserts a new token for a user", async () => {
+    const row = await repo.upsert(USER_A, "ExponentPushToken[a]", "ios");
+    expect(row.userId).toBe(USER_A);
+    expect(row.token).toBe("ExponentPushToken[a]");
+    expect(row.platform).toBe("ios");
+  });
+
+  it("re-registering the same token under a different user reassigns it (no duplicates)", async () => {
+    await repo.upsert(USER_A, "ExponentPushToken[shared]", "ios");
+    const second = await repo.upsert(USER_B, "ExponentPushToken[shared]", "ios");
+    expect(second.userId).toBe(USER_B);
+    const rows = await db.select().from(pushToken).where(eq(pushToken.token, "ExponentPushToken[shared]"));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("listByUser returns only that user's tokens", async () => {
+    await repo.upsert(USER_A, "ExponentPushToken[a1]", "ios");
+    await repo.upsert(USER_A, "ExponentPushToken[a2]", "android");
+    await repo.upsert(USER_B, "ExponentPushToken[b1]", "ios");
+    const rows = await repo.listByUser(USER_A);
+    expect(rows.map((r) => r.token).sort()).toEqual(["ExponentPushToken[a1]", "ExponentPushToken[a2]"]);
+  });
+
+  it("deleteForUser removes only when owned by that user", async () => {
+    await repo.upsert(USER_A, "ExponentPushToken[a]", "ios");
+    await repo.upsert(USER_B, "ExponentPushToken[b]", "ios");
+    await repo.deleteForUser(USER_A, "ExponentPushToken[b]");
+    const bRows = await db.select().from(pushToken).where(eq(pushToken.token, "ExponentPushToken[b]"));
+    expect(bRows).toHaveLength(1);
+
+    await repo.deleteForUser(USER_A, "ExponentPushToken[a]");
+    const aRows = await db.select().from(pushToken).where(eq(pushToken.token, "ExponentPushToken[a]"));
+    expect(aRows).toHaveLength(0);
+  });
+
+  it("deleteTokens removes a set of tokens regardless of owner (receipt pruning)", async () => {
+    await repo.upsert(USER_A, "ExponentPushToken[x]", "ios");
+    await repo.upsert(USER_B, "ExponentPushToken[y]", "ios");
+    await repo.deleteTokens(["ExponentPushToken[x]", "ExponentPushToken[y]"]);
+    const rows = await db.select().from(pushToken);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/apps/server/src/features/notifications/tokens.repository.ts
+++ b/apps/server/src/features/notifications/tokens.repository.ts
@@ -1,0 +1,39 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { pushToken } from "@pruvi/db/schema/push-tokens";
+import type { db } from "@pruvi/db";
+
+type DbClient = typeof db;
+
+export class TokensRepository {
+  constructor(private db: DbClient) {}
+
+  async upsert(userId: string, token: string, platform: "ios" | "android") {
+    const [row] = await this.db
+      .insert(pushToken)
+      .values({ userId, token, platform })
+      .onConflictDoUpdate({
+        target: pushToken.token,
+        set: { userId, platform, lastUsedAt: new Date() },
+      })
+      .returning();
+    return row;
+  }
+
+  async listByUser(userId: string) {
+    return this.db
+      .select()
+      .from(pushToken)
+      .where(eq(pushToken.userId, userId));
+  }
+
+  async deleteForUser(userId: string, token: string) {
+    await this.db
+      .delete(pushToken)
+      .where(and(eq(pushToken.userId, userId), eq(pushToken.token, token)));
+  }
+
+  async deleteTokens(tokens: string[]) {
+    if (tokens.length === 0) return;
+    await this.db.delete(pushToken).where(inArray(pushToken.token, tokens));
+  }
+}

--- a/apps/server/src/features/notifications/tokens.route.ts
+++ b/apps/server/src/features/notifications/tokens.route.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { RegisterPushTokenBodySchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { unwrapResult } from "../../types";
+import { TokensRepository } from "./tokens.repository";
+import { TokensService } from "./tokens.service";
+
+const repo = new TokensRepository(db);
+const service = new TokensService(repo);
+
+export const tokensRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.post(
+    "/users/me/push-tokens",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { body: RegisterPushTokenBodySchema },
+    },
+    async (request) => {
+      const { token, platform } = request.body;
+      const result = await service.register(request.userId, token, platform);
+      return unwrapResult(result);
+    },
+  );
+
+  fastify.delete(
+    "/users/me/push-tokens/:token",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { params: z.object({ token: z.string() }) },
+    },
+    async (request, reply) => {
+      const { token } = request.params;
+      await service.unregister(request.userId, token);
+      reply.status(204).send();
+    },
+  );
+};

--- a/apps/server/src/features/notifications/tokens.service.test.ts
+++ b/apps/server/src/features/notifications/tokens.service.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { TokensService } from "./tokens.service";
+
+function stubRepo(overrides: any = {}) {
+  return {
+    upsert: vi.fn().mockResolvedValue({ id: 1, token: "t", platform: "ios", userId: "u", lastUsedAt: new Date(), createdAt: new Date() }),
+    deleteForUser: vi.fn().mockResolvedValue(undefined),
+    listByUser: vi.fn().mockResolvedValue([]),
+    deleteTokens: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("TokensService.register", () => {
+  it("returns the upserted row data on success", async () => {
+    const repo = stubRepo();
+    const service = new TokensService(repo as any);
+    const result = await service.register("u", "ExponentPushToken[a]", "ios");
+    expect(result.isOk()).toBe(true);
+    expect(repo.upsert).toHaveBeenCalledWith("u", "ExponentPushToken[a]", "ios");
+  });
+});
+
+describe("TokensService.unregister", () => {
+  it("calls deleteForUser and returns ok regardless", async () => {
+    const repo = stubRepo();
+    const service = new TokensService(repo as any);
+    const result = await service.unregister("u", "ExponentPushToken[a]");
+    expect(result.isOk()).toBe(true);
+    expect(repo.deleteForUser).toHaveBeenCalledWith("u", "ExponentPushToken[a]");
+  });
+});
+
+describe("TokensService.listTokensForUser", () => {
+  it("returns just the token strings", async () => {
+    const repo = stubRepo({
+      listByUser: vi.fn().mockResolvedValue([
+        { id: 1, token: "ExponentPushToken[a]", platform: "ios" },
+        { id: 2, token: "ExponentPushToken[b]", platform: "android" },
+      ]),
+    });
+    const service = new TokensService(repo as any);
+    const tokens = await service.listTokensForUser("u");
+    expect(tokens).toEqual(["ExponentPushToken[a]", "ExponentPushToken[b]"]);
+  });
+});

--- a/apps/server/src/features/notifications/tokens.service.ts
+++ b/apps/server/src/features/notifications/tokens.service.ts
@@ -1,4 +1,4 @@
-import { ok, type Result } from "neverthrow";
+import { err, ok, type Result } from "neverthrow";
 import { AppError } from "../../utils/errors";
 import type { TokensRepository } from "./tokens.repository";
 
@@ -12,7 +12,7 @@ export class TokensService {
   ): Promise<Result<{ id: number; token: string; platform: "ios" | "android" }, AppError>> {
     const row = await this.repo.upsert(userId, token, platform);
     if (!row) {
-      throw new AppError("Failed to upsert push token", 500, "UPSERT_FAILED");
+      return err(new AppError("Failed to upsert push token", 500, "UPSERT_FAILED"));
     }
     return ok({ id: row.id, token: row.token, platform: row.platform });
   }

--- a/apps/server/src/features/notifications/tokens.service.ts
+++ b/apps/server/src/features/notifications/tokens.service.ts
@@ -1,0 +1,29 @@
+import { ok, type Result } from "neverthrow";
+import { AppError } from "../../utils/errors";
+import type { TokensRepository } from "./tokens.repository";
+
+export class TokensService {
+  constructor(private repo: TokensRepository) {}
+
+  async register(
+    userId: string,
+    token: string,
+    platform: "ios" | "android",
+  ): Promise<Result<{ id: number; token: string; platform: "ios" | "android" }, AppError>> {
+    const row = await this.repo.upsert(userId, token, platform);
+    if (!row) {
+      throw new AppError("Failed to upsert push token", 500, "UPSERT_FAILED");
+    }
+    return ok({ id: row.id, token: row.token, platform: row.platform });
+  }
+
+  async unregister(userId: string, token: string): Promise<Result<null, AppError>> {
+    await this.repo.deleteForUser(userId, token);
+    return ok(null);
+  }
+
+  async listTokensForUser(userId: string): Promise<string[]> {
+    const rows = await this.repo.listByUser(userId);
+    return rows.map((r) => r.token);
+  }
+}

--- a/apps/server/src/features/sessions/sessions.route.ts
+++ b/apps/server/src/features/sessions/sessions.route.ts
@@ -7,19 +7,45 @@ import { QuestionsRepository } from "../questions/questions.repository";
 import { QuestionsService } from "../questions/questions.service";
 import { TopicsRepository } from "../topics/topics.repository";
 import { TopicsService } from "../topics/topics.service";
+import { TokensRepository } from "../notifications/tokens.repository";
+import { TokensService } from "../notifications/tokens.service";
+import { PreferencesRepository } from "../notifications/preferences.repository";
+import { SweepRepository } from "../notifications/sweep.repository";
+import { Dispatcher } from "../notifications/dispatcher";
+import { StreaksRepository } from "../streaks/streaks.repository";
+import { StreaksService } from "../streaks/streaks.service";
 import { db } from "@pruvi/db";
 import { successResponse, unwrapResult } from "../../types";
-
-const sessionsRepo = new SessionsRepository(db);
-const questionsRepo = new QuestionsRepository(db);
-const questionsService = new QuestionsService(questionsRepo);
-const topicsRepo = new TopicsRepository(db);
-const topicsService = new TopicsService(topicsRepo);
-const service = new SessionsService(sessionsRepo, questionsService, topicsService);
 
 const SESSION_CACHE_TTL = 30; // 30 seconds
 
 export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const sessionsRepo = new SessionsRepository(db);
+  const questionsRepo = new QuestionsRepository(db);
+  const questionsService = new QuestionsService(questionsRepo);
+  const topicsRepo = new TopicsRepository(db);
+  const topicsService = new TopicsService(topicsRepo);
+  const tokensRepo = new TokensRepository(db);
+  const tokensService = new TokensService(tokensRepo);
+  const prefsRepo = new PreferencesRepository(db);
+  const sweepRepo = new SweepRepository(db);
+  const streaksRepo = new StreaksRepository(db);
+  const streaksService = new StreaksService(streaksRepo);
+  const dispatcher = fastify.queues.notificationsSend
+    ? new Dispatcher({
+        tokensService,
+        prefsRepo,
+        sweepRepo,
+        sendQueue: fastify.queues.notificationsSend,
+      })
+    : null;
+  const service = new SessionsService(
+    sessionsRepo,
+    questionsService,
+    topicsService,
+    streaksService,
+    dispatcher,
+  );
   // POST /sessions/start
   fastify.post(
     "/sessions/start",

--- a/apps/server/src/features/sessions/sessions.service.ts
+++ b/apps/server/src/features/sessions/sessions.service.ts
@@ -4,6 +4,8 @@ import { NotFoundError, ValidationError } from "../../utils/errors";
 import type { SessionsRepository } from "./sessions.repository";
 import type { QuestionsService } from "../questions/questions.service";
 import type { TopicsService } from "../topics/topics.service";
+import type { Dispatcher } from "../notifications/dispatcher";
+import type { StreaksService } from "../streaks/streaks.service";
 
 type SessionRow = NonNullable<Awaited<ReturnType<SessionsRepository["findTodaySession"]>>>;
 type QuestionItem = { id: number; subtopicId: number; [key: string]: unknown };
@@ -13,6 +15,8 @@ export class SessionsService {
     private repo: SessionsRepository,
     private questionsService: QuestionsService,
     private topicsService: TopicsService,
+    private streaksService: StreaksService | null = null,
+    private dispatcher: Dispatcher | null = null,
   ) {}
 
   /** Start or resume today's session */
@@ -144,6 +148,31 @@ export class SessionsService {
     }
 
     const completed = await this.repo.completeSession(sessionId, questionsAnswered, questionsCorrect);
+
+    // Fire-and-forget achievement notifications
+    if (this.dispatcher) {
+      if (this.streaksService) {
+        this.streaksService
+          .getStreaks(userId)
+          .then((r) => {
+            if (r.isOk() && (r.value.currentStreak === 7 || r.value.currentStreak === 30)) {
+              const kind = `${r.value.currentStreak}-day-streak` as "7-day-streak" | "30-day-streak";
+              this.dispatcher!
+                .sendAchievementNotification(userId, kind)
+                .catch((e) => console.error("streak achievement push failed", e));
+            }
+          })
+          .catch((e) => console.error("streak read failed in achievement hook", e));
+      }
+      for (const t of transitions) {
+        if (t.to === "quase_mestre") {
+          this.dispatcher
+            .sendAchievementNotification(userId, "quase-mestre", { subtopicName: t.name })
+            .catch((e) => console.error("mastery achievement push failed", e));
+        }
+      }
+    }
+
     return ok({ session: completed, transitions });
   }
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import {
   validatorCompiler,
 } from "fastify-type-provider-zod";
 import { gamificationRoutes } from "./features/gamification";
+import { tokensRoutes } from "./features/notifications";
 import { livesRoutes } from "./features/lives";
 import { onboardingRoutes } from "./features/onboarding";
 import { progressRoutes } from "./features/progress";
@@ -77,6 +78,7 @@ export async function buildApp() {
   await app.register(progressRoutes);
   await app.register(subjectsRoutes);
   await app.register(topicsRoutes);
+  await app.register(tokensRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,7 +9,7 @@ import {
   validatorCompiler,
 } from "fastify-type-provider-zod";
 import { gamificationRoutes } from "./features/gamification";
-import { tokensRoutes } from "./features/notifications";
+import { tokensRoutes, preferencesRoutes } from "./features/notifications";
 import { livesRoutes } from "./features/lives";
 import { onboardingRoutes } from "./features/onboarding";
 import { progressRoutes } from "./features/progress";
@@ -79,6 +79,7 @@ export async function buildApp() {
   await app.register(subjectsRoutes);
   await app.register(topicsRoutes);
   await app.register(tokensRoutes);
+  await app.register(preferencesRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/apps/server/src/plugins/queue.ts
+++ b/apps/server/src/plugins/queue.ts
@@ -3,11 +3,14 @@ import fp from "fastify-plugin";
 import { Queue } from "bullmq";
 import { env } from "@pruvi/env/server";
 import { parseRedisUrl } from "../utils/redis";
+import type { SendJobData } from "../features/notifications/dispatcher";
 
 declare module "fastify" {
   interface FastifyInstance {
     queues: {
       sessionPrefetch: Queue | null;
+      notificationsCron: Queue | null;
+      notificationsSend: Queue<SendJobData> | null;
     };
   }
 }
@@ -17,26 +20,44 @@ export type SessionPrefetchJobData = {
   mode: "all" | "theoretical";
 };
 
+export type NotificationsCronJobData = { kind: "sweep" };
+
 const plugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
   if (!env.REDIS_URL) {
     fastify.log.info("No REDIS_URL — BullMQ queues disabled");
-    fastify.decorate("queues", { sessionPrefetch: null });
+    fastify.decorate("queues", {
+      sessionPrefetch: null,
+      notificationsCron: null,
+      notificationsSend: null,
+    });
     return;
   }
 
   const connection = parseRedisUrl(env.REDIS_URL);
 
-  const sessionPrefetchQueue = new Queue<SessionPrefetchJobData>(
-    "session-prefetch",
-    { connection }
+  const sessionPrefetchQueue = new Queue<SessionPrefetchJobData>("session-prefetch", { connection });
+  const notificationsCronQueue = new Queue<NotificationsCronJobData>("notifications-cron", { connection });
+  const notificationsSendQueue = new Queue<SendJobData>("notifications-send", { connection });
+
+  // Hourly cron — BullMQ dedupes repeatable jobs by name + pattern, so re-registration on boot is idempotent
+  await notificationsCronQueue.add(
+    "sweep",
+    { kind: "sweep" },
+    { repeat: { pattern: "0 * * * *" }, removeOnComplete: true, removeOnFail: true },
   );
 
   fastify.decorate("queues", {
     sessionPrefetch: sessionPrefetchQueue,
+    notificationsCron: notificationsCronQueue,
+    notificationsSend: notificationsSendQueue,
   });
 
   fastify.addHook("onClose", async () => {
-    await sessionPrefetchQueue.close();
+    await Promise.all([
+      sessionPrefetchQueue.close(),
+      notificationsCronQueue.close(),
+      notificationsSendQueue.close(),
+    ]);
   });
 };
 

--- a/apps/server/src/test/db-helpers.ts
+++ b/apps/server/src/test/db-helpers.ts
@@ -63,7 +63,7 @@ export async function setupTestDb() {
 export async function cleanupTestDb() {
   const db = getTestDb();
   await db.execute(sql`
-    TRUNCATE TABLE review_log, daily_session, question, subtopic, topic, subject,
+    TRUNCATE TABLE push_token, review_log, daily_session, question, subtopic, topic, subject,
       account, session, verification, "user" CASCADE
   `);
 }

--- a/apps/server/src/worker.ts
+++ b/apps/server/src/worker.ts
@@ -1,18 +1,23 @@
 import { startSessionPrefetchWorker } from "./workers/session-prefetch.worker";
+import { startNotificationsWorker } from "./workers/notifications.worker";
 
-const worker = startSessionPrefetchWorker();
+const prefetch = startSessionPrefetchWorker();
+const notifications = startNotificationsWorker();
 
-if (!worker) {
-  console.error("Worker failed to start — REDIS_URL required");
+if (!prefetch && !notifications) {
+  console.error("All workers failed to start — REDIS_URL required");
   process.exit(1);
 }
 
-console.log("Session prefetch worker started");
+console.log("Workers started:", {
+  prefetch: !!prefetch,
+  notifications: !!notifications,
+});
 
-// Graceful shutdown
 const shutdown = async () => {
-  console.log("Shutting down worker...");
-  await worker.cleanup();
+  console.log("Shutting down workers...");
+  if (prefetch) await prefetch.cleanup();
+  if (notifications) await notifications.cleanup();
   process.exit(0);
 };
 

--- a/apps/server/src/workers/notifications.worker.ts
+++ b/apps/server/src/workers/notifications.worker.ts
@@ -1,0 +1,73 @@
+import { Worker, Queue, type Job } from "bullmq";
+import { Expo } from "expo-server-sdk";
+import { env } from "@pruvi/env/server";
+import { db } from "@pruvi/db";
+import { parseRedisUrl } from "../utils/redis";
+import { TokensRepository } from "../features/notifications/tokens.repository";
+import { TokensService } from "../features/notifications/tokens.service";
+import { PreferencesRepository } from "../features/notifications/preferences.repository";
+import { SweepRepository } from "../features/notifications/sweep.repository";
+import { Dispatcher, type SendJobData } from "../features/notifications/dispatcher";
+import { PushClient } from "../features/notifications/push.client";
+
+export function startNotificationsWorker() {
+  if (!env.REDIS_URL) {
+    console.log("No REDIS_URL — notifications worker disabled");
+    return null;
+  }
+
+  const connection = parseRedisUrl(env.REDIS_URL);
+
+  const tokensRepo = new TokensRepository(db);
+  const prefsRepo = new PreferencesRepository(db);
+  const sweepRepo = new SweepRepository(db);
+  const tokensService = new TokensService(tokensRepo);
+  const sendQueue = new Queue<SendJobData>("notifications-send", { connection });
+  const dispatcher = new Dispatcher({ tokensService, prefsRepo, sweepRepo, sendQueue });
+
+  const expoInstance = new Expo(
+    env.EXPO_ACCESS_TOKEN ? { accessToken: env.EXPO_ACCESS_TOKEN } : {},
+  );
+  // Expo.isExpoPushToken is a static method; adapt to ExpoLike interface shape
+  const expoAdapter = {
+    sendPushNotificationsAsync: (msgs: Parameters<typeof expoInstance.sendPushNotificationsAsync>[0]) =>
+      expoInstance.sendPushNotificationsAsync(msgs),
+    isExpoPushToken: (token: unknown) => Expo.isExpoPushToken(token),
+  };
+  const pushClient = new PushClient(expoAdapter);
+
+  const cronWorker = new Worker(
+    "notifications-cron",
+    async (_job: Job<{ kind: "sweep" }>) => {
+      const utcHour = new Date().getUTCHours();
+      const brtHour = (utcHour + 24 - 3) % 24;
+      await dispatcher.dispatchStreakReminder({ brtHour, variant: "primary" });
+      await dispatcher.dispatchStreakReminder({ brtHour, variant: "late" });
+      return { brtHour };
+    },
+    { connection, concurrency: 1 },
+  );
+
+  const sendWorker = new Worker<SendJobData>(
+    "notifications-send",
+    async (job: Job<SendJobData>) => {
+      const { tokens, title, body, data } = job.data;
+      const tickets = await pushClient.sendBatch(tokens, { title, body }, data);
+      const pruned = pushClient.pruneTokensFromTickets(tokens, tickets);
+      if (pruned.length > 0) {
+        await tokensRepo.deleteTokens(pruned);
+      }
+      return { sent: tokens.length, pruned: pruned.length };
+    },
+    { connection, concurrency: 5 },
+  );
+
+  cronWorker.on("failed", (job, err) => console.error("cron job failed:", job?.id, err));
+  sendWorker.on("failed", (job, err) => console.error("send job failed:", job?.id, err));
+
+  const cleanup = async () => {
+    await Promise.all([cronWorker.close(), sendWorker.close(), sendQueue.close()]);
+  };
+
+  return { cleanup };
+}

--- a/docs/superpowers/handoff-2026-05-11.md
+++ b/docs/superpowers/handoff-2026-05-11.md
@@ -1,0 +1,200 @@
+# Session Handoff — 2026-05-11
+
+> Backend-only buildout. Frontend is being rebuilt separately and is NOT in scope. Continuation point for the next session — reads cold.
+
+---
+
+## TL;DR
+
+**Today landed Phase 2A (topic system) and Phase 2B (push notifications) as two stacked PRs.**
+
+| PR | Branch | Phase | State |
+|---|---|---|---|
+| [#15](https://github.com/CeCamillo/pruvi/pull/15) | `feature/phase-2a-topic-system` | 2A | Open, awaiting review |
+| [#16](https://github.com/CeCamillo/pruvi/pull/16) | `feature/phase-2b-push-notifications` | 2B | Open, stacked on #15 |
+
+Neither has merged yet. Local DB has both migrations applied. PR #15 should merge before PR #16. After both land, the next session can branch from `main` for Phase 2C.
+
+**Test posture:** 107 unit / 36 integration / `verify:migration` clean / both workers boot clean.
+
+---
+
+## What's on each branch
+
+### PR #15 — Phase 2A (topic system)
+
+**Schema (migration `0003_glamorous_nova.sql`)**
+- New tables: `topic`, `subtopic` (hierarchical: subject → topic → subtopic)
+- `question.subtopic_id` NOT NULL FK (Geral subtopic backfilled per subject for the existing 111 questions)
+- `daily_session.mastery_snapshot` jsonb (captured at session start)
+
+**Shared schemas (`@pruvi/shared`)**
+- `MasteryState` enum (Zod-derived single source of truth): `aprendendo | entendendo | afiado | quase_mestre`
+- `computeMastery(efAvg, reviewCount): MasteryState` — pure SM-2 EF averaging with sample-size gates (5 / 8 / 12 reviews to leave aprendendo, reach afiado, reach quase_mestre respectively)
+- `StartSessionBodySchema` extended with optional `topicId`
+
+**API**
+- `GET /subjects/:subjectId/trilha` — nested tree with mastery state per subtopic
+- `GET /topics/:topicId` — drill-in detail
+- `GET /users/me/mastery?subjectId=` — flat list of all subtopic mastery
+- `POST /sessions/start` extended: `{ mode, topicId? }` filters questions by subtopic + snapshots mastery
+- `POST /sessions/:id/complete` extended: returns `transitions: []` (upward only, end-of-session)
+- `POST /questions/:id/answer` extended: invalidates `mastery:*`, `trilha:*`, `topic:*` caches
+
+**Demo seed:** `pnpm seed:demo-topics` creates Citologia + 3 real subtopics under Biology, reassigns 6 questions from Geral. Idempotent.
+
+### PR #16 — Phase 2B (push notifications, stacked on #15)
+
+**Schema (migration `0004_tense_jack_power.sql`)**
+- New `push_token` table (per device; UNIQUE on token; ON DELETE CASCADE on user_id; CHECK on platform)
+- 3 user columns: `notification_hour` (default 19, CHECK 0–23), `streak_reminders_enabled`, `achievement_notifications_enabled`
+
+**API**
+- `POST /users/me/push-tokens` — upsert by token (handles user-switching on shared devices)
+- `DELETE /users/me/push-tokens/:token` — scoped, silent 204
+- `GET /users/me/notification-preferences` — cached `prefs:notif:{userId}` 60s
+- `PUT /users/me/notification-preferences` — partial update; empty body rejected
+
+**Scheduling**
+- BullMQ `notifications-cron` queue with repeatable job `0 * * * *` UTC
+- Cron handler computes BRT hour = `(utcHour + 24 - 3) % 24`, calls dispatcher for primary + late (`hour - 2`) variants
+- Eligibility query: streak reminders enabled + hour matches + no completed session today (BRT day boundary via double `AT TIME ZONE`)
+- Send jobs chunked at 100 (Expo batch limit), invalid tokens pruned from `DeviceNotRegistered` tickets
+
+**Achievement hooks (fire-and-forget in `sessions.completeSession`)**
+- 7d / 30d streak milestones via `streaksService.getStreaks`
+- "Quase mestre" mastery via the existing transition array
+
+**Worker:** `notifications.worker.ts` runs alongside `session-prefetch.worker.ts` in the same `PROCESS_TYPE=worker` process.
+
+**Templates:** PT-BR strings in `apps/server/src/features/notifications/templates.ts` — Pruvi voice, no spam, achievement-positive.
+
+---
+
+## How the session ran
+
+Established workflow this session, codified for future:
+
+1. **Branch-per-phase, stacked PRs**. Each phase gets its own spec doc → plan doc → feature branch → PR.
+2. **Subagent-driven development with per-task spec + quality reviews.** Memory file `feedback_never_skip_reviews.md` enforces this — never skip reviews, even for trivial mechanical tasks. Reviews are parallelizable (read-only) but implementers are serial.
+3. **Real findings caught mid-flight by reviewers** (not deferred): missing platform CHECK constraint, empty-body PUT crash, brittle result-shape cast, throw-vs-`return err()` inconsistency.
+4. **PGlite DDL in `packages/db/src/test-client.ts` is hand-maintained** — must mirror every Drizzle schema change in lockstep.
+
+---
+
+## Open follow-ups (carry-over)
+
+### Phase 2A
+- **Prefetch fast-path skips mastery snapshot.** When `POST /sessions/start` hits the prefetch cache (`skipQuestions=true`), `mastery_snapshot` is never written, so `POST /sessions/:id/complete` returns `transitions: []` even when the user crossed thresholds. Plan permitted this; spec-divergence call-out for next pass. Fix options: snapshot at complete instead of start; or run the snapshot inside the prefetch worker.
+
+### Phase 2B
+- **No async receipt polling.** `pruneTokensFromTickets` only handles errors that appear in the immediate ticket response. The full receipts API (24h delayed status) is unused. Acceptable until delivery volume is real.
+- **Streak reminders use compute-on-read.** Hook lives in `sessions.completeSession`, not `streaksService` (which has no `updateStreak` — streaks are computed-on-read from `daily_session.created_at` dates). This is correct given the codebase but spec wording was imprecise.
+
+### Cross-cutting / known tech debt
+- **Pre-existing `packages/shared/src/sm2.test.ts` failures** — stale test file out of sync with implementation. Not blocking but should be cleaned up.
+- **Migration 0003 (Phase 2A) lacks pre-`SET NOT NULL` assertion guard.** Defensive concern flagged by code review; cannot retroactively edit (drizzle-kit checksum). Worth a follow-up "verification migration" before production rollout if `question` table grows.
+- **`questions.repository.integration.test.ts` and a few others** retain pre-existing typecheck noise (`TS18048` and friends). Not blocking. Sweep candidate for a tech-debt phase.
+
+---
+
+## Phase 2 progress
+
+| Sub-phase | Description | Status |
+|---|---|---|
+| 2A | Topic system | ✅ Done — PR #15 open |
+| 2B | Push notifications | ✅ Done — PR #16 open (stacked on #15) |
+| 2C | Lives mechanic redesign + DB CHECK constraints | ⏳ Pending |
+| 2D | Social / friends ranking | ⏳ Pending |
+| 2E+ | Ultra / monetization (subscription, simulado, lives purchase, streak shield) | ⏳ Pending (defer until retention is validated) |
+
+### Phase 2C — what it needs (from backend audit + CodeRabbit deferred items)
+- Switch lives refill from 24h reset to 1-per-4h (spec 3.5)
+- Atomic-decrement to fix race (current implementation has TOCTOU on `lives` column)
+- DB CHECK constraints: `lives >= 0`, `lives <= 5` (Ultra unlimited handled separately), `total_xp >= 0`, `current_level >= 1`
+- Probably smallest of remaining sub-phases — clears multiple deferred items in one pass
+
+### Phase 2D — what it needs
+- `friendship` table (bi-directional via two rows or pair-ordered single row)
+- `friend_invitation` flow for spec 4.2
+- Weekly XP rollup table or query (decide: materialized vs on-read)
+- `GET /users/me/friends/ranking` returning weekly XP sorted
+
+---
+
+## Open product / infra questions for next session
+
+Carried forward from prior handoffs, still unresolved:
+- Apple Developer credentials — when available? `auth/src/index.ts` registers Apple provider conditionally; the build is clean without keys but the iOS launch will need them.
+- Resend sending domain verified? Placeholder values are in `apps/server/.env`.
+- GCP OAuth redirect URI must match `${BETTER_AUTH_URL}/api/auth/callback/google`.
+- Content team on question explanation backfill (Phase 1B left renderers null-safe).
+- For Phase 2B: when do we get a real Expo push project + access token to test sends against a physical device?
+
+---
+
+## Reference paths
+
+### Today's design specs + plans
+- `docs/superpowers/specs/2026-05-10-phase-2a-topic-system-design.md`
+- `docs/superpowers/plans/2026-05-10-phase-2a-topic-system.md`
+- `docs/superpowers/specs/2026-05-10-phase-2b-push-notifications-design.md`
+- `docs/superpowers/plans/2026-05-10-phase-2b-push-notifications.md`
+
+### Earlier handoffs
+- `docs/superpowers/handoff-2026-05-10.md` — covers Phase 0 / 1A / 1B / 1C
+
+### Standing reference docs
+- `docs/backend-audit-main.md` — feature-by-feature audit against `pruvi-freatures.md`
+- `pruvi-freatures.md` — product spec (22 features, 6 modules)
+
+### Key code paths
+- Auth: `packages/auth/src/index.ts`
+- Env: `packages/env/src/server.ts`
+- DB schemas: `packages/db/src/schema/`
+- PGlite mirror: `packages/db/src/test-client.ts` (must stay in lockstep)
+- Latest migrations: `packages/db/src/migrations/0003_glamorous_nova.sql` (2A) and `0004_tense_jack_power.sql` (2B)
+- Server entry: `apps/server/src/index.ts`
+- Worker entry: `apps/server/src/worker.ts` (now starts both prefetch + notifications workers)
+- Canonical feature pattern: `apps/server/src/features/onboarding/`
+- Topics module (2A): `apps/server/src/features/topics/`
+- Notifications module (2B): `apps/server/src/features/notifications/`
+
+### Memory files (`~/.claude/projects/-Users-cesarcamillo-dev-pruvi/memory/`)
+- `feedback_never_skip_reviews.md` — never skip per-task spec + quality reviews in subagent-driven workflow
+
+---
+
+## Running things locally
+
+```bash
+pnpm install
+docker compose -f packages/db/docker-compose.yml up -d   # via pnpm db:start
+pnpm verify:migration
+
+pnpm --filter server test                  # 107 unit
+pnpm --filter server test:integration      # 36 integration
+pnpm run check-types
+
+pnpm dev:server                            # http server
+pnpm dev:worker                            # bullmq workers (prefetch + notifications)
+
+pnpm seed:demo-topics                      # idempotent — Citologia + 3 subtopics
+```
+
+`apps/server/.env` requires: `DATABASE_URL`, `BETTER_AUTH_SECRET` (32+), `BETTER_AUTH_URL`, `CORS_ORIGIN`, `REDIS_URL`, `PORT`, `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`. Optional: `APPLE_*` (3 vars all-or-nothing), `EXPO_ACCESS_TOKEN`.
+
+---
+
+## Resuming after `/compact`
+
+Pick up at one of:
+1. **Merge PR #15 → merge PR #16 → start Phase 2C brainstorm** (lives mechanic). Smallest remaining sub-phase.
+2. **Address Phase 2A's prefetch-snapshot gap** before starting 2C — cheap fix, removes a known correctness wart.
+3. **Tech-debt sweep** — sm2.test.ts cleanup + the typecheck noise in integration test files.
+
+Recommended: option 1. Phase 2C is the cheapest unlock and ties up loose CodeRabbit-flagged items.
+
+---
+
+*End of handoff.*

--- a/docs/superpowers/plans/2026-04-30-auth-ux-completion.md
+++ b/docs/superpowers/plans/2026-04-30-auth-ux-completion.md
@@ -1,0 +1,858 @@
+# Auth UX Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Better-Auth's existing sign-in/sign-up reachable through a hardened, testable auth gate, wire logout, and stop the server URL env var from being silently optional.
+
+**Architecture:** Single `AuthGate` at `app/_layout.tsx` reads session + onboarding-completion signals and routes to `(auth)`, `(onboarding)`, or `(app)`. The redirect logic is extracted as a pure function (`getAuthRedirectTarget`) to make all 9 routing rules unit-testable. Error-code → Portuguese mapping lives in `lib/auth-errors.ts`. Logout uses a confirmation alert + `authClient.signOut()` + `queryClient.clear()`; the `AuthGate` handles redirection automatically.
+
+**Tech Stack:** Expo Router v4, Better-Auth + Better-Auth Expo plugin, TanStack Query v5, react-hook-form + zod, `bun:test` for unit tests, `@t3-oss/env-core` for env validation.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-auth-ux-completion-design.md`
+
+---
+
+## File Structure
+
+**New files (`apps/native/`):**
+
+| Path | Responsibility |
+|------|----------------|
+| `lib/auth-redirect.ts` | Pure function `getAuthRedirectTarget(session, prefs, segments) → AuthRedirectResult`. The 9-row redirect table. |
+| `lib/__tests__/auth-redirect.test.ts` | Unit tests for every row of the redirect table. |
+| `lib/auth-errors.ts` | `getAuthErrorMessage(error: unknown): string`. Maps Better-Auth error codes to Portuguese copy. |
+| `lib/__tests__/auth-errors.test.ts` | Unit tests for known error codes + fallback. |
+| `lib/ui/confirm.ts` | `confirmDestructiveAction(title: string, message?: string): Promise<boolean>`. Wraps `Alert.alert`. |
+| `lib/__tests__/confirm.test.ts` | Unit tests by mocking `Alert.alert`. |
+
+**Modified files (`apps/native/`):**
+
+| Path | Change |
+|------|--------|
+| `app/_layout.tsx` | `AuthGate` switches from inline branches to `getAuthRedirectTarget`. |
+| `app/(auth)/login.tsx` | Replace inline error string with `getAuthErrorMessage`. |
+| `app/(auth)/register.tsx` | Same. |
+| `app/(app)/(tabs)/profile.tsx` | Add interim "Sair" button (later moves to `mais.tsx` when drawer UI ports). |
+
+**Modified file (`packages/env/`):**
+
+| Path | Change |
+|------|--------|
+| `packages/env/src/native.ts` | `EXPO_PUBLIC_SERVER_URL` from `.optional()` to required `z.url()`. |
+| `packages/env/src/__tests__/native.test.ts` | New: assert schema rejects missing/empty URL. |
+
+**No backend changes.** Sub-project #1 is FE-only.
+
+---
+
+## Branch Strategy
+
+This plan assumes work happens on a **new branch off `feature/phase4-progress-subject`**, not the current `feature/onboarding-screens`. Phase4 has the working backend, the auth scaffolding (~80% of this spec), and the SM-2 + sessions wiring; the merged-UI branch lacks all of that. The mocked drawer UI from `feature/onboarding-screens` will be ported in a later sub-project — it's not needed to land auth completion.
+
+The Sair button lives on `profile.tsx` for now; when the drawer/`mais.tsx` UI is ported, the handler moves there.
+
+---
+
+## Task 0: Branch Reconciliation
+
+**Goal:** Establish `feature/auth-ux-completion` from `feature/phase4-progress-subject` and verify the baseline runs.
+
+**Files:** None (pure git + verification).
+
+- [ ] **Step 1: Confirm clean working tree on the current branch**
+
+```bash
+git status
+```
+Expected: `nothing to commit, working tree clean` (the design spec is already committed).
+
+- [ ] **Step 2: Switch to phase4 and pull latest**
+
+```bash
+git checkout feature/phase4-progress-subject
+git pull --ff-only origin feature/phase4-progress-subject
+```
+Expected: `Already up to date.` or fast-forward output.
+
+- [ ] **Step 3: Create the feature branch**
+
+```bash
+git checkout -b feature/auth-ux-completion
+```
+Expected: `Switched to a new branch 'feature/auth-ux-completion'`.
+
+- [ ] **Step 4: Cherry-pick the design + plan docs from `feature/onboarding-screens`**
+
+```bash
+git cherry-pick 0743d08
+```
+Expected: `[feature/auth-ux-completion <sha>] docs: auth ux completion design spec (Tier 1 #1)`.
+
+(After implementing, the plan doc itself will be committed in Task 6.)
+
+- [ ] **Step 5: Verify backend tests pass on the baseline**
+
+```bash
+cd apps/server && pnpm test
+```
+Expected: all tests green. (Sanity check — no FE work has touched server yet.)
+
+- [ ] **Step 6: Verify native typecheck passes on the baseline**
+
+```bash
+cd ../native && pnpm typecheck
+```
+Expected: `Found 0 errors.`
+
+- [ ] **Step 7: Commit the plan doc**
+
+```bash
+git add docs/superpowers/plans/2026-04-30-auth-ux-completion.md
+git commit -m "docs: auth ux completion implementation plan"
+```
+
+---
+
+## Task 1: Extract `getAuthRedirectTarget` Pure Function (TDD)
+
+**Goal:** Lift the routing logic out of `AuthGate` JSX into a pure function that takes (session, prefs, segments) and returns a typed result. Cover every row of the redirect table with unit tests.
+
+**Files:**
+- Create: `apps/native/lib/auth-redirect.ts`
+- Create: `apps/native/lib/__tests__/auth-redirect.test.ts`
+- Modify: `apps/native/app/_layout.tsx` (lines 30–80, the AuthGate branches)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/native/lib/__tests__/auth-redirect.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { getAuthRedirectTarget } from "../auth-redirect";
+
+const sessionPending = { isPending: true, error: null, data: null } as const;
+const sessionError = { isPending: false, error: new Error("net"), data: null } as const;
+const sessionNone = { isPending: false, error: null, data: null } as const;
+const sessionOk = { isPending: false, error: null, data: { user: { id: "u1" } } } as const;
+
+const prefsPending = { isPending: true, data: undefined } as const;
+const prefsIncomplete = { isPending: false, data: { onboardingCompleted: false } } as const;
+const prefsComplete = { isPending: false, data: { onboardingCompleted: true } } as const;
+
+describe("getAuthRedirectTarget", () => {
+  it("loading while session is pending", () => {
+    expect(getAuthRedirectTarget(sessionPending, prefsPending, []))
+      .toEqual({ kind: "loading" });
+  });
+
+  it("error when session check failed", () => {
+    expect(getAuthRedirectTarget(sessionError, prefsPending, []))
+      .toEqual({ kind: "error" });
+  });
+
+  it("stays on (auth) when unauthenticated", () => {
+    expect(getAuthRedirectTarget(sessionNone, prefsPending, ["(auth)"]))
+      .toEqual({ kind: "stay" });
+  });
+
+  it("redirects to /(auth)/login when unauthenticated outside (auth)", () => {
+    expect(getAuthRedirectTarget(sessionNone, prefsPending, ["(app)"]))
+      .toEqual({ kind: "redirect", href: "/(auth)/login" });
+  });
+
+  it("loading while prefs pending after session resolved", () => {
+    expect(getAuthRedirectTarget(sessionOk, prefsPending, ["(app)"]))
+      .toEqual({ kind: "loading" });
+  });
+
+  it("stays in (onboarding) when authenticated and onboarding incomplete", () => {
+    expect(getAuthRedirectTarget(sessionOk, prefsIncomplete, ["(onboarding)"]))
+      .toEqual({ kind: "stay" });
+  });
+
+  it("redirects to onboarding/start when authenticated and onboarding incomplete elsewhere", () => {
+    expect(getAuthRedirectTarget(sessionOk, prefsIncomplete, ["(app)"]))
+      .toEqual({ kind: "redirect", href: "/(onboarding)/start" });
+  });
+
+  it("redirects to /(app) when authenticated, onboarded, but in (auth)", () => {
+    expect(getAuthRedirectTarget(sessionOk, prefsComplete, ["(auth)"]))
+      .toEqual({ kind: "redirect", href: "/(app)/(tabs)" });
+  });
+
+  it("redirects to /(app) when authenticated, onboarded, but in (onboarding)", () => {
+    expect(getAuthRedirectTarget(sessionOk, prefsComplete, ["(onboarding)"]))
+      .toEqual({ kind: "redirect", href: "/(app)/(tabs)" });
+  });
+
+  it("stays in (app) when authenticated and onboarded", () => {
+    expect(getAuthRedirectTarget(sessionOk, prefsComplete, ["(app)"]))
+      .toEqual({ kind: "stay" });
+  });
+
+  it("treats empty segments as stay (cold-start race)", () => {
+    expect(getAuthRedirectTarget(sessionOk, prefsComplete, []))
+      .toEqual({ kind: "stay" });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd apps/native && bun test lib/__tests__/auth-redirect.test.ts
+```
+Expected: failure with `Cannot find module '../auth-redirect'`.
+
+- [ ] **Step 3: Implement `getAuthRedirectTarget`**
+
+Create `apps/native/lib/auth-redirect.ts`:
+
+```ts
+import type { Href } from "expo-router";
+
+type SessionState = {
+  isPending: boolean;
+  error: unknown;
+  data: { user: { id: string } } | null;
+};
+
+type PrefsState = {
+  isPending: boolean;
+  data: { onboardingCompleted: boolean } | undefined;
+};
+
+export type AuthRedirectResult =
+  | { kind: "loading" }
+  | { kind: "error" }
+  | { kind: "stay" }
+  | { kind: "redirect"; href: Href };
+
+export function getAuthRedirectTarget(
+  session: SessionState,
+  prefs: PrefsState,
+  segments: readonly string[]
+): AuthRedirectResult {
+  if (session.isPending) return { kind: "loading" };
+  if (session.error) return { kind: "error" };
+
+  // Empty segments only happen for one render on cold-start before the URL
+  // is resolved. Treat as "stay" so we don't push redirects into nowhere.
+  if (segments.length === 0) return { kind: "stay" };
+
+  const inAuth = segments[0] === "(auth)";
+  const inOnboarding = segments[0] === "(onboarding)";
+
+  if (!session.data) {
+    if (inAuth) return { kind: "stay" };
+    return { kind: "redirect", href: "/(auth)/login" };
+  }
+
+  if (prefs.isPending) return { kind: "loading" };
+  const completed = prefs.data?.onboardingCompleted === true;
+
+  if (!completed) {
+    if (inOnboarding) return { kind: "stay" };
+    return { kind: "redirect", href: "/(onboarding)/start" };
+  }
+
+  if (inAuth || inOnboarding) {
+    return { kind: "redirect", href: "/(app)/(tabs)" };
+  }
+  return { kind: "stay" };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+bun test lib/__tests__/auth-redirect.test.ts
+```
+Expected: all 11 tests pass.
+
+- [ ] **Step 5: Replace AuthGate's inline branches with the pure function**
+
+Modify `apps/native/app/_layout.tsx`. Replace the `AuthGate` function body with:
+
+```tsx
+function AuthGate() {
+  const session = authClient.useSession();
+  const segments = useSegments();
+  const prefs = usePreferences({ enabled: !!session.data });
+
+  const result = getAuthRedirectTarget(
+    {
+      isPending: session.isPending,
+      error: session.error,
+      data: session.data ?? null,
+    },
+    {
+      isPending: prefs.isPending,
+      data: prefs.data ?? undefined,
+    },
+    segments
+  );
+
+  if (result.kind === "loading") return <LoadingScreen />;
+  if (result.kind === "error") {
+    return (
+      <View className="flex-1 bg-background items-center justify-center px-8">
+        <Text className="text-foreground text-base text-center">
+          Não foi possível verificar sua sessão. Verifique sua conexão e tente novamente.
+        </Text>
+      </View>
+    );
+  }
+  if (result.kind === "redirect") return <Redirect href={result.href} />;
+  return <Slot />;
+}
+```
+
+Add the import at the top of `_layout.tsx`:
+
+```tsx
+import { getAuthRedirectTarget } from "@/lib/auth-redirect";
+```
+
+Verify these existing imports remain (they are still used): `Redirect`, `Slot`, `useSegments`, `Spinner`, `Text`, `View`, `authClient`, `usePreferences`.
+
+- [ ] **Step 6: Run typecheck + tests**
+
+```bash
+pnpm typecheck && bun test lib/__tests__/auth-redirect.test.ts
+```
+Expected: typecheck clean, all redirect tests still passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/native/lib/auth-redirect.ts \
+        apps/native/lib/__tests__/auth-redirect.test.ts \
+        apps/native/app/_layout.tsx
+git commit -m "refactor(native): extract auth redirect logic to pure function with tests"
+```
+
+---
+
+## Task 2: Add `getAuthErrorMessage` Helper (TDD)
+
+**Goal:** Replace the bare-string error fallbacks in login/register with a single helper that maps Better-Auth error codes to Portuguese copy.
+
+**Files:**
+- Create: `apps/native/lib/auth-errors.ts`
+- Create: `apps/native/lib/__tests__/auth-errors.test.ts`
+- Modify: `apps/native/app/(auth)/login.tsx` (the `onSubmit` handler around line 118)
+- Modify: `apps/native/app/(auth)/register.tsx` (the equivalent handler)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/native/lib/__tests__/auth-errors.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { getAuthErrorMessage } from "../auth-errors";
+
+describe("getAuthErrorMessage", () => {
+  it("maps INVALID_EMAIL_OR_PASSWORD to Portuguese", () => {
+    expect(getAuthErrorMessage({ code: "INVALID_EMAIL_OR_PASSWORD" }))
+      .toBe("Email ou senha incorretos.");
+  });
+
+  it("maps USER_ALREADY_EXISTS to Portuguese", () => {
+    expect(getAuthErrorMessage({ code: "USER_ALREADY_EXISTS" }))
+      .toBe("Já existe uma conta com esse email.");
+  });
+
+  it("maps PASSWORD_TOO_SHORT to Portuguese", () => {
+    expect(getAuthErrorMessage({ code: "PASSWORD_TOO_SHORT" }))
+      .toBe("Senha muito curta. Use ao menos 8 caracteres.");
+  });
+
+  it("falls back to a generic message on unknown codes", () => {
+    expect(getAuthErrorMessage({ code: "SOMETHING_WEIRD" }))
+      .toBe("Algo deu errado. Tente novamente.");
+  });
+
+  it("falls back when input is not an object", () => {
+    expect(getAuthErrorMessage(null)).toBe("Algo deu errado. Tente novamente.");
+    expect(getAuthErrorMessage("string")).toBe("Algo deu errado. Tente novamente.");
+    expect(getAuthErrorMessage(undefined)).toBe("Algo deu errado. Tente novamente.");
+  });
+
+  it("uses error.message when no known code is present and message exists", () => {
+    expect(getAuthErrorMessage({ message: "rede falhou" }))
+      .toBe("rede falhou");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bun test lib/__tests__/auth-errors.test.ts
+```
+Expected: failure with `Cannot find module '../auth-errors'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `apps/native/lib/auth-errors.ts`:
+
+```ts
+const FALLBACK = "Algo deu errado. Tente novamente.";
+
+const CODE_MAP: Record<string, string> = {
+  INVALID_EMAIL_OR_PASSWORD: "Email ou senha incorretos.",
+  USER_ALREADY_EXISTS: "Já existe uma conta com esse email.",
+  PASSWORD_TOO_SHORT: "Senha muito curta. Use ao menos 8 caracteres.",
+  EMAIL_NOT_VERIFIED: "Confirme seu email antes de entrar.",
+  USER_NOT_FOUND: "Não encontramos uma conta com esse email.",
+  TOO_MANY_REQUESTS: "Muitas tentativas. Aguarde um instante e tente de novo.",
+};
+
+export function getAuthErrorMessage(error: unknown): string {
+  if (!error || typeof error !== "object") return FALLBACK;
+
+  const code = "code" in error && typeof error.code === "string" ? error.code : null;
+  if (code && CODE_MAP[code]) return CODE_MAP[code];
+
+  const message = "message" in error && typeof error.message === "string" ? error.message : null;
+  if (message && message.length > 0) return message;
+
+  return FALLBACK;
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+bun test lib/__tests__/auth-errors.test.ts
+```
+Expected: all 6 tests pass.
+
+- [ ] **Step 5: Wire into login.tsx**
+
+In `apps/native/app/(auth)/login.tsx`, find the `onSubmit` block (around line 118):
+
+```tsx
+const onSubmit = async (data: LoginForm) => {
+  setFormError(null);
+  const result = await authService.login(data.email.trim(), data.password);
+  if (result.error) {
+    setFormError(result.error.message || "Não foi possível entrar");
+  } else {
+    reset();
+  }
+};
+```
+
+Replace with:
+
+```tsx
+const onSubmit = async (data: LoginForm) => {
+  setFormError(null);
+  const result = await authService.login(data.email.trim(), data.password);
+  if (result.error) {
+    setFormError(getAuthErrorMessage(result.error));
+  } else {
+    reset();
+  }
+};
+```
+
+Add the import at the top:
+
+```tsx
+import { getAuthErrorMessage } from "@/lib/auth-errors";
+```
+
+- [ ] **Step 6: Wire into register.tsx**
+
+Apply the same change in `apps/native/app/(auth)/register.tsx`. Find the `onSubmit` handler and replace any inline `result.error.message || "..."` fallback with `getAuthErrorMessage(result.error)`. Add the same import.
+
+- [ ] **Step 7: Run typecheck + all native tests**
+
+```bash
+pnpm typecheck && bun test lib/__tests__
+```
+Expected: typecheck clean, all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/native/lib/auth-errors.ts \
+        apps/native/lib/__tests__/auth-errors.test.ts \
+        "apps/native/app/(auth)/login.tsx" \
+        "apps/native/app/(auth)/register.tsx"
+git commit -m "feat(native): map Better-Auth error codes to Portuguese copy"
+```
+
+---
+
+## Task 3: Add `confirmDestructiveAction` Helper (TDD)
+
+**Goal:** Provide a Promise-returning wrapper over `Alert.alert` for destructive confirmations (logout now, deletion later).
+
+**Files:**
+- Create: `apps/native/lib/ui/confirm.ts`
+- Create: `apps/native/lib/__tests__/confirm.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/native/lib/__tests__/confirm.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { Alert } from "react-native";
+import { confirmDestructiveAction } from "../ui/confirm";
+
+const originalAlert = Alert.alert;
+
+afterEach(() => {
+  Alert.alert = originalAlert;
+});
+
+function spyAlert(buttonToTap: "Cancel" | "Confirm") {
+  const calls: Array<{ title: string; message?: string }> = [];
+  Alert.alert = mock((title: string, message?: string, buttons?: any[]) => {
+    calls.push({ title, message });
+    const target = buttons?.find((b) =>
+      buttonToTap === "Confirm" ? b.style === "destructive" : b.style === "cancel"
+    );
+    target?.onPress?.();
+  }) as unknown as typeof Alert.alert;
+  return calls;
+}
+
+describe("confirmDestructiveAction", () => {
+  it("resolves true when destructive button is tapped", async () => {
+    spyAlert("Confirm");
+    await expect(confirmDestructiveAction("Sair?")).resolves.toBe(true);
+  });
+
+  it("resolves false when cancel button is tapped", async () => {
+    spyAlert("Cancel");
+    await expect(confirmDestructiveAction("Sair?")).resolves.toBe(false);
+  });
+
+  it("passes title and optional message to Alert.alert", async () => {
+    const calls = spyAlert("Cancel");
+    await confirmDestructiveAction("Excluir conta?", "Esta ação é permanente.");
+    expect(calls[0]).toEqual({ title: "Excluir conta?", message: "Esta ação é permanente." });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bun test lib/__tests__/confirm.test.ts
+```
+Expected: failure with `Cannot find module '../ui/confirm'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `apps/native/lib/ui/confirm.ts`:
+
+```ts
+import { Alert } from "react-native";
+
+export function confirmDestructiveAction(
+  title: string,
+  message?: string
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    Alert.alert(title, message, [
+      { text: "Cancelar", style: "cancel", onPress: () => resolve(false) },
+      { text: "Confirmar", style: "destructive", onPress: () => resolve(true) },
+    ]);
+  });
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+bun test lib/__tests__/confirm.test.ts
+```
+Expected: all 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/native/lib/ui/confirm.ts \
+        apps/native/lib/__tests__/confirm.test.ts
+git commit -m "feat(native): add confirmDestructiveAction alert helper"
+```
+
+---
+
+## Task 4: Wire Sair (Logout) Button on Profile
+
+**Goal:** Add a Sair button on the existing profile screen that confirms, signs out, and clears the query cache. The `AuthGate` will auto-redirect to `/(auth)/login` on the next render.
+
+**Files:**
+- Modify: `apps/native/app/(app)/(tabs)/profile.tsx`
+
+(No test for the button itself — it's a thin glue between confirmed-helpers. The integration is verified manually in Task 6.)
+
+- [ ] **Step 1: Read the current profile screen**
+
+```bash
+wc -l "apps/native/app/(app)/(tabs)/profile.tsx"
+head -20 "apps/native/app/(app)/(tabs)/profile.tsx"
+```
+Confirm imports and structure. Identify a place near the bottom of the screen for a settings-style row.
+
+- [ ] **Step 2: Add the Sair handler and button**
+
+Add these imports at the top of `profile.tsx`:
+
+```tsx
+import { Pressable, Alert } from "react-native";
+import { useQueryClient } from "@tanstack/react-query";
+import { authClient } from "@/lib/auth-client";
+import { confirmDestructiveAction } from "@/lib/ui/confirm";
+import { getAuthErrorMessage } from "@/lib/auth-errors";
+```
+
+Inside the component, add:
+
+```tsx
+const queryClient = useQueryClient();
+
+const onSair = async () => {
+  const ok = await confirmDestructiveAction(
+    "Sair da conta?",
+    "Você precisará entrar novamente."
+  );
+  if (!ok) return;
+  const { error } = await authClient.signOut();
+  if (error) {
+    Alert.alert("Erro", getAuthErrorMessage(error));
+    return;
+  }
+  queryClient.clear();
+};
+```
+
+In the JSX, near the bottom of the scrollable content (after the existing profile sections), add:
+
+```tsx
+<Pressable
+  accessibilityRole="button"
+  onPress={onSair}
+  className="mx-4 mt-8 mb-12 py-4 rounded-2xl bg-destructive/10 items-center"
+>
+  <Text className="text-destructive font-semibold text-base">Sair</Text>
+</Pressable>
+```
+
+(If the existing screen uses `StyleSheet` instead of `className`, mirror that pattern: define a `sairButton` and `sairText` style and apply via `style={...}`.)
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+cd apps/native && pnpm typecheck
+```
+Expected: `Found 0 errors.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/native/app/(app)/(tabs)/profile.tsx"
+git commit -m "feat(native): add Sair logout button to profile"
+```
+
+---
+
+## Task 5: Harden `EXPO_PUBLIC_SERVER_URL`
+
+**Goal:** Make the env var required so missing config fails at startup, not at first network call.
+
+**Files:**
+- Modify: `packages/env/src/native.ts`
+- Create: `packages/env/src/__tests__/native.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/env/src/__tests__/native.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+
+function loadEnv(envOverride: Record<string, string | undefined>) {
+  // Re-import the module under a tweaked process.env to test schema parsing.
+  for (const [k, v] of Object.entries(envOverride)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  // Bust the require cache for a clean re-evaluation.
+  const path = require.resolve("../native");
+  delete require.cache[path];
+  return require("../native");
+}
+
+describe("native env", () => {
+  it("rejects missing EXPO_PUBLIC_SERVER_URL at parse time", () => {
+    expect(() =>
+      loadEnv({ EXPO_PUBLIC_SERVER_URL: undefined })
+    ).toThrow();
+  });
+
+  it("rejects empty string EXPO_PUBLIC_SERVER_URL", () => {
+    expect(() =>
+      loadEnv({ EXPO_PUBLIC_SERVER_URL: "" })
+    ).toThrow();
+  });
+
+  it("rejects non-URL strings", () => {
+    expect(() =>
+      loadEnv({ EXPO_PUBLIC_SERVER_URL: "not a url" })
+    ).toThrow();
+  });
+
+  it("accepts a valid URL", () => {
+    const { env } = loadEnv({ EXPO_PUBLIC_SERVER_URL: "http://localhost:3000" });
+    expect(env.EXPO_PUBLIC_SERVER_URL).toBe("http://localhost:3000");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify failures (current code is `.optional()`)**
+
+```bash
+cd packages/env && bun test
+```
+Expected: the 3 "rejects" tests fail because the schema still allows `undefined`/`""`. The accept test passes.
+
+- [ ] **Step 3: Tighten the schema**
+
+Modify `packages/env/src/native.ts`. Replace the existing client block:
+
+```ts
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+export const env = createEnv({
+  clientPrefix: "EXPO_PUBLIC_",
+  client: {
+    EXPO_PUBLIC_SERVER_URL: z.url(),
+  },
+  runtimeEnv: process.env,
+  emptyStringAsUndefined: true,
+});
+```
+
+(Drop `.optional()`. `emptyStringAsUndefined: true` ensures empty strings are treated as missing.)
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+bun test
+```
+Expected: all 4 tests pass.
+
+- [ ] **Step 5: Set the var locally if not already set**
+
+Confirm `apps/native/.env` (or wherever the dev env lives) has `EXPO_PUBLIC_SERVER_URL=http://localhost:3000`. If it doesn't, add it:
+
+```bash
+grep EXPO_PUBLIC_SERVER_URL apps/native/.env || echo 'EXPO_PUBLIC_SERVER_URL=http://localhost:3000' >> apps/native/.env
+```
+
+- [ ] **Step 6: Verify the native app boots with the required var present**
+
+```bash
+cd apps/native && pnpm typecheck
+```
+Expected: `Found 0 errors.`
+
+(A full Expo boot requires more setup; the typecheck + the test suite are sufficient to confirm the schema works.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/env/src/native.ts \
+        packages/env/src/__tests__/native.test.ts
+git commit -m "feat(env): require EXPO_PUBLIC_SERVER_URL at parse time"
+```
+
+---
+
+## Task 6: Final Manual Smoke Test
+
+**Goal:** Walk the acceptance criteria from the spec on a real simulator before opening the PR.
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Start the backend**
+
+```bash
+cd apps/server && pnpm dev
+```
+Wait for: `[INFO] Server listening on 3000`. Leave running.
+
+- [ ] **Step 2: Start the simulator**
+
+```bash
+cd apps/native && pnpm ios
+```
+Wait for the app to load.
+
+- [ ] **Step 3: Acceptance walk-through**
+
+Mark each as you confirm:
+
+- [ ] Cold-fresh launch shows a spinner briefly, then the **login screen**.
+- [ ] Tap "Não tem conta? Criar conta" → navigates to **register**. Hardware/swipe back → returns to login (not a blank screen).
+- [ ] Submit valid signup → lands on `(onboarding)/start`.
+- [ ] Force-quit during onboarding → reopen → lands on `(onboarding)/start` again.
+- [ ] Complete onboarding (mocked answers OK) → force-quit → reopen → lands on **drawer/tabs home** (not onboarding).
+- [ ] Submit invalid login (wrong password) → see Portuguese error: `"Email ou senha incorretos."`
+- [ ] Tap **Sair** on profile → see confirmation alert → tap Confirmar → land on login screen.
+- [ ] Tap **Sair** on profile → see confirmation alert → tap Cancelar → stay on profile.
+
+- [ ] **Step 4: Confirm env hardening locally**
+
+```bash
+cd apps/native && EXPO_PUBLIC_SERVER_URL= pnpm start
+```
+Expected: build/run **fails** with a Zod validation error about `EXPO_PUBLIC_SERVER_URL`. (Then restore the env var by running normally.)
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin feature/auth-ux-completion
+```
+
+- [ ] **Step 6: Open a PR**
+
+Use `gh pr create` with title `feat: auth ux completion (Tier 1 #1)` and a body that links to the spec + plan and lists the acceptance checklist above.
+
+---
+
+## Self-Review Notes
+
+Run after writing this plan:
+
+**1. Spec coverage:**
+- ✓ Architecture (root-layout gating) — Task 1.
+- ✓ Route structure — already exists on phase4; no new task needed (documented in Task 0 branch strategy).
+- ✓ Redirect rules table — Task 1, all 9 rows tested.
+- ✓ Logout flow — Task 4 (Sair on profile) + Task 3 (confirm helper).
+- ✓ Sign-in / sign-up screens — already exist on phase4; getErrorMessage integration in Task 2.
+- ✓ Env hardening — Task 5.
+- ✓ Loading state — handled inside `getAuthRedirectTarget` ("loading" kind).
+- ✓ Error UX — Task 1 (session error) + Task 2 (form errors).
+- ✓ Testing — Tasks 1, 2, 3, 5 all TDD; Task 6 manual.
+
+**2. Placeholder scan:** clean — every step has full code or exact commands.
+
+**3. Type consistency:**
+- `getAuthRedirectTarget(session, prefs, segments)` signature matches across Task 1 test, implementation, and Task 1 Step 5 caller.
+- `getAuthErrorMessage(error: unknown): string` — used identically in login.tsx, register.tsx, profile.tsx.
+- `confirmDestructiveAction(title, message?): Promise<boolean>` — matches usage in profile.tsx.
+
+**4. Out-of-scope items respected:**
+- No password reset, email verification, Google OAuth, account deletion, or avatar upload tasks.
+- Drawer/mais.tsx port is acknowledged as future work (Sair lives interim on profile).

--- a/docs/superpowers/plans/2026-05-10-phase-2b-push-notifications.md
+++ b/docs/superpowers/plans/2026-05-10-phase-2b-push-notifications.md
@@ -1,0 +1,1883 @@
+# Phase 2B — Push Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the push-notification pipeline (Expo) for scheduled streak reminders (19h + 21h BRT) and achievement notifications (7d/30d streak, "quase mestre" mastery), with per-type opt-out and device token storage.
+
+**Architecture:** New `push_token` table + 3 user pref columns. New `notifications` feature module with Expo Push API wrapper, tokens/preferences CRUD endpoints, dispatcher service, and a worker handling two BullMQ queues: `notifications-cron` (hourly sweep) and `notifications-send` (batched fan-out). Achievement events hook from `sessions.service.completeSession` post-success.
+
+**Tech Stack:** Drizzle ORM · BullMQ · `expo-server-sdk` · Fastify 5 · Vitest + PGlite · neverthrow `Result<T, AppError>`.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-phase-2b-push-notifications-design.md`
+
+---
+
+## File Map
+
+**Create:**
+- `packages/shared/src/notifications.ts` — Zod schemas
+- `packages/db/src/schema/push-tokens.ts` — Drizzle schema
+- `packages/db/src/migrations/0004_<adjective>_<noun>.sql` — drizzle-kit generated, hand-checked
+- `apps/server/src/features/notifications/index.ts`
+- `apps/server/src/features/notifications/push.client.ts` — Expo SDK wrapper
+- `apps/server/src/features/notifications/templates.ts` — PT-BR message builders
+- `apps/server/src/features/notifications/dispatcher.ts` — orchestration
+- `apps/server/src/features/notifications/tokens.repository.ts`
+- `apps/server/src/features/notifications/tokens.service.ts`
+- `apps/server/src/features/notifications/tokens.route.ts`
+- `apps/server/src/features/notifications/preferences.repository.ts`
+- `apps/server/src/features/notifications/preferences.service.ts`
+- `apps/server/src/features/notifications/preferences.route.ts`
+- `apps/server/src/features/notifications/templates.test.ts`
+- `apps/server/src/features/notifications/push.client.test.ts`
+- `apps/server/src/features/notifications/dispatcher.test.ts`
+- `apps/server/src/features/notifications/tokens.service.test.ts`
+- `apps/server/src/features/notifications/preferences.service.test.ts`
+- `apps/server/src/features/notifications/tokens.repository.integration.test.ts`
+- `apps/server/src/features/notifications/notifications.sweep.integration.test.ts`
+- `apps/server/src/workers/notifications.worker.ts`
+
+**Modify:**
+- `packages/shared/src/index.ts` — re-export notifications
+- `packages/db/src/schema/auth.ts` — add 3 user notification columns
+- `packages/db/src/schema/index.ts` — re-export push-tokens
+- `packages/db/src/test-client.ts` — mirror DDL
+- `packages/env/src/server.ts` — add `EXPO_ACCESS_TOKEN`
+- `apps/server/package.json` — add `expo-server-sdk` dep
+- `apps/server/src/plugins/queue.ts` — register 2 new queues + repeatable cron
+- `apps/server/src/worker.ts` — start notifications worker alongside prefetch
+- `apps/server/src/index.ts` — register tokens + preferences routes
+- `apps/server/src/features/sessions/sessions.service.ts` — fire achievement notifications post-complete
+
+---
+
+## Task 1: Shared Zod schemas
+
+**Files:**
+- Create: `packages/shared/src/notifications.ts`
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] **Step 1: Create schemas**
+
+```typescript
+import { z } from "zod";
+
+export const PushPlatformSchema = z.enum(["ios", "android"]);
+export type PushPlatform = z.infer<typeof PushPlatformSchema>;
+
+export const RegisterPushTokenBodySchema = z.object({
+  token: z.string().regex(/^Expo(nent)?PushToken\[.+\]$/, {
+    message: "Invalid Expo push token format",
+  }),
+  platform: PushPlatformSchema,
+});
+export type RegisterPushTokenBody = z.infer<typeof RegisterPushTokenBodySchema>;
+
+export const PushTokenResponseSchema = z.object({
+  id: z.number().int().positive(),
+  token: z.string(),
+  platform: PushPlatformSchema,
+});
+
+export const NotificationPreferencesSchema = z.object({
+  notificationHour: z.number().int().min(0).max(23),
+  streakRemindersEnabled: z.boolean(),
+  achievementNotificationsEnabled: z.boolean(),
+});
+export type NotificationPreferences = z.infer<typeof NotificationPreferencesSchema>;
+
+export const UpdateNotificationPreferencesBodySchema = NotificationPreferencesSchema.partial();
+export type UpdateNotificationPreferencesBody = z.infer<typeof UpdateNotificationPreferencesBodySchema>;
+```
+
+- [ ] **Step 2: Re-export**
+
+In `packages/shared/src/index.ts`, append:
+```typescript
+export * from "./notifications";
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+pnpm --filter @pruvi/shared check-types
+git add packages/shared/src/notifications.ts packages/shared/src/index.ts
+git commit -m "feat(shared): notifications zod schemas"
+```
+
+---
+
+## Task 2: Drizzle schema — push_token + user columns
+
+**Files:**
+- Create: `packages/db/src/schema/push-tokens.ts`
+- Modify: `packages/db/src/schema/auth.ts`
+- Modify: `packages/db/src/schema/index.ts`
+
+- [ ] **Step 1: Create push_token schema**
+
+`packages/db/src/schema/push-tokens.ts`:
+
+```typescript
+import { relations } from "drizzle-orm";
+import { index, integer, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+
+import { user } from "./auth";
+
+export const pushToken = pgTable(
+  "push_token",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    token: text("token").notNull().unique(),
+    platform: text("platform", { enum: ["ios", "android"] }).notNull(),
+    lastUsedAt: timestamp("last_used_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("push_token_user_idx").on(table.userId),
+  ],
+);
+
+export const pushTokenRelations = relations(pushToken, ({ one }) => ({
+  user: one(user, {
+    fields: [pushToken.userId],
+    references: [user.id],
+  }),
+}));
+```
+
+- [ ] **Step 2: Extend user schema with notification columns**
+
+In `packages/db/src/schema/auth.ts`, inside the `user` `pgTable({...})` object, add (before `createdAt`):
+
+```typescript
+notificationHour: integer("notification_hour").notNull().default(19),
+streakRemindersEnabled: boolean("streak_reminders_enabled").notNull().default(true),
+achievementNotificationsEnabled: boolean("achievement_notifications_enabled").notNull().default(true),
+```
+
+- [ ] **Step 3: Re-export**
+
+In `packages/db/src/schema/index.ts`, append after the topics re-export:
+```typescript
+export * from "./push-tokens";
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+pnpm --filter @pruvi/db check-types
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/db/src/schema/
+git commit -m "feat(db): push_token table + user notification columns"
+```
+
+---
+
+## Task 3: Migration 0004
+
+**Files:**
+- Create: `packages/db/src/migrations/0004_<name>.sql` (drizzle-kit)
+
+- [ ] **Step 1: Start pg + generate**
+
+```bash
+pnpm db:start
+pnpm --filter @pruvi/db db:generate
+```
+
+A new `0004_*.sql` appears with: `CREATE TABLE push_token` + `ALTER TABLE user ADD COLUMN ...` (×3).
+
+- [ ] **Step 2: Inspect + add CHECK constraint**
+
+Open the generated SQL. Append (or insert after the user ALTERs):
+
+```sql
+ALTER TABLE "user" ADD CONSTRAINT "user_notification_hour_chk" CHECK ("notification_hour" BETWEEN 0 AND 23);
+```
+
+Use `--> statement-breakpoint` between statements as the existing migrations do.
+
+- [ ] **Step 3: Apply + smoke**
+
+```bash
+pnpm --filter @pruvi/db db:migrate
+pnpm verify:migration
+```
+
+Expected: both clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/db/src/migrations/
+git commit -m "feat(db): migration 0004 — push_token + user notification prefs"
+```
+
+---
+
+## Task 4: PGlite test client mirror
+
+**Files:**
+- Modify: `packages/db/src/test-client.ts`
+
+- [ ] **Step 1: Add user columns + push_token**
+
+In the SQL template, modify the existing `"user"` CREATE TABLE to include the new columns:
+
+```sql
+notification_hour INTEGER NOT NULL DEFAULT 19,
+streak_reminders_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+achievement_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+```
+
+Add after the `daily_session` block (after the topics tables — order doesn't matter for push_token since it only depends on user):
+
+```sql
+    CREATE TABLE IF NOT EXISTS "push_token" (
+      id SERIAL PRIMARY KEY,
+      user_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+      token TEXT NOT NULL UNIQUE,
+      platform TEXT NOT NULL,
+      last_used_at TIMESTAMP NOT NULL DEFAULT NOW(),
+      created_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+```
+
+- [ ] **Step 2: Update cleanup helper**
+
+In `apps/server/src/test/db-helpers.ts`, `cleanupTestDb` (or whatever TRUNCATE helper exists) — add `push_token` to the truncate list.
+
+- [ ] **Step 3: Sanity test**
+
+```bash
+pnpm --filter server test
+```
+Expected: still passes (no new tests yet, just ensure existing tests still work with the modified DDL).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/db/src/test-client.ts apps/server/src/test/db-helpers.ts
+git commit -m "chore(db): mirror push_token + user notification columns in pglite"
+```
+
+---
+
+## Task 5: Env additions + expo-server-sdk dependency
+
+**Files:**
+- Modify: `packages/env/src/server.ts`
+- Modify: `apps/server/package.json`
+
+- [ ] **Step 1: Add env var**
+
+In `packages/env/src/server.ts`, add to the `server` block:
+
+```typescript
+EXPO_ACCESS_TOKEN: z.string().optional(),
+```
+
+- [ ] **Step 2: Install dep**
+
+```bash
+pnpm --filter server add expo-server-sdk
+```
+
+Confirm `apps/server/package.json` now lists `"expo-server-sdk": "^3.x.x"` (or current latest).
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+pnpm --filter server check-types
+git add packages/env/src/server.ts apps/server/package.json pnpm-lock.yaml
+git commit -m "feat(server): add expo-server-sdk + EXPO_ACCESS_TOKEN env"
+```
+
+---
+
+## Task 6: Templates (`templates.ts`)
+
+**Files:**
+- Create: `apps/server/src/features/notifications/templates.ts`
+- Create: `apps/server/src/features/notifications/templates.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import {
+  streakReminderPrimary,
+  streakReminderLate,
+  streakMilestone,
+  masteryAchievement,
+  type PushPayload,
+} from "./templates";
+
+describe("notification templates", () => {
+  it("streakReminderPrimary returns non-empty PT-BR payload", () => {
+    const p = streakReminderPrimary();
+    expect(p.title).toMatch(/Pruvi/);
+    expect(p.body.length).toBeGreaterThan(0);
+  });
+
+  it("streakReminderLate references risk to streak", () => {
+    const p = streakReminderLate();
+    expect(p.title.toLowerCase()).toContain("streak");
+  });
+
+  it("streakMilestone(7) and (30) produce different bodies", () => {
+    const a = streakMilestone(7);
+    const b = streakMilestone(30);
+    expect(a.title).toMatch(/7/);
+    expect(b.title).toMatch(/30/);
+    expect(a.body).not.toEqual(b.body);
+  });
+
+  it("masteryAchievement includes the subtopic name", () => {
+    const p = masteryAchievement("Membrana plasmática");
+    expect(p.body).toContain("Membrana plasmática");
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+pnpm --filter server test templates.test
+```
+Expected: FAIL — cannot find `./templates`.
+
+- [ ] **Step 3: Implement**
+
+`apps/server/src/features/notifications/templates.ts`:
+
+```typescript
+export type PushPayload = {
+  title: string;
+  body: string;
+};
+
+export function streakReminderPrimary(): PushPayload {
+  return {
+    title: "A Pruvi te esperou hoje 💛",
+    body: "Ainda dá tempo — 5 minutos é o suficiente.",
+  };
+}
+
+export function streakReminderLate(): PushPayload {
+  return {
+    title: "Seu streak está em risco",
+    body: "Uma sessão rápida segura o ritmo.",
+  };
+}
+
+export function streakMilestone(days: 7 | 30): PushPayload {
+  return {
+    title: `${days} dias de streak! 🔥`,
+    body:
+      days === 7
+        ? "Uma semana firme. Tá pegando o jeito."
+        : "Um mês. Isso é dedicação real.",
+  };
+}
+
+export function masteryAchievement(subtopicName: string): PushPayload {
+  return {
+    title: "Quase mestre! ⭐",
+    body: `Você está dominando ${subtopicName}.`,
+  };
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+```bash
+pnpm --filter server test templates.test
+```
+Expected: PASS — all 4 cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/features/notifications/templates.ts apps/server/src/features/notifications/templates.test.ts
+git commit -m "feat(notifications): pt-br message templates"
+```
+
+---
+
+## Task 7: Push client (Expo wrapper)
+
+**Files:**
+- Create: `apps/server/src/features/notifications/push.client.ts`
+- Create: `apps/server/src/features/notifications/push.client.test.ts`
+
+- [ ] **Step 1: Failing tests**
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { PushClient, EXPO_BATCH_SIZE } from "./push.client";
+
+function makeExpoStub(overrides: Partial<{
+  sendPushNotificationsAsync: ReturnType<typeof vi.fn>;
+  isExpoPushToken: ReturnType<typeof vi.fn>;
+}> = {}) {
+  return {
+    sendPushNotificationsAsync: overrides.sendPushNotificationsAsync ?? vi.fn().mockResolvedValue([]),
+    isExpoPushToken: overrides.isExpoPushToken ?? vi.fn().mockReturnValue(true),
+    chunkPushNotifications: (msgs: unknown[]) => [msgs],
+  } as any;
+}
+
+describe("PushClient.sendBatch", () => {
+  it("returns empty tickets when no tokens provided", async () => {
+    const expo = makeExpoStub();
+    const client = new PushClient(expo);
+    const tickets = await client.sendBatch([], { title: "x", body: "y" });
+    expect(tickets).toEqual([]);
+    expect(expo.sendPushNotificationsAsync).not.toHaveBeenCalled();
+  });
+
+  it("calls Expo with a properly shaped message per token", async () => {
+    const sendMock = vi.fn().mockResolvedValue([{ status: "ok", id: "t1" }]);
+    const expo = makeExpoStub({ sendPushNotificationsAsync: sendMock });
+    const client = new PushClient(expo);
+    await client.sendBatch(["ExponentPushToken[a]", "ExponentPushToken[b]"], {
+      title: "T",
+      body: "B",
+    });
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const messages = sendMock.mock.calls[0][0];
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ to: "ExponentPushToken[a]", title: "T", body: "B" });
+  });
+
+  it("filters out invalid tokens via isExpoPushToken", async () => {
+    const expo = makeExpoStub({
+      isExpoPushToken: vi.fn((t: string) => t.startsWith("ExponentPushToken")),
+    });
+    const client = new PushClient(expo);
+    await client.sendBatch(["ExponentPushToken[a]", "bogus"], { title: "T", body: "B" });
+    const messages = expo.sendPushNotificationsAsync.mock.calls[0][0];
+    expect(messages).toHaveLength(1);
+  });
+});
+
+describe("PushClient.pruneTokensFromTickets", () => {
+  it("returns tokens whose ticket has DeviceNotRegistered detail", () => {
+    const client = new PushClient(makeExpoStub());
+    const tokens = ["ExponentPushToken[a]", "ExponentPushToken[b]"];
+    const tickets = [
+      { status: "ok", id: "t1" },
+      { status: "error", message: "x", details: { error: "DeviceNotRegistered" } },
+    ];
+    const pruned = client.pruneTokensFromTickets(tokens, tickets as any);
+    expect(pruned).toEqual(["ExponentPushToken[b]"]);
+  });
+});
+
+it("EXPO_BATCH_SIZE is 100", () => {
+  expect(EXPO_BATCH_SIZE).toBe(100);
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+pnpm --filter server test push.client.test
+```
+Expected: FAIL — cannot find `./push.client`.
+
+- [ ] **Step 3: Implement**
+
+`apps/server/src/features/notifications/push.client.ts`:
+
+```typescript
+import type Expo from "expo-server-sdk";
+import type { ExpoPushMessage, ExpoPushTicket } from "expo-server-sdk";
+import type { PushPayload } from "./templates";
+
+export const EXPO_BATCH_SIZE = 100;
+
+export class PushClient {
+  constructor(private expo: Expo) {}
+
+  /** Send the same payload to a batch of tokens. Returns Expo tickets. */
+  async sendBatch(tokens: string[], payload: PushPayload, data?: Record<string, unknown>): Promise<ExpoPushTicket[]> {
+    if (tokens.length === 0) return [];
+
+    const valid = tokens.filter((t) => this.expo.isExpoPushToken(t));
+    if (valid.length === 0) return [];
+
+    const messages: ExpoPushMessage[] = valid.map((to) => ({
+      to,
+      title: payload.title,
+      body: payload.body,
+      data,
+      sound: "default" as const,
+    }));
+
+    return this.expo.sendPushNotificationsAsync(messages);
+  }
+
+  /** Inspect Expo tickets and return tokens that should be pruned (DeviceNotRegistered). */
+  pruneTokensFromTickets(tokens: string[], tickets: ExpoPushTicket[]): string[] {
+    const out: string[] = [];
+    for (let i = 0; i < tickets.length; i++) {
+      const t = tickets[i];
+      if (t.status === "error" && t.details?.error === "DeviceNotRegistered") {
+        if (tokens[i]) out.push(tokens[i]);
+      }
+    }
+    return out;
+  }
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+```bash
+pnpm --filter server test push.client.test
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/features/notifications/push.client.ts apps/server/src/features/notifications/push.client.test.ts
+git commit -m "feat(notifications): expo push client wrapper"
+```
+
+---
+
+## Task 8: Tokens repository (with upsert)
+
+**Files:**
+- Create: `apps/server/src/features/notifications/tokens.repository.ts`
+- Create: `apps/server/src/features/notifications/tokens.repository.integration.test.ts`
+
+- [ ] **Step 1: Failing integration tests**
+
+```typescript
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { setupTestDb, getTestDb, teardownTestDb, cleanupTestDb } from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { pushToken } from "@pruvi/db/schema/push-tokens";
+import { TokensRepository } from "./tokens.repository";
+
+const db = getTestDb();
+const repo = new TokensRepository(db);
+
+const USER_A = "user_tokens_a";
+const USER_B = "user_tokens_b";
+
+beforeAll(async () => {
+  await setupTestDb();
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  await cleanupTestDb();
+  await db.insert(user).values([
+    { id: USER_A, name: "A", email: `${USER_A}@x.com` },
+    { id: USER_B, name: "B", email: `${USER_B}@x.com` },
+  ]);
+});
+
+describe("TokensRepository.upsert", () => {
+  it("inserts a new token for a user", async () => {
+    const row = await repo.upsert(USER_A, "ExponentPushToken[a]", "ios");
+    expect(row.userId).toBe(USER_A);
+    expect(row.token).toBe("ExponentPushToken[a]");
+    expect(row.platform).toBe("ios");
+  });
+
+  it("re-registering the same token under a different user reassigns it (no duplicates)", async () => {
+    await repo.upsert(USER_A, "ExponentPushToken[shared]", "ios");
+    const second = await repo.upsert(USER_B, "ExponentPushToken[shared]", "ios");
+    expect(second.userId).toBe(USER_B);
+    const rows = await db.select().from(pushToken).where(eq(pushToken.token, "ExponentPushToken[shared]"));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("listByUser returns only that user's tokens", async () => {
+    await repo.upsert(USER_A, "ExponentPushToken[a1]", "ios");
+    await repo.upsert(USER_A, "ExponentPushToken[a2]", "android");
+    await repo.upsert(USER_B, "ExponentPushToken[b1]", "ios");
+    const rows = await repo.listByUser(USER_A);
+    expect(rows.map((r) => r.token).sort()).toEqual(["ExponentPushToken[a1]", "ExponentPushToken[a2]"]);
+  });
+
+  it("deleteForUser removes only when owned by that user", async () => {
+    await repo.upsert(USER_A, "ExponentPushToken[a]", "ios");
+    await repo.upsert(USER_B, "ExponentPushToken[b]", "ios");
+    await repo.deleteForUser(USER_A, "ExponentPushToken[b]");  // not owned — no-op
+    const bRows = await db.select().from(pushToken).where(eq(pushToken.token, "ExponentPushToken[b]"));
+    expect(bRows).toHaveLength(1);
+
+    await repo.deleteForUser(USER_A, "ExponentPushToken[a]");
+    const aRows = await db.select().from(pushToken).where(eq(pushToken.token, "ExponentPushToken[a]"));
+    expect(aRows).toHaveLength(0);
+  });
+
+  it("deleteTokens removes a set of tokens regardless of owner (used by receipt pruning)", async () => {
+    await repo.upsert(USER_A, "ExponentPushToken[x]", "ios");
+    await repo.upsert(USER_B, "ExponentPushToken[y]", "ios");
+    await repo.deleteTokens(["ExponentPushToken[x]", "ExponentPushToken[y]"]);
+    const rows = await db.select().from(pushToken);
+    expect(rows).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+pnpm --filter server test:integration tokens.repository
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`apps/server/src/features/notifications/tokens.repository.ts`:
+
+```typescript
+import { and, eq, inArray } from "drizzle-orm";
+import { pushToken } from "@pruvi/db/schema/push-tokens";
+import type { db } from "@pruvi/db";
+
+type DbClient = typeof db;
+
+export class TokensRepository {
+  constructor(private db: DbClient) {}
+
+  /** Upsert by token: insert or reassign user_id + refresh last_used_at. */
+  async upsert(userId: string, token: string, platform: "ios" | "android") {
+    const [row] = await this.db
+      .insert(pushToken)
+      .values({ userId, token, platform })
+      .onConflictDoUpdate({
+        target: pushToken.token,
+        set: { userId, platform, lastUsedAt: new Date() },
+      })
+      .returning();
+    return row;
+  }
+
+  async listByUser(userId: string) {
+    return this.db
+      .select()
+      .from(pushToken)
+      .where(eq(pushToken.userId, userId));
+  }
+
+  /** Delete a single token only if it belongs to userId. Silent if not. */
+  async deleteForUser(userId: string, token: string) {
+    await this.db
+      .delete(pushToken)
+      .where(and(eq(pushToken.userId, userId), eq(pushToken.token, token)));
+  }
+
+  /** Delete a set of tokens regardless of owner (used by receipt pruning). */
+  async deleteTokens(tokens: string[]) {
+    if (tokens.length === 0) return;
+    await this.db.delete(pushToken).where(inArray(pushToken.token, tokens));
+  }
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+```bash
+pnpm --filter server test:integration tokens.repository
+```
+Expected: PASS — all 5 cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/features/notifications/tokens.repository.ts apps/server/src/features/notifications/tokens.repository.integration.test.ts
+git commit -m "feat(notifications): tokens repository with upsert"
+```
+
+---
+
+## Task 9: Tokens service + route
+
+**Files:**
+- Create: `apps/server/src/features/notifications/tokens.service.ts`
+- Create: `apps/server/src/features/notifications/tokens.service.test.ts`
+- Create: `apps/server/src/features/notifications/tokens.route.ts`
+
+- [ ] **Step 1: Failing unit tests**
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { TokensService } from "./tokens.service";
+
+function stubRepo(overrides: any = {}) {
+  return {
+    upsert: vi.fn().mockResolvedValue({ id: 1, token: "t", platform: "ios", userId: "u", lastUsedAt: new Date(), createdAt: new Date() }),
+    deleteForUser: vi.fn().mockResolvedValue(undefined),
+    listByUser: vi.fn().mockResolvedValue([]),
+    deleteTokens: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("TokensService.register", () => {
+  it("returns the upserted row data on success", async () => {
+    const repo = stubRepo();
+    const service = new TokensService(repo as any);
+    const result = await service.register("u", "ExponentPushToken[a]", "ios");
+    expect(result.isOk()).toBe(true);
+    expect(repo.upsert).toHaveBeenCalledWith("u", "ExponentPushToken[a]", "ios");
+  });
+});
+
+describe("TokensService.unregister", () => {
+  it("calls deleteForUser and returns ok regardless", async () => {
+    const repo = stubRepo();
+    const service = new TokensService(repo as any);
+    const result = await service.unregister("u", "ExponentPushToken[a]");
+    expect(result.isOk()).toBe(true);
+    expect(repo.deleteForUser).toHaveBeenCalledWith("u", "ExponentPushToken[a]");
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+pnpm --filter server test tokens.service.test
+```
+
+- [ ] **Step 3: Implement service**
+
+`apps/server/src/features/notifications/tokens.service.ts`:
+
+```typescript
+import { ok, type Result } from "neverthrow";
+import type { AppError } from "../../utils/errors";
+import type { TokensRepository } from "./tokens.repository";
+
+export class TokensService {
+  constructor(private repo: TokensRepository) {}
+
+  async register(
+    userId: string,
+    token: string,
+    platform: "ios" | "android",
+  ): Promise<Result<{ id: number; token: string; platform: "ios" | "android" }, AppError>> {
+    const row = await this.repo.upsert(userId, token, platform);
+    return ok({ id: row.id, token: row.token, platform: row.platform });
+  }
+
+  async unregister(userId: string, token: string): Promise<Result<null, AppError>> {
+    await this.repo.deleteForUser(userId, token);
+    return ok(null);
+  }
+
+  /** Used by dispatcher. */
+  async listTokensForUser(userId: string): Promise<string[]> {
+    const rows = await this.repo.listByUser(userId);
+    return rows.map((r) => r.token);
+  }
+}
+```
+
+- [ ] **Step 4: Confirm tests pass**
+
+```bash
+pnpm --filter server test tokens.service.test
+```
+
+- [ ] **Step 5: Implement route**
+
+`apps/server/src/features/notifications/tokens.route.ts`:
+
+```typescript
+import { z } from "zod";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { RegisterPushTokenBodySchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { successResponse, unwrapResult } from "../../types";
+import { TokensRepository } from "./tokens.repository";
+import { TokensService } from "./tokens.service";
+
+const repo = new TokensRepository(db);
+const service = new TokensService(repo);
+
+export const tokensRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.post(
+    "/users/me/push-tokens",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { body: RegisterPushTokenBodySchema },
+    },
+    async (request) => {
+      const { token, platform } = request.body;
+      const result = await service.register(request.userId, token, platform);
+      return unwrapResult(result);
+    },
+  );
+
+  fastify.delete(
+    "/users/me/push-tokens/:token",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { params: z.object({ token: z.string() }) },
+    },
+    async (request, reply) => {
+      const { token } = request.params;
+      await service.unregister(request.userId, token);
+      reply.status(204).send();
+    },
+  );
+};
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/server/src/features/notifications/tokens.service.ts apps/server/src/features/notifications/tokens.service.test.ts apps/server/src/features/notifications/tokens.route.ts
+git commit -m "feat(notifications): tokens service + register/delete routes"
+```
+
+---
+
+## Task 10: Preferences (repo + service + route)
+
+**Files:**
+- Create: `apps/server/src/features/notifications/preferences.repository.ts`
+- Create: `apps/server/src/features/notifications/preferences.service.ts`
+- Create: `apps/server/src/features/notifications/preferences.service.test.ts`
+- Create: `apps/server/src/features/notifications/preferences.route.ts`
+
+- [ ] **Step 1: Failing unit tests**
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { PreferencesService } from "./preferences.service";
+
+function stubRepo(overrides: any = {}) {
+  return {
+    get: vi.fn().mockResolvedValue({
+      notificationHour: 19,
+      streakRemindersEnabled: true,
+      achievementNotificationsEnabled: true,
+    }),
+    update: vi.fn().mockImplementation(async (_userId, patch) => ({
+      notificationHour: patch.notificationHour ?? 19,
+      streakRemindersEnabled: patch.streakRemindersEnabled ?? true,
+      achievementNotificationsEnabled: patch.achievementNotificationsEnabled ?? true,
+    })),
+    ...overrides,
+  };
+}
+
+describe("PreferencesService.get", () => {
+  it("returns ok with prefs from repo", async () => {
+    const repo = stubRepo();
+    const service = new PreferencesService(repo as any);
+    const result = await service.get("u");
+    expect(result._unsafeUnwrap()).toMatchObject({
+      notificationHour: 19,
+      streakRemindersEnabled: true,
+      achievementNotificationsEnabled: true,
+    });
+  });
+
+  it("returns NotFoundError when repo returns null", async () => {
+    const repo = stubRepo({ get: vi.fn().mockResolvedValue(null) });
+    const service = new PreferencesService(repo as any);
+    const result = await service.get("u");
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("PreferencesService.update", () => {
+  it("applies partial patch", async () => {
+    const repo = stubRepo();
+    const service = new PreferencesService(repo as any);
+    const result = await service.update("u", { notificationHour: 20 });
+    expect(result._unsafeUnwrap().notificationHour).toBe(20);
+    expect(repo.update).toHaveBeenCalledWith("u", { notificationHour: 20 });
+  });
+
+  it("rejects an out-of-range hour", async () => {
+    const repo = stubRepo();
+    const service = new PreferencesService(repo as any);
+    const result = await service.update("u", { notificationHour: 25 });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("rejects a negative hour", async () => {
+    const repo = stubRepo();
+    const service = new PreferencesService(repo as any);
+    const result = await service.update("u", { notificationHour: -1 });
+    expect(result.isErr()).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+pnpm --filter server test preferences.service.test
+```
+
+- [ ] **Step 3: Implement repository**
+
+`apps/server/src/features/notifications/preferences.repository.ts`:
+
+```typescript
+import { eq } from "drizzle-orm";
+import { user } from "@pruvi/db/schema/auth";
+import type { db } from "@pruvi/db";
+
+type DbClient = typeof db;
+
+export type PrefsRow = {
+  notificationHour: number;
+  streakRemindersEnabled: boolean;
+  achievementNotificationsEnabled: boolean;
+};
+
+export type PrefsPatch = Partial<PrefsRow>;
+
+export class PreferencesRepository {
+  constructor(private db: DbClient) {}
+
+  async get(userId: string): Promise<PrefsRow | null> {
+    const [row] = await this.db
+      .select({
+        notificationHour: user.notificationHour,
+        streakRemindersEnabled: user.streakRemindersEnabled,
+        achievementNotificationsEnabled: user.achievementNotificationsEnabled,
+      })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async update(userId: string, patch: PrefsPatch): Promise<PrefsRow | null> {
+    const [row] = await this.db
+      .update(user)
+      .set(patch)
+      .where(eq(user.id, userId))
+      .returning({
+        notificationHour: user.notificationHour,
+        streakRemindersEnabled: user.streakRemindersEnabled,
+        achievementNotificationsEnabled: user.achievementNotificationsEnabled,
+      });
+    return row ?? null;
+  }
+}
+```
+
+- [ ] **Step 4: Implement service**
+
+`apps/server/src/features/notifications/preferences.service.ts`:
+
+```typescript
+import { err, ok, type Result } from "neverthrow";
+import { NotFoundError, ValidationError, type AppError } from "../../utils/errors";
+import type {
+  PreferencesRepository,
+  PrefsPatch,
+  PrefsRow,
+} from "./preferences.repository";
+
+export class PreferencesService {
+  constructor(private repo: PreferencesRepository) {}
+
+  async get(userId: string): Promise<Result<PrefsRow, AppError>> {
+    const prefs = await this.repo.get(userId);
+    if (!prefs) return err(new NotFoundError("User not found"));
+    return ok(prefs);
+  }
+
+  async update(userId: string, patch: PrefsPatch): Promise<Result<PrefsRow, AppError>> {
+    if (patch.notificationHour !== undefined) {
+      if (
+        !Number.isInteger(patch.notificationHour) ||
+        patch.notificationHour < 0 ||
+        patch.notificationHour > 23
+      ) {
+        return err(new ValidationError("notificationHour must be 0–23"));
+      }
+    }
+    const updated = await this.repo.update(userId, patch);
+    if (!updated) return err(new NotFoundError("User not found"));
+    return ok(updated);
+  }
+}
+```
+
+- [ ] **Step 5: Run, confirm pass**
+
+```bash
+pnpm --filter server test preferences.service.test
+```
+Expected: PASS.
+
+- [ ] **Step 6: Implement route**
+
+`apps/server/src/features/notifications/preferences.route.ts`:
+
+```typescript
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { UpdateNotificationPreferencesBodySchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { successResponse, unwrapResult } from "../../types";
+import { PreferencesRepository } from "./preferences.repository";
+import { PreferencesService } from "./preferences.service";
+
+const repo = new PreferencesRepository(db);
+const service = new PreferencesService(repo);
+
+const PREFS_TTL = 60;
+
+export const preferencesRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/users/me/notification-preferences",
+    { preHandler: [fastify.authenticate] },
+    async (request) => {
+      const cacheKey = `prefs:notif:${request.userId}`;
+      const cached = await fastify.cache.get<unknown>(cacheKey);
+      if (cached) return successResponse(cached);
+
+      const result = await service.get(request.userId);
+      const response = unwrapResult(result);
+      await fastify.cache.set(cacheKey, response.data, PREFS_TTL);
+      return response;
+    },
+  );
+
+  fastify.put(
+    "/users/me/notification-preferences",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { body: UpdateNotificationPreferencesBodySchema },
+    },
+    async (request) => {
+      const result = await service.update(request.userId, request.body);
+      const response = unwrapResult(result);
+      await fastify.cache.del(`prefs:notif:${request.userId}`);
+      return response;
+    },
+  );
+};
+```
+
+- [ ] **Step 7: Module index**
+
+`apps/server/src/features/notifications/index.ts`:
+
+```typescript
+export { tokensRoutes } from "./tokens.route";
+export { preferencesRoutes } from "./preferences.route";
+```
+
+- [ ] **Step 8: Register routes**
+
+In `apps/server/src/index.ts`, add the import and registrations near other features:
+```typescript
+import { tokensRoutes, preferencesRoutes } from "./features/notifications";
+// ...
+await app.register(tokensRoutes);
+await app.register(preferencesRoutes);
+```
+
+- [ ] **Step 9: Boot smoke**
+
+```bash
+pnpm dev:server
+```
+Confirm clean startup, then kill.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/server/src/features/notifications/ apps/server/src/index.ts
+git commit -m "feat(notifications): preferences endpoints + module index"
+```
+
+---
+
+## Task 11: Dispatcher service
+
+**Files:**
+- Create: `apps/server/src/features/notifications/dispatcher.ts`
+- Create: `apps/server/src/features/notifications/dispatcher.test.ts`
+
+- [ ] **Step 1: Failing tests**
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { Dispatcher } from "./dispatcher";
+
+function makeDeps(over: any = {}) {
+  return {
+    tokensService: { listTokensForUser: vi.fn().mockResolvedValue(["ExponentPushToken[a]"]) },
+    prefsRepo: { get: vi.fn().mockResolvedValue({ notificationHour: 19, streakRemindersEnabled: true, achievementNotificationsEnabled: true }) },
+    sweepRepo: {
+      findEligibleForStreakReminder: vi.fn().mockResolvedValue([
+        { userId: "u1", token: "ExponentPushToken[u1]" },
+        { userId: "u2", token: "ExponentPushToken[u2]" },
+      ]),
+    },
+    sendQueue: { add: vi.fn().mockResolvedValue(undefined) },
+    ...over,
+  };
+}
+
+describe("Dispatcher.sendAchievementNotification", () => {
+  it("bails when achievement_notifications_enabled is false", async () => {
+    const deps = makeDeps({
+      prefsRepo: {
+        get: vi.fn().mockResolvedValue({ notificationHour: 19, streakRemindersEnabled: true, achievementNotificationsEnabled: false }),
+      },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.sendAchievementNotification("u", "7-day-streak");
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("bails when user has no tokens", async () => {
+    const deps = makeDeps({
+      tokensService: { listTokensForUser: vi.fn().mockResolvedValue([]) },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.sendAchievementNotification("u", "7-day-streak");
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("enqueues a send job for a 7-day streak", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.sendAchievementNotification("u", "7-day-streak");
+    expect(deps.sendQueue.add).toHaveBeenCalledTimes(1);
+    const [_name, payload] = deps.sendQueue.add.mock.calls[0];
+    expect(payload.tokens).toEqual(["ExponentPushToken[a]"]);
+    expect(payload.title).toMatch(/7/);
+  });
+
+  it("includes the subtopic name in the mastery achievement body", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.sendAchievementNotification("u", "quase-mestre", { subtopicName: "Membrana" });
+    const [, payload] = deps.sendQueue.add.mock.calls[0];
+    expect(payload.body).toContain("Membrana");
+  });
+});
+
+describe("Dispatcher.dispatchStreakReminder", () => {
+  it("calls the eligibility query with hour and enqueues a send per chunk", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.dispatchStreakReminder({ brtHour: 19, variant: "primary" });
+    expect(deps.sweepRepo.findEligibleForStreakReminder).toHaveBeenCalledWith(19);
+    expect(deps.sendQueue.add).toHaveBeenCalledTimes(1);
+    const [, payload] = deps.sendQueue.add.mock.calls[0];
+    expect(payload.tokens).toEqual(["ExponentPushToken[u1]", "ExponentPushToken[u2]"]);
+  });
+
+  it("late variant queries hour minus 2 modulo 24", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.dispatchStreakReminder({ brtHour: 1, variant: "late" });
+    expect(deps.sweepRepo.findEligibleForStreakReminder).toHaveBeenCalledWith(23);
+  });
+
+  it("does nothing when no eligible users", async () => {
+    const deps = makeDeps({
+      sweepRepo: { findEligibleForStreakReminder: vi.fn().mockResolvedValue([]) },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.dispatchStreakReminder({ brtHour: 19, variant: "primary" });
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+pnpm --filter server test dispatcher.test
+```
+
+- [ ] **Step 3: Implement**
+
+`apps/server/src/features/notifications/dispatcher.ts`:
+
+```typescript
+import type { Queue } from "bullmq";
+import {
+  streakReminderPrimary,
+  streakReminderLate,
+  streakMilestone,
+  masteryAchievement,
+  type PushPayload,
+} from "./templates";
+import type { TokensService } from "./tokens.service";
+import type { PreferencesRepository } from "./preferences.repository";
+import type { SweepRepository } from "./sweep.repository";
+import { EXPO_BATCH_SIZE } from "./push.client";
+
+export type AchievementKind = "7-day-streak" | "30-day-streak" | "quase-mestre";
+
+export type SendJobData = {
+  tokens: string[];
+  title: string;
+  body: string;
+  data?: Record<string, unknown>;
+};
+
+export type DispatcherDeps = {
+  tokensService: TokensService;
+  prefsRepo: PreferencesRepository;
+  sweepRepo: SweepRepository;
+  sendQueue: Queue<SendJobData>;
+};
+
+export class Dispatcher {
+  constructor(private deps: DispatcherDeps) {}
+
+  async sendAchievementNotification(
+    userId: string,
+    kind: AchievementKind,
+    vars?: { subtopicName?: string },
+  ): Promise<void> {
+    const prefs = await this.deps.prefsRepo.get(userId);
+    if (!prefs?.achievementNotificationsEnabled) return;
+
+    const tokens = await this.deps.tokensService.listTokensForUser(userId);
+    if (tokens.length === 0) return;
+
+    let payload: PushPayload;
+    if (kind === "7-day-streak") payload = streakMilestone(7);
+    else if (kind === "30-day-streak") payload = streakMilestone(30);
+    else payload = masteryAchievement(vars?.subtopicName ?? "");
+
+    for (let i = 0; i < tokens.length; i += EXPO_BATCH_SIZE) {
+      const chunk = tokens.slice(i, i + EXPO_BATCH_SIZE);
+      await this.deps.sendQueue.add("send", {
+        tokens: chunk,
+        title: payload.title,
+        body: payload.body,
+        data: { kind },
+      });
+    }
+  }
+
+  async dispatchStreakReminder(opts: { brtHour: number; variant: "primary" | "late" }): Promise<void> {
+    const targetHour = opts.variant === "late" ? (opts.brtHour - 2 + 24) % 24 : opts.brtHour;
+    const eligible = await this.deps.sweepRepo.findEligibleForStreakReminder(targetHour);
+    if (eligible.length === 0) return;
+
+    const payload = opts.variant === "late" ? streakReminderLate() : streakReminderPrimary();
+    const tokens = eligible.map((r) => r.token);
+
+    for (let i = 0; i < tokens.length; i += EXPO_BATCH_SIZE) {
+      const chunk = tokens.slice(i, i + EXPO_BATCH_SIZE);
+      await this.deps.sendQueue.add("send", {
+        tokens: chunk,
+        title: payload.title,
+        body: payload.body,
+        data: { kind: `streak-${opts.variant}` },
+      });
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+```bash
+pnpm --filter server test dispatcher.test
+```
+Expected: PASS — 7 cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/features/notifications/dispatcher.ts apps/server/src/features/notifications/dispatcher.test.ts
+git commit -m "feat(notifications): dispatcher for streak + achievement pushes"
+```
+
+---
+
+## Task 12: Sweep repository (eligibility query)
+
+**Files:**
+- Create: `apps/server/src/features/notifications/sweep.repository.ts`
+- Create: `apps/server/src/features/notifications/notifications.sweep.integration.test.ts`
+
+- [ ] **Step 1: Failing integration tests**
+
+```typescript
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { setupTestDb, getTestDb, teardownTestDb, cleanupTestDb } from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { pushToken } from "@pruvi/db/schema/push-tokens";
+import { dailySession } from "@pruvi/db/schema/daily-sessions";
+import { SweepRepository } from "./sweep.repository";
+
+const db = getTestDb();
+const repo = new SweepRepository(db);
+
+beforeAll(async () => { await setupTestDb(); });
+afterAll(async () => { await teardownTestDb(); });
+beforeEach(async () => { await cleanupTestDb(); });
+
+describe("SweepRepository.findEligibleForStreakReminder", () => {
+  it("returns user with hour match + token + reminders enabled + no completed session today", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19, streakRemindersEnabled: true });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([{ userId: "u1", token: "ExponentPushToken[u1]" }]);
+  });
+
+  it("skips users with streakRemindersEnabled = false", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19, streakRemindersEnabled: false });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([]);
+  });
+
+  it("skips users whose hour doesn't match", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 20 });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([]);
+  });
+
+  it("skips users who have a completed session today", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19 });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    await db.insert(dailySession).values({ userId: "u1", status: "completed" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([]);
+  });
+
+  it("includes users with an active (incomplete) session today", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19 });
+    await db.insert(pushToken).values({ userId: "u1", token: "ExponentPushToken[u1]", platform: "ios" });
+    await db.insert(dailySession).values({ userId: "u1", status: "active" });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows.map((r) => r.userId)).toEqual(["u1"]);
+  });
+
+  it("returns one row per (user, token) pair when user has multiple devices", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19 });
+    await db.insert(pushToken).values([
+      { userId: "u1", token: "ExponentPushToken[a]", platform: "ios" },
+      { userId: "u1", token: "ExponentPushToken[b]", platform: "android" },
+    ]);
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows.map((r) => r.token).sort()).toEqual(["ExponentPushToken[a]", "ExponentPushToken[b]"]);
+  });
+
+  it("skips users with no push tokens", async () => {
+    await db.insert(user).values({ id: "u1", name: "U1", email: "u1@x.com", notificationHour: 19 });
+    const rows = await repo.findEligibleForStreakReminder(19);
+    expect(rows).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+pnpm --filter server test:integration notifications.sweep
+```
+
+- [ ] **Step 3: Implement**
+
+`apps/server/src/features/notifications/sweep.repository.ts`:
+
+```typescript
+import { sql } from "drizzle-orm";
+import type { db } from "@pruvi/db";
+
+type DbClient = typeof db;
+
+export class SweepRepository {
+  constructor(private db: DbClient) {}
+
+  async findEligibleForStreakReminder(brtHour: number): Promise<Array<{ userId: string; token: string }>> {
+    const rows = await this.db.execute(sql<{ user_id: string; token: string }>`
+      SELECT u.id AS user_id, pt.token
+      FROM "user" u
+      JOIN "push_token" pt ON pt.user_id = u.id
+      WHERE u.streak_reminders_enabled = TRUE
+        AND u.notification_hour = ${brtHour}
+        AND NOT EXISTS (
+          SELECT 1 FROM "daily_session" ds
+          WHERE ds.user_id = u.id
+            AND ds.status = 'completed'
+            AND ds.created_at::date = (NOW() AT TIME ZONE 'America/Sao_Paulo')::date
+        )
+    `);
+    return (rows as any).rows
+      ? (rows as any).rows.map((r: any) => ({ userId: r.user_id, token: r.token }))
+      : (rows as any).map((r: any) => ({ userId: r.user_id, token: r.token }));
+  }
+}
+```
+
+Note: `db.execute(sql\`...\`)` shape varies between node-postgres and PGlite. The conditional handling at the end accommodates both. If your environment produces a single consistent shape, simplify accordingly during implementation.
+
+- [ ] **Step 4: Run, confirm pass**
+
+```bash
+pnpm --filter server test:integration notifications.sweep
+```
+Expected: PASS — 7 cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/features/notifications/sweep.repository.ts apps/server/src/features/notifications/notifications.sweep.integration.test.ts
+git commit -m "feat(notifications): sweep eligibility query"
+```
+
+---
+
+## Task 13: Queue plugin — register notifications queues + cron
+
+**Files:**
+- Modify: `apps/server/src/plugins/queue.ts`
+
+- [ ] **Step 1: Extend the plugin**
+
+Replace the contents of `apps/server/src/plugins/queue.ts`:
+
+```typescript
+import type { FastifyInstance, FastifyPluginAsync } from "fastify";
+import fp from "fastify-plugin";
+import { Queue } from "bullmq";
+import { env } from "@pruvi/env/server";
+import { parseRedisUrl } from "../utils/redis";
+import type { SendJobData } from "../features/notifications/dispatcher";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    queues: {
+      sessionPrefetch: Queue | null;
+      notificationsCron: Queue | null;
+      notificationsSend: Queue<SendJobData> | null;
+    };
+  }
+}
+
+export type SessionPrefetchJobData = {
+  userId: string;
+  mode: "all" | "theoretical";
+};
+
+export type NotificationsCronJobData = { kind: "sweep" };
+
+const plugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+  if (!env.REDIS_URL) {
+    fastify.log.info("No REDIS_URL — BullMQ queues disabled");
+    fastify.decorate("queues", { sessionPrefetch: null, notificationsCron: null, notificationsSend: null });
+    return;
+  }
+
+  const connection = parseRedisUrl(env.REDIS_URL);
+
+  const sessionPrefetchQueue = new Queue<SessionPrefetchJobData>("session-prefetch", { connection });
+  const notificationsCronQueue = new Queue<NotificationsCronJobData>("notifications-cron", { connection });
+  const notificationsSendQueue = new Queue<SendJobData>("notifications-send", { connection });
+
+  // Register hourly cron (idempotent — BullMQ dedupes repeatable jobs by name + pattern)
+  await notificationsCronQueue.add(
+    "sweep",
+    { kind: "sweep" },
+    { repeat: { pattern: "0 * * * *" }, removeOnComplete: true, removeOnFail: true },
+  );
+
+  fastify.decorate("queues", {
+    sessionPrefetch: sessionPrefetchQueue,
+    notificationsCron: notificationsCronQueue,
+    notificationsSend: notificationsSendQueue,
+  });
+
+  fastify.addHook("onClose", async () => {
+    await Promise.all([
+      sessionPrefetchQueue.close(),
+      notificationsCronQueue.close(),
+      notificationsSendQueue.close(),
+    ]);
+  });
+};
+
+export const queuePlugin = fp(plugin, {
+  name: "queue",
+  dependencies: ["redis"],
+});
+```
+
+- [ ] **Step 2: Boot smoke**
+
+```bash
+pnpm dev:server
+```
+Confirm clean startup (Redis must be running). Kill.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/server/src/plugins/queue.ts
+git commit -m "feat(queue): register notifications-cron + notifications-send queues"
+```
+
+---
+
+## Task 14: Notifications worker
+
+**Files:**
+- Create: `apps/server/src/workers/notifications.worker.ts`
+- Modify: `apps/server/src/worker.ts`
+
+- [ ] **Step 1: Implement worker**
+
+`apps/server/src/workers/notifications.worker.ts`:
+
+```typescript
+import { Worker, Queue, type Job } from "bullmq";
+import Expo from "expo-server-sdk";
+import { env } from "@pruvi/env/server";
+import { db } from "@pruvi/db";
+import { parseRedisUrl } from "../utils/redis";
+import { TokensRepository } from "../features/notifications/tokens.repository";
+import { TokensService } from "../features/notifications/tokens.service";
+import { PreferencesRepository } from "../features/notifications/preferences.repository";
+import { SweepRepository } from "../features/notifications/sweep.repository";
+import { Dispatcher, type SendJobData } from "../features/notifications/dispatcher";
+import { PushClient } from "../features/notifications/push.client";
+
+export function startNotificationsWorker() {
+  if (!env.REDIS_URL) {
+    console.log("No REDIS_URL — notifications worker disabled");
+    return null;
+  }
+
+  const connection = parseRedisUrl(env.REDIS_URL);
+
+  const tokensRepo = new TokensRepository(db);
+  const prefsRepo = new PreferencesRepository(db);
+  const sweepRepo = new SweepRepository(db);
+  const tokensService = new TokensService(tokensRepo);
+  const sendQueue = new Queue<SendJobData>("notifications-send", { connection });
+  const dispatcher = new Dispatcher({ tokensService, prefsRepo, sweepRepo, sendQueue });
+
+  const expo = new Expo(env.EXPO_ACCESS_TOKEN ? { accessToken: env.EXPO_ACCESS_TOKEN } : {});
+  const pushClient = new PushClient(expo);
+
+  // Cron worker
+  const cronWorker = new Worker(
+    "notifications-cron",
+    async (_job: Job<{ kind: "sweep" }>) => {
+      const utcHour = new Date().getUTCHours();
+      const brtHour = (utcHour + 24 - 3) % 24;
+      await dispatcher.dispatchStreakReminder({ brtHour, variant: "primary" });
+      await dispatcher.dispatchStreakReminder({ brtHour, variant: "late" });
+      return { brtHour };
+    },
+    { connection, concurrency: 1 },
+  );
+
+  // Send worker
+  const sendWorker = new Worker<SendJobData>(
+    "notifications-send",
+    async (job: Job<SendJobData>) => {
+      const { tokens, title, body, data } = job.data;
+      const tickets = await pushClient.sendBatch(tokens, { title, body }, data);
+      const pruned = pushClient.pruneTokensFromTickets(tokens, tickets);
+      if (pruned.length > 0) {
+        await tokensRepo.deleteTokens(pruned);
+      }
+      return { sent: tokens.length, pruned: pruned.length };
+    },
+    { connection, concurrency: 5 },
+  );
+
+  cronWorker.on("failed", (job, err) => console.error("cron job failed:", job?.id, err));
+  sendWorker.on("failed", (job, err) => console.error("send job failed:", job?.id, err));
+
+  const cleanup = async () => {
+    await Promise.all([cronWorker.close(), sendWorker.close(), sendQueue.close()]);
+  };
+
+  return { cleanup };
+}
+```
+
+- [ ] **Step 2: Start it from the worker entrypoint**
+
+Replace `apps/server/src/worker.ts`:
+
+```typescript
+import { startSessionPrefetchWorker } from "./workers/session-prefetch.worker";
+import { startNotificationsWorker } from "./workers/notifications.worker";
+
+const prefetch = startSessionPrefetchWorker();
+const notifications = startNotificationsWorker();
+
+if (!prefetch && !notifications) {
+  console.error("All workers failed to start — REDIS_URL required");
+  process.exit(1);
+}
+
+console.log("Workers started: ", {
+  prefetch: !!prefetch,
+  notifications: !!notifications,
+});
+
+const shutdown = async () => {
+  console.log("Shutting down workers...");
+  if (prefetch) await prefetch.cleanup();
+  if (notifications) await notifications.cleanup();
+  process.exit(0);
+};
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+```
+
+- [ ] **Step 3: Boot smoke**
+
+```bash
+pnpm dev:worker
+```
+Confirm both workers register. Kill.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/server/src/workers/notifications.worker.ts apps/server/src/worker.ts
+git commit -m "feat(worker): notifications cron + send workers"
+```
+
+---
+
+## Task 15: Wire achievement hooks into sessions.completeSession
+
+**Files:**
+- Modify: `apps/server/src/features/sessions/sessions.service.ts`
+- Modify: `apps/server/src/features/sessions/sessions.route.ts`
+
+- [ ] **Step 1: Inject dispatcher into SessionsService**
+
+Find the existing `SessionsService` constructor (3 args: repo, questionsService, topicsService). Add a 4th optional arg for the dispatcher. Updated constructor:
+
+```typescript
+import type { Dispatcher } from "../notifications/dispatcher";
+import type { StreaksService } from "../streaks/streaks.service";
+
+export class SessionsService {
+  constructor(
+    private repo: SessionsRepository,
+    private questionsService: QuestionsService,
+    private topicsService: TopicsService,
+    private streaksService: StreaksService | null = null,
+    private dispatcher: Dispatcher | null = null,
+  ) {}
+```
+
+(Defaults to `null` so existing test instantiations don't break; production wiring passes both.)
+
+- [ ] **Step 2: Fire achievements in `completeSession`**
+
+In `completeSession`, after `const completed = await this.repo.completeSession(...)` and before the final `return ok(...)`, add:
+
+```typescript
+// Fire-and-forget achievement notifications
+if (this.dispatcher) {
+  // Streak milestone push (7d or 30d)
+  if (this.streaksService) {
+    this.streaksService
+      .getStreaks(userId)
+      .then((r) => {
+        if (r.isOk() && (r.value.currentStreak === 7 || r.value.currentStreak === 30)) {
+          this.dispatcher!
+            .sendAchievementNotification(userId, `${r.value.currentStreak}-day-streak` as "7-day-streak" | "30-day-streak")
+            .catch((e) => console.error("streak achievement push failed", e));
+        }
+      })
+      .catch((e) => console.error("streak read failed in achievement hook", e));
+  }
+
+  // Mastery achievement push (per quase_mestre transition)
+  for (const t of transitions) {
+    if (t.to === "quase_mestre") {
+      this.dispatcher
+        .sendAchievementNotification(userId, "quase-mestre", { subtopicName: t.name })
+        .catch((e) => console.error("mastery achievement push failed", e));
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Wire dispatcher in the route**
+
+In `sessions.route.ts`, after the existing service instantiation, add:
+
+```typescript
+import { TokensRepository } from "../notifications/tokens.repository";
+import { TokensService } from "../notifications/tokens.service";
+import { PreferencesRepository } from "../notifications/preferences.repository";
+import { SweepRepository } from "../notifications/sweep.repository";
+import { Dispatcher } from "../notifications/dispatcher";
+import { StreaksRepository } from "../streaks/streaks.repository";
+import { StreaksService } from "../streaks/streaks.service";
+
+const tokensRepo = new TokensRepository(db);
+const prefsRepo = new PreferencesRepository(db);
+const sweepRepo = new SweepRepository(db);
+const tokensService = new TokensService(tokensRepo);
+const streaksRepo = new StreaksRepository(db);
+const streaksService = new StreaksService(streaksRepo);
+```
+
+For the dispatcher we need the `notificationsSend` queue from the fastify plugin. The cleanest path: inject lazily inside the route plugin function via `fastify.queues.notificationsSend`. Wrap the service instantiation inside the plugin async fn instead of at module scope:
+
+```typescript
+export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const dispatcher = fastify.queues.notificationsSend
+    ? new Dispatcher({
+        tokensService,
+        prefsRepo,
+        sweepRepo,
+        sendQueue: fastify.queues.notificationsSend,
+      })
+    : null;
+  const service = new SessionsService(sessionsRepo, questionsService, topicsService, streaksService, dispatcher);
+
+  // ... existing route handlers (refer to `service`)
+};
+```
+
+(If the existing route file has `service` at module scope, refactor it to live inside the plugin function. The closure-captured `service` still works for handlers.)
+
+- [ ] **Step 4: Update existing tests for the new constructor**
+
+Where `new SessionsService(repo, questionsService, topicsService)` is called in tests, leave as-is — the new params default to null. Confirm the test suite still passes:
+
+```bash
+pnpm --filter server test sessions.service
+```
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+pnpm --filter server test
+pnpm --filter server test:integration
+```
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/server/src/features/sessions/
+git commit -m "feat(sessions): fire achievement notifications on complete"
+```
+
+---
+
+## Task 16: End-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Migration smoke**
+
+```bash
+pnpm verify:migration
+```
+Expected: PASS — `push_token` and the 3 user columns queryable.
+
+- [ ] **Step 2: Full test suite**
+
+```bash
+pnpm --filter server test
+pnpm --filter server test:integration
+pnpm --filter @pruvi/shared test
+```
+Expected: PASS (modulo pre-existing `sm2.test.ts` failures in `@pruvi/shared` unrelated to this phase).
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+pnpm run check-types
+```
+Expected: zero NEW non-test errors. Pre-existing test typecheck noise carries over.
+
+- [ ] **Step 4: Server boot smoke**
+
+```bash
+pnpm dev:server &
+SERVER_PID=$!
+sleep 3
+kill $SERVER_PID 2>/dev/null
+```
+
+- [ ] **Step 5: Worker boot smoke**
+
+```bash
+pnpm dev:worker &
+WORKER_PID=$!
+sleep 3
+kill $WORKER_PID 2>/dev/null
+```
+Confirm logs show both `session-prefetch` and `notifications` workers started, plus the `notifications-cron` queue registered.
+
+- [ ] **Step 6: Cron registration check**
+
+```bash
+docker exec -i $(docker ps --filter "name=redis" -q | head -1) redis-cli ZRANGE "bull:notifications-cron:repeat" 0 -1
+```
+Expected: one entry for the `sweep` repeatable job.
+
+- [ ] **Step 7: Final commit if needed**
+
+```bash
+git status
+```
+If anything is dirty:
+
+```bash
+git add -A
+git commit -m "chore: end-to-end verification fixes"
+```
+
+---
+
+## Self-review notes (resolved while writing)
+
+- **Spec coverage:** every section of the spec maps to a task — data model (Tasks 2-4), API surface (Tasks 9-10), scheduling architecture (Tasks 11-14), event hooks (Task 15), templates (Task 6), testing strategy (covered within each task).
+- **Achievement hook placement:** all achievement firings happen in `sessions.service.completeSession`. Streak milestones use `streaksService.getStreaks` to read the new currentStreak (no event emitter pattern needed — leverages existing read-side API).
+- **Sweep query** uses `NOW() AT TIME ZONE 'America/Sao_Paulo'` to align with the streak service's existing day-boundary convention.
+- **Fire-and-forget:** all achievement dispatch is `.catch()`-wrapped so push failures never poison the HTTP response.
+- **EXPO_BATCH_SIZE = 100** is a constant in `push.client.ts` and consumed by `dispatcher.ts` — single source of truth.
+- **Defaults on new user columns** mean migration 0004 needs no backfill — Postgres applies the defaults to existing rows automatically.
+
+---
+
+*End of plan.*

--- a/docs/superpowers/specs/2026-05-10-phase-2b-push-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-10-phase-2b-push-notifications-design.md
@@ -1,0 +1,270 @@
+# Phase 2B — Push Notifications (Design Spec)
+
+**Date:** 2026-05-10
+**Phase:** 2B
+**Source spec:** `pruvi-freatures.md` §3.4 (Streak diário — push às 19h), §6.1 (Notificações push), §6.3 (configurações — horário editável)
+
+## Goal
+
+Ship the push-notification pipeline for streak reminders and achievement notifications. Two scheduled streak reminders (19h + 21h BRT for users who haven't trained today), plus event-triggered notifications for 7d/30d streak milestones and "quase mestre" mastery transitions. Per-type opt-out via user preferences. Expo Push API as the delivery backend.
+
+## Non-goals
+
+- Frontend UI for notification preferences (frontend rebuild owns this; the API + storage ship here).
+- A/B testing of message copy.
+- Delivery analytics dashboard (logs are sufficient for MVP — Expo's receipts API gives 24h of delivery data on demand).
+- Per-user IANA timezones (single timezone — America/Sao_Paulo — for MVP per audience targeting).
+- Quiet hours / Do Not Disturb integration.
+- Editable `notification_hour` from the settings UI (column ready; UI wires later).
+
+## Data Model
+
+### New table
+
+```
+push_token
+  id            serial PK
+  user_id       text NOT NULL REFERENCES "user"(id) ON DELETE CASCADE
+  token         text NOT NULL UNIQUE
+  platform      text NOT NULL  CHECK (platform IN ('ios','android'))
+  last_used_at  timestamp NOT NULL DEFAULT now()
+  created_at    timestamp NOT NULL DEFAULT now()
+  INDEX (user_id)
+```
+
+**Why `UNIQUE (token)` not `(user_id, token)`:** Expo tokens uniquely identify a device installation. If a device's user changes (sign-out then sign-in as another account), the `ON CONFLICT (token) DO UPDATE` upsert at the register endpoint reassigns the row's `user_id` cleanly. A compound key would leave a dangling token under the old account.
+
+### Extensions on `user`
+
+```
++ notification_hour                   integer NOT NULL DEFAULT 19
++ streak_reminders_enabled            boolean NOT NULL DEFAULT true
++ achievement_notifications_enabled   boolean NOT NULL DEFAULT true
++ CHECK CONSTRAINT user_notification_hour_chk: notification_hour BETWEEN 0 AND 23
+```
+
+Flat columns (not a side table) follow the established `selectedExam`/`difficulties` pattern. Prefs are always co-fetched with the user; a separate table adds a JOIN with no isolation benefit.
+
+## Architecture
+
+### Feature module
+
+```
+apps/server/src/features/notifications/
+  index.ts                  # tokensRoutes + preferencesRoutes exports
+  push.client.ts            # Wrapper over expo-server-sdk: sendBatch(messages[])
+  templates.ts              # Pure PT-BR string builders per notification kind
+  dispatcher.ts             # buildAndSendStreakReminders(brtHour, variant), sendAchievementNotification(userId, kind, vars)
+  tokens.repository.ts
+  tokens.service.ts
+  tokens.route.ts
+  preferences.repository.ts
+  preferences.service.ts
+  preferences.route.ts
+  tokens.service.test.ts
+  preferences.service.test.ts
+  dispatcher.test.ts
+  templates.test.ts
+  push.client.test.ts
+  tokens.repository.integration.test.ts
+  notifications.sweep.integration.test.ts
+```
+
+### Queue & worker
+
+- `apps/server/src/plugins/queue.ts` registers two queues:
+  - `notifications-cron` — repeatable job at `pattern: '0 * * * *'` (top of each UTC hour). Job data: `{ kind: 'sweep' }`.
+  - `notifications-send` — fan-out queue for batched sends. Job data: `{ tokens: string[], title, body, data? }`.
+- `apps/server/src/workers/notifications.worker.ts` (new) subscribes to both queues. Started from the existing worker entrypoint alongside `session-prefetch.worker.ts`. Single worker process (`PROCESS_TYPE=worker`).
+
+### Event hooks for achievements (in-process, fire-and-forget)
+
+- `streaks.service` — after streak update, if `newStreak === 7 || newStreak === 30`:
+  ```typescript
+  dispatcher.sendAchievementNotification(userId, `${newStreak}-day-streak`)
+    .catch((e) => log.error({ err: e }, "achievement push failed"));
+  ```
+- `sessions.service.completeSession` — before returning, for each upward transition where `to === 'quase_mestre'`:
+  ```typescript
+  dispatcher.sendAchievementNotification(userId, 'quase-mestre', { subtopicName: t.name })
+    .catch((e) => log.error({ err: e }, "mastery push failed"));
+  ```
+
+Fire-and-forget is deliberate: a missed push is a UX nick; a 500 on `complete` is a regression. The dispatcher reads opt-in prefs, loads tokens, builds the payload, and enqueues a `notifications-send` job — never blocking on Expo's HTTP round-trip.
+
+## API Surface
+
+All endpoints require auth and return the standard `{ success: true, data: ... }` envelope.
+
+### `POST /users/me/push-tokens`
+
+Body:
+```json
+{ "token": "ExponentPushToken[...]", "platform": "ios" }
+```
+
+Behavior: `ON CONFLICT (token) DO UPDATE` — sets `user_id = request.userId`, refreshes `last_used_at`.
+
+Response:
+```json
+{ "id": 42, "token": "ExponentPushToken[...]", "platform": "ios" }
+```
+
+Validation: `token` must match `/^Expo(nent)?PushToken\[.+\]$/`. Bogus tokens still get rejected at send time by Expo + pruned via receipt handling.
+
+### `DELETE /users/me/push-tokens/:token`
+
+Deletes only if owned by `request.userId`. Returns 204 either way (no token enumeration). Same defensive pattern as `DELETE /users/me` (LGPD).
+
+### `GET /users/me/notification-preferences`
+
+Response:
+```json
+{
+  "notificationHour": 19,
+  "streakRemindersEnabled": true,
+  "achievementNotificationsEnabled": true
+}
+```
+
+Cached: `prefs:notif:{userId}` (60s TTL, invalidated on PUT).
+
+### `PUT /users/me/notification-preferences`
+
+Partial body — any subset of the fields above. Server-side validation:
+- `notificationHour`: integer 0–23
+- Booleans: standard Zod parse
+
+Response: full prefs after update. Invalidates the cache key.
+
+## Scheduling
+
+### Hourly sweep
+
+`notifications-cron` fires at `0 * * * *` UTC. Handler:
+
+```typescript
+const utcHour = new Date().getUTCHours();
+const brtHour = (utcHour + 24 - 3) % 24;
+
+await dispatchStreakReminder({ brtHour, variant: 'primary' });
+await dispatchStreakReminder({ brtHour, variant: 'late' });
+```
+
+### Eligibility query (per variant)
+
+```sql
+SELECT u.id, pt.token
+FROM "user" u
+JOIN push_token pt ON pt.user_id = u.id
+WHERE u.streak_reminders_enabled = true
+  AND u.notification_hour = $1                                    -- primary: brtHour. late: brtHour - 2 (with mod 24)
+  AND NOT EXISTS (
+    SELECT 1 FROM daily_session ds
+    WHERE ds.user_id = u.id
+      AND ds.status = 'completed'
+      AND ds.created_at::date = (now() AT TIME ZONE 'America/Sao_Paulo')::date
+  )
+```
+
+Result rows chunked to 100 (Expo batch limit), each chunk enqueued as a `notifications-send` job.
+
+### `notifications-send` handler
+
+1. Call `expo.sendPushNotificationsAsync(chunk)`.
+2. Inspect tickets: for any `DeviceNotRegistered` status (or matching error in receipts), delete the offending token row from `push_token`.
+3. Log `{ userId, kind, tokenCount, expoTicketIds }` to structured logger.
+
+### Achievement dispatch
+
+`sendAchievementNotification(userId, kind, vars?)`:
+1. Read `achievement_notifications_enabled` (cached). If false → return.
+2. Load all `push_token.token` for the user.
+3. Build payload via `templates.ts`.
+4. Enqueue a `notifications-send` job.
+
+## Message Templates (`templates.ts`)
+
+Pure PT-BR string builders, no engine, no DB.
+
+```typescript
+export const streakReminderPrimary = (): PushPayload => ({
+  title: "A Pruvi te esperou hoje 💛",
+  body: "Ainda dá tempo — 5 minutos é o suficiente.",
+});
+
+export const streakReminderLate = (): PushPayload => ({
+  title: "Seu streak está em risco",
+  body: "Uma sessão rápida segura o ritmo.",
+});
+
+export const streakMilestone = (days: 7 | 30): PushPayload => ({
+  title: `${days} dias de streak! 🔥`,
+  body: days === 7
+    ? "Uma semana firme. Tá pegando o jeito."
+    : "Um mês. Isso é dedicação real.",
+});
+
+export const masteryAchievement = (subtopicName: string): PushPayload => ({
+  title: "Quase mestre! ⭐",
+  body: `Você está dominando ${subtopicName}.`,
+});
+```
+
+Edits ship via PR review alongside other code changes. If/when A/B testing copy becomes a need, swap in a strategy interface — not today.
+
+## Migration `0004_<name>.sql`
+
+1. `CREATE TABLE push_token` (columns + UNIQUE on token + ON DELETE CASCADE FK on user_id + INDEX on user_id)
+2. `ALTER TABLE "user" ADD COLUMN notification_hour integer NOT NULL DEFAULT 19`
+3. `ALTER TABLE "user" ADD COLUMN streak_reminders_enabled boolean NOT NULL DEFAULT true`
+4. `ALTER TABLE "user" ADD COLUMN achievement_notifications_enabled boolean NOT NULL DEFAULT true`
+5. `ALTER TABLE "user" ADD CONSTRAINT user_notification_hour_chk CHECK (notification_hour BETWEEN 0 AND 23)`
+
+Mirror the DDL in `packages/db/src/test-client.ts` in lockstep.
+
+## Shared Schemas (`packages/shared/src/notifications.ts`)
+
+- `RegisterPushTokenBodySchema` — `{ token: z.string().regex(/^Expo(nent)?PushToken\[.+\]$/), platform: z.enum(['ios','android']) }`
+- `PushTokenResponseSchema` — `{ id, token, platform }`
+- `NotificationPreferencesSchema` — full prefs read response
+- `UpdateNotificationPreferencesBodySchema` — partial of prefs
+
+## Env
+
+`packages/env/src/server.ts` adds:
+- `EXPO_ACCESS_TOKEN: z.string().optional()` — passed to `Expo` client constructor when present (higher rate limits + receipt fetching).
+
+## Testing Strategy
+
+### Unit (Vitest, Expo client mocked)
+- `templates.test.ts` — every template returns non-empty PT-BR title + body
+- `dispatcher.test.ts` — bails on prefs-disabled; respects token list; enqueues one job per chunk
+- `tokens.service.test.ts` — register upserts; unregister scoped to user; silent on foreign-token delete
+- `preferences.service.test.ts` — partial update merges; out-of-range hour rejected
+- `push.client.test.ts` — receipt handler prunes `DeviceNotRegistered` tokens
+- Sweep handler — stubbed repo, asserts primary-vs-late filter logic
+
+### Integration (PGlite)
+- `tokens.repository.integration.test.ts` — upsert by token (re-insert same token under different user → single row, updated user_id)
+- `notifications.sweep.integration.test.ts` — seed users with various `notification_hour` values, completed/uncompleted sessions today, prefs disabled; assert eligibility query returns the exact expected set
+
+### Manual smoke (requires one Expo physical device)
+- Register a real Expo token via `POST /users/me/push-tokens`
+- Force-trigger a sweep via a one-shot dev script
+- Confirm push arrives on device
+
+## Acceptance Criteria
+
+- 4 endpoints live, type-safe, integration-tested
+- Migration 0004 applies cleanly + `verify:migration` passes
+- Hourly cron sweep registered and idempotent (replays don't double-send — Expo dedupes by `id` within batch, plus our query is naturally idempotent within an hour)
+- Achievement event hooks fire from streaks + sessions services without blocking HTTP responses
+- `DeviceNotRegistered` receipts prune the corresponding `push_token` row
+- All unit + integration tests pass
+- Worker boots clean with the new queues registered
+- Zero non-test typecheck errors
+
+---
+
+*End of spec.*

--- a/packages/db/src/migrations/0004_tense_jack_power.sql
+++ b/packages/db/src/migrations/0004_tense_jack_power.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "push_token" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"token" text NOT NULL,
+	"platform" text NOT NULL,
+	"last_used_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "push_token_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "notification_hour" integer DEFAULT 19 NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "streak_reminders_enabled" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "achievement_notifications_enabled" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "push_token" ADD CONSTRAINT "push_token_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "push_token_user_idx" ON "push_token" USING btree ("user_id");
+--> statement-breakpoint
+ALTER TABLE "user" ADD CONSTRAINT "user_notification_hour_chk" CHECK ("notification_hour" BETWEEN 0 AND 23);

--- a/packages/db/src/migrations/0004_tense_jack_power.sql
+++ b/packages/db/src/migrations/0004_tense_jack_power.sql
@@ -15,3 +15,5 @@ ALTER TABLE "push_token" ADD CONSTRAINT "push_token_user_id_user_id_fk" FOREIGN 
 CREATE INDEX "push_token_user_idx" ON "push_token" USING btree ("user_id");
 --> statement-breakpoint
 ALTER TABLE "user" ADD CONSTRAINT "user_notification_hour_chk" CHECK ("notification_hour" BETWEEN 0 AND 23);
+--> statement-breakpoint
+ALTER TABLE "push_token" ADD CONSTRAINT "push_token_platform_chk" CHECK ("platform" IN ('ios','android'));

--- a/packages/db/src/migrations/meta/0004_snapshot.json
+++ b/packages/db/src/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1079 @@
+{
+  "id": "b4442195-5bc7-4a50-a75f-a99ac8326520",
+  "prevId": "c2555d90-2fe2-4273-8262-c075f1216176",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives": {
+          "name": "lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lives_reset_at": {
+          "name": "lives_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "selected_exam": {
+          "name": "selected_exam",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulties": {
+          "name": "difficulties",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "daily_study_time_minutes": {
+          "name": "daily_study_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_session": {
+      "name": "daily_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_correct": {
+          "name": "questions_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastery_snapshot": {
+          "name": "mastery_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_session_user_created_idx": {
+          "name": "daily_session_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_session_user_id_user_id_fk": {
+          "name": "daily_session_user_id_user_id_fk",
+          "tableFrom": "daily_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subject_name_unique": {
+          "name": "subject_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "subject_slug_unique": {
+          "name": "subject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopic": {
+      "name": "subtopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtopic_topic_order_idx": {
+          "name": "subtopic_topic_order_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopic_topic_id_topic_id_fk": {
+          "name": "subtopic_topic_id_topic_id_fk",
+          "tableFrom": "subtopic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtopic_topic_slug_uniq": {
+          "name": "subtopic_topic_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topic_subject_order_idx": {
+          "name": "topic_subject_order_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_subject_id_subject_id_fk": {
+          "name": "topic_subject_id_subject_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_subject_slug_uniq": {
+          "name": "topic_subject_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_option_index": {
+          "name": "correct_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_calculation": {
+          "name": "requires_calculation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtopic_id": {
+          "name": "subtopic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_subject_difficulty_idx": {
+          "name": "question_subject_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_subtopic_difficulty_idx": {
+          "name": "question_subtopic_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_subject_id_subject_id_fk": {
+          "name": "question_subject_id_subject_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_subtopic_id_subtopic_id_fk": {
+          "name": "question_subtopic_id_subtopic_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subtopic",
+          "columnsFrom": [
+            "subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_log": {
+      "name": "review_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "easiness_factor": {
+          "name": "easiness_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_log_user_next_review_idx": {
+          "name": "review_log_user_next_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_log_user_question_idx": {
+          "name": "review_log_user_question_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_log_user_id_user_id_fk": {
+          "name": "review_log_user_id_user_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_log_question_id_question_id_fk": {
+          "name": "review_log_question_id_question_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778462355878,
       "tag": "0003_glamorous_nova",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1778465570446,
+      "tag": "0004_tense_jack_power",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -21,6 +21,9 @@ export const user = pgTable("user", {
     .default(sql`'{}'::text[]`),
   dailyStudyTimeMinutes: integer("daily_study_time_minutes"),
   onboardingCompleted: boolean("onboarding_completed").notNull().default(false),
+  notificationHour: integer("notification_hour").notNull().default(19),
+  streakRemindersEnabled: boolean("streak_reminders_enabled").notNull().default(true),
+  achievementNotificationsEnabled: boolean("achievement_notifications_enabled").notNull().default(true),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -4,3 +4,4 @@ export * from "./topics";
 export * from "./questions";
 export * from "./review-log";
 export * from "./daily-sessions";
+export * from "./push-tokens";

--- a/packages/db/src/schema/push-tokens.ts
+++ b/packages/db/src/schema/push-tokens.ts
@@ -1,0 +1,28 @@
+import { relations } from "drizzle-orm";
+import { index, integer, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+
+import { user } from "./auth";
+
+export const pushToken = pgTable(
+  "push_token",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    token: text("token").notNull().unique(),
+    platform: text("platform", { enum: ["ios", "android"] }).notNull(),
+    lastUsedAt: timestamp("last_used_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("push_token_user_idx").on(table.userId),
+  ],
+);
+
+export const pushTokenRelations = relations(pushToken, ({ one }) => ({
+  user: one(user, {
+    fields: [pushToken.userId],
+    references: [user.id],
+  }),
+}));

--- a/packages/db/src/test-client.ts
+++ b/packages/db/src/test-client.ts
@@ -134,7 +134,7 @@ export async function createTestDb() {
       id SERIAL PRIMARY KEY,
       user_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
       token TEXT NOT NULL UNIQUE,
-      platform TEXT NOT NULL,
+      platform TEXT NOT NULL CHECK (platform IN ('ios','android')),
       last_used_at TIMESTAMP NOT NULL DEFAULT NOW(),
       created_at TIMESTAMP NOT NULL DEFAULT NOW()
     );

--- a/packages/db/src/test-client.ts
+++ b/packages/db/src/test-client.ts
@@ -23,6 +23,9 @@ export async function createTestDb() {
       difficulties TEXT[] NOT NULL DEFAULT '{}',
       daily_study_time_minutes INTEGER,
       onboarding_completed BOOLEAN NOT NULL DEFAULT FALSE,
+      notification_hour INTEGER NOT NULL DEFAULT 19,
+      streak_reminders_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+      achievement_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE,
       created_at TIMESTAMP NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMP NOT NULL DEFAULT NOW()
     );
@@ -124,6 +127,15 @@ export async function createTestDb() {
       questions_correct INTEGER NOT NULL DEFAULT 0,
       mastery_snapshot JSONB,
       completed_at TIMESTAMP,
+      created_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS "push_token" (
+      id SERIAL PRIMARY KEY,
+      user_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+      token TEXT NOT NULL UNIQUE,
+      platform TEXT NOT NULL,
+      last_used_at TIMESTAMP NOT NULL DEFAULT NOW(),
       created_at TIMESTAMP NOT NULL DEFAULT NOW()
     );
   `);

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -18,6 +18,7 @@ export const env = createEnv({
     APPLE_CLIENT_ID: z.string().optional(),
     APPLE_CLIENT_SECRET: z.string().optional(),
     APPLE_BUNDLE_ID: z.string().optional(),
+    EXPO_ACCESS_TOKEN: z.string().optional(),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,3 +11,4 @@ export * from "./users";
 export * from "./progress";
 export * from "./mastery";
 export * from "./topics";
+export * from "./notifications";

--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -24,5 +24,8 @@ export const NotificationPreferencesSchema = z.object({
 });
 export type NotificationPreferences = z.infer<typeof NotificationPreferencesSchema>;
 
-export const UpdateNotificationPreferencesBodySchema = NotificationPreferencesSchema.partial();
+export const UpdateNotificationPreferencesBodySchema = NotificationPreferencesSchema.partial().refine(
+  (v) => Object.keys(v).length > 0,
+  { message: "At least one preference field must be provided" },
+);
 export type UpdateNotificationPreferencesBody = z.infer<typeof UpdateNotificationPreferencesBodySchema>;

--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const PushPlatformSchema = z.enum(["ios", "android"]);
+export type PushPlatform = z.infer<typeof PushPlatformSchema>;
+
+export const RegisterPushTokenBodySchema = z.object({
+  token: z.string().regex(/^Expo(nent)?PushToken\[.+\]$/, {
+    message: "Invalid Expo push token format",
+  }),
+  platform: PushPlatformSchema,
+});
+export type RegisterPushTokenBody = z.infer<typeof RegisterPushTokenBodySchema>;
+
+export const PushTokenResponseSchema = z.object({
+  id: z.number().int().positive(),
+  token: z.string(),
+  platform: PushPlatformSchema,
+});
+
+export const NotificationPreferencesSchema = z.object({
+  notificationHour: z.number().int().min(0).max(23),
+  streakRemindersEnabled: z.boolean(),
+  achievementNotificationsEnabled: z.boolean(),
+});
+export type NotificationPreferences = z.infer<typeof NotificationPreferencesSchema>;
+
+export const UpdateNotificationPreferencesBodySchema = NotificationPreferencesSchema.partial();
+export type UpdateNotificationPreferencesBody = z.infer<typeof UpdateNotificationPreferencesBodySchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@electric-sql/pglite@0.3.15)(@prisma/client@7.5.0(prisma@7.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(bun-types@1.3.10)(kysely@0.28.12)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))
+      expo-server-sdk:
+        specifier: ^6.1.0
+        version: 6.1.0
       fastify:
         specifier: ^5.3.3
         version: 5.8.2
@@ -3780,6 +3783,9 @@ packages:
     resolution: {integrity: sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==}
     engines: {node: '>=8'}
 
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
@@ -4060,6 +4066,10 @@ packages:
     resolution: {integrity: sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==}
     peerDependencies:
       expo: '*'
+
+  expo-server-sdk@6.1.0:
+    resolution: {integrity: sha512-ISuax1AQ7cpM5RAqcu8gVcoLL0ZKskJ5OLoMWmdITBe9nYjTucjdGyBq817YkIvTcj1pAUwx+9toUT7l/V7thA==}
+    engines: {node: '>=20'}
 
   expo-server@1.0.5:
     resolution: {integrity: sha512-IGR++flYH70rhLyeXF0Phle56/k4cee87WeQ4mamS+MkVAVP+dDlOHf2nN06Z9Y2KhU0Gp1k+y61KkghF7HdhA==}
@@ -5430,6 +5440,13 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
@@ -6312,6 +6329,10 @@ packages:
   undici@6.24.1:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -10646,6 +10667,8 @@ snapshots:
 
   env-editor@0.4.2: {}
 
+  err-code@2.0.3: {}
+
   error-stack-parser@2.1.4:
     dependencies:
       stackframe: 1.3.4
@@ -11034,6 +11057,12 @@ snapshots:
   expo-secure-store@15.0.8(expo@54.0.33):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
+  expo-server-sdk@6.1.0:
+    dependencies:
+      promise-limit: 2.7.0
+      promise-retry: 2.0.1
+      undici: 7.25.0
 
   expo-server@1.0.5: {}
 
@@ -12617,6 +12646,13 @@ snapshots:
 
   progress@2.0.3: {}
 
+  promise-limit@2.7.0: {}
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+
   promise@7.3.1:
     dependencies:
       asap: 2.0.6
@@ -13667,6 +13703,8 @@ snapshots:
   undici-types@7.19.2: {}
 
   undici@6.24.1: {}
+
+  undici@7.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- Push notifications pipeline via Expo SDK: token registration, per-user prefs, hourly BRT-aware streak reminder cron, and achievement hooks (7d/30d streak, "quase mestre" mastery).
- New `push_token` table (per-device, UNIQUE on token, CASCADE on user) + 3 user columns (`notification_hour`, `streak_reminders_enabled`, `achievement_notifications_enabled`) with CHECK constraints.
- BullMQ `notifications-cron` (repeatable `0 * * * *`) + `notifications-send` queues; worker prunes tokens on `DeviceNotRegistered`.

## Test plan
- [x] 107 unit tests pass
- [x] 36 integration tests (PGlite) pass
- [x] `pnpm verify:migration` clean
- [x] Worker boots clean with both prefetch + notifications queues

Resubmission of original PR #16 after rebase onto main (post-#15 merge).

## Notes
- Migration `0004_tense_jack_power.sql` adds `push_token` + user pref columns + CHECK constraints.
- Streak eligibility query uses double `AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo'` for BRT day boundary.
- Empty-body PUT on `/users/me/notification-preferences` rejected at shared schema + service layer.
- Achievement notifications fire-and-forget from `sessions.completeSession` to avoid blocking HTTP responses.

## Known follow-ups
- Prefetch fast-path on `POST /sessions/start` skips mastery snapshot (transitions empty when prefetch hits).
- Expo receipt polling (24h) not wired — only immediate ticket errors prune tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notification system with streak reminders and achievement notifications for milestones (7-day, 30-day streaks, mastery achievements).
  * User notification preferences: configure notification hour (0–23), toggle streak and achievement notifications on/off.
  * Notification token management: register/unregister push devices (iOS, Android).
  * Automatic achievement notifications triggered on session completion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CeCamillo/pruvi/pull/17)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->