### PR TITLE
feat: phase 2d — social ranking (friendships + invitations + weekly XP)

### DIFF
--- a/apps/server/src/features/reviews/reviews.repository.ts
+++ b/apps/server/src/features/reviews/reviews.repository.ts
@@ -56,6 +56,7 @@ export class ReviewsRepository {
     interval: number;
     repetitions: number;
     nextReviewAt: Date;
+    xpEarned: number;
   }) {
     const [row] = await this.db
       .insert(reviewLog)

--- a/apps/server/src/features/reviews/reviews.service.test.ts
+++ b/apps/server/src/features/reviews/reviews.service.test.ts
@@ -56,7 +56,7 @@ describe("ReviewsService.answerQuestion", () => {
 
     expect(mockRepo.insertReview).toHaveBeenCalledOnce();
     expect(mockRepo.insertReview).toHaveBeenCalledWith(
-      expect.objectContaining({ quality: 4, userId: USER_ID, questionId: QUESTION_ID })
+      expect.objectContaining({ quality: 4, userId: USER_ID, questionId: QUESTION_ID, xpEarned: 35 })
     );
 
     expect(mockRepo.awardXp).toHaveBeenCalledWith(USER_ID, 35);
@@ -78,7 +78,7 @@ describe("ReviewsService.answerQuestion", () => {
     expect(value.answer.livesRemaining).toBe(4);
 
     expect(mockRepo.insertReview).toHaveBeenCalledWith(
-      expect.objectContaining({ quality: 1 })
+      expect.objectContaining({ quality: 1, xpEarned: 0 })
     );
 
     expect(mockLivesRepo.tryDecrement).toHaveBeenCalledOnce();

--- a/apps/server/src/features/reviews/reviews.service.ts
+++ b/apps/server/src/features/reviews/reviews.service.ts
@@ -63,7 +63,13 @@ export class ReviewsService {
     // 5. Calculate new SM-2 state
     const newState = calculateSM2(previousState, quality);
 
-    // 6. Insert new review_log row
+    // 6. Calculate XP before inserting so it can be persisted with the review row
+    const xpAwarded = calculateXpForAnswer(
+      correct,
+      q.difficulty as Difficulty
+    );
+
+    // 6b. Insert new review_log row (including xpEarned)
     await this.repo.insertReview({
       userId,
       questionId,
@@ -72,13 +78,10 @@ export class ReviewsService {
       interval: newState.interval,
       repetitions: newState.repetitions,
       nextReviewAt: newState.nextReviewAt,
+      xpEarned: xpAwarded,
     });
 
-    // 6b. Award XP
-    const xpAwarded = calculateXpForAnswer(
-      correct,
-      q.difficulty as Difficulty
-    );
+    // 6c. Award XP
     if (xpAwarded > 0) {
       await this.repo.awardXp(userId, xpAwarded);
     }

--- a/apps/server/src/features/social/friendships/friendships.repository.integration.test.ts
+++ b/apps/server/src/features/social/friendships/friendships.repository.integration.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import {
+  setupTestDb,
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { friendship } from "@pruvi/db/schema/friendship";
+import { FriendshipsRepository } from "./friendships.repository";
+
+describe("FriendshipsRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new FriendshipsRepository(db);
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  async function insertUser(id: string, opts?: { username?: string; inviteCode?: string }) {
+    await db.insert(user).values({
+      id,
+      name: `User ${id}`,
+      email: `${id}@example.com`,
+      emailVerified: false,
+      inviteCode: opts?.inviteCode ?? `code${id.replace(/-/g, "").slice(0, 8)}`,
+      username: opts?.username ?? null,
+      updatedAt: new Date(),
+    });
+  }
+
+  describe("findByUsername", () => {
+    it("finds a user by username (case-insensitive)", async () => {
+      await insertUser("user-a", { username: "alice" });
+      const result = await repo.findByUsername("ALICE");
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe("user-a");
+    });
+
+    it("returns null for unknown username", async () => {
+      const result = await repo.findByUsername("nobody");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("findExistingPair", () => {
+    it("finds pair regardless of order (a,b) vs (b,a)", async () => {
+      await insertUser("user-1");
+      await insertUser("user-2");
+      await db.insert(friendship).values({
+        requesterId: "user-1",
+        recipientId: "user-2",
+        status: "pending",
+      });
+
+      const result1 = await repo.findExistingPair("user-1", "user-2");
+      const result2 = await repo.findExistingPair("user-2", "user-1");
+
+      expect(result1).not.toBeNull();
+      expect(result2).not.toBeNull();
+      expect(result1?.id).toBe(result2?.id);
+    });
+  });
+
+  describe("createRequest", () => {
+    it("inserts a pending friendship and returns the row", async () => {
+      await insertUser("req-1");
+      await insertUser("rec-1");
+
+      const row = await repo.createRequest("req-1", "rec-1");
+
+      expect(row.status).toBe("pending");
+      expect(row.requesterId).toBe("req-1");
+      expect(row.recipientId).toBe("rec-1");
+    });
+  });
+
+  describe("pair UNIQUE index (LEAST/GREATEST)", () => {
+    it("prevents inserting reverse duplicate (a,b) then (b,a)", async () => {
+      await insertUser("pair-a");
+      await insertUser("pair-b");
+
+      await db.insert(friendship).values({
+        requesterId: "pair-a",
+        recipientId: "pair-b",
+        status: "pending",
+      });
+
+      await expect(
+        db.insert(friendship).values({
+          requesterId: "pair-b",
+          recipientId: "pair-a",
+          status: "pending",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("no-self-friendship CHECK", () => {
+    it("rejects inserting a friendship where requester equals recipient", async () => {
+      await insertUser("solo-1");
+
+      await expect(
+        db.insert(friendship).values({
+          requesterId: "solo-1",
+          recipientId: "solo-1",
+          status: "pending",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("status CHECK", () => {
+    it("rejects invalid status values", async () => {
+      await insertUser("st-1");
+      await insertUser("st-2");
+
+      await expect(
+        db.execute(
+          // Use raw SQL to bypass Drizzle's enum typing
+          // @ts-ignore
+          `INSERT INTO friendship (requester_id, recipient_id, status) VALUES ('st-1', 'st-2', 'unknown')`,
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("getRequest", () => {
+    it("returns request when it belongs to recipient and is pending", async () => {
+      await insertUser("sender-x");
+      await insertUser("recip-x");
+      const created = await repo.createRequest("sender-x", "recip-x");
+
+      const result = await repo.getRequest(created.id, "recip-x");
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(created.id);
+    });
+
+    it("returns null when request belongs to different recipient", async () => {
+      await insertUser("sender-y");
+      await insertUser("recip-y");
+      await insertUser("other-y");
+      const created = await repo.createRequest("sender-y", "recip-y");
+
+      const result = await repo.getRequest(created.id, "other-y");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("respond", () => {
+    it("updates status to accepted and sets acceptedAt", async () => {
+      await insertUser("s1");
+      await insertUser("r1");
+      const created = await repo.createRequest("s1", "r1");
+
+      await repo.respond(created.id, "accept");
+
+      const [updated] = await db
+        .select()
+        .from(friendship)
+        .where((t) => t.id === created.id);
+      // Just verify via repo.getRequest no longer finds it (pending gone)
+      const req = await repo.getRequest(created.id, "r1");
+      expect(req).toBeNull(); // no longer pending
+    });
+
+    it("updates status to declined and leaves acceptedAt null", async () => {
+      await insertUser("s2");
+      await insertUser("r2");
+      const created = await repo.createRequest("s2", "r2");
+
+      await repo.respond(created.id, "decline");
+
+      const req = await repo.getRequest(created.id, "r2");
+      expect(req).toBeNull(); // no longer pending
+    });
+  });
+
+  describe("listAcceptedFriendsWithUserData", () => {
+    it("returns the other party when current user is the requester", async () => {
+      await insertUser("me-1", { username: "me1" });
+      await insertUser("friend-1", { username: "friend1" });
+      const req = await repo.createRequest("me-1", "friend-1");
+      await repo.respond(req.id, "accept");
+
+      const friends = await repo.listAcceptedFriendsWithUserData("me-1");
+      expect(friends).toHaveLength(1);
+      expect(friends[0]?.id).toBe("friend-1");
+    });
+
+    it("returns the other party when current user is the recipient", async () => {
+      await insertUser("me-2", { username: "me2" });
+      await insertUser("friend-2", { username: "friend2" });
+      const req = await repo.createRequest("friend-2", "me-2");
+      await repo.respond(req.id, "accept");
+
+      const friends = await repo.listAcceptedFriendsWithUserData("me-2");
+      expect(friends).toHaveLength(1);
+      expect(friends[0]?.id).toBe("friend-2");
+    });
+  });
+
+  describe("listIncomingRequests", () => {
+    it("returns pending requests where user is recipient", async () => {
+      await insertUser("sender-req");
+      await insertUser("recip-req");
+      await repo.createRequest("sender-req", "recip-req");
+
+      const requests = await repo.listIncomingRequests("recip-req");
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.from.id).toBe("sender-req");
+    });
+
+    it("does not return requests where user is the sender", async () => {
+      await insertUser("sender-req2");
+      await insertUser("recip-req2");
+      await repo.createRequest("sender-req2", "recip-req2");
+
+      const requests = await repo.listIncomingRequests("sender-req2");
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  describe("deletePair", () => {
+    it("deletes friendship regardless of which user is requester vs recipient", async () => {
+      await insertUser("del-a");
+      await insertUser("del-b");
+      await db.insert(friendship).values({
+        requesterId: "del-a",
+        recipientId: "del-b",
+        status: "accepted",
+        acceptedAt: new Date(),
+      });
+
+      // deletePair called with (b, a) — reversed order — should still delete
+      await repo.deletePair("del-b", "del-a");
+
+      const pair = await repo.findExistingPair("del-a", "del-b");
+      expect(pair).toBeNull();
+    });
+  });
+});

--- a/apps/server/src/features/social/friendships/friendships.repository.integration.test.ts
+++ b/apps/server/src/features/social/friendships/friendships.repository.integration.test.ts
@@ -5,6 +5,7 @@ import {
   teardownTestDb,
   getTestDb,
 } from "../../../test/db-helpers";
+import { eq } from "drizzle-orm";
 import { user } from "@pruvi/db/schema/auth";
 import { friendship } from "@pruvi/db/schema/friendship";
 import { FriendshipsRepository } from "./friendships.repository";
@@ -166,10 +167,10 @@ describe("FriendshipsRepository (integration)", () => {
       const [updated] = await db
         .select()
         .from(friendship)
-        .where((t) => t.id === created.id);
-      // Just verify via repo.getRequest no longer finds it (pending gone)
-      const req = await repo.getRequest(created.id, "r1");
-      expect(req).toBeNull(); // no longer pending
+        .where(eq(friendship.id, created.id));
+      expect(updated?.status).toBe("accepted");
+      expect(updated?.acceptedAt).not.toBeNull();
+      expect(updated?.acceptedAt).toBeInstanceOf(Date);
     });
 
     it("updates status to declined and leaves acceptedAt null", async () => {
@@ -179,8 +180,12 @@ describe("FriendshipsRepository (integration)", () => {
 
       await repo.respond(created.id, "decline");
 
-      const req = await repo.getRequest(created.id, "r2");
-      expect(req).toBeNull(); // no longer pending
+      const [updated] = await db
+        .select()
+        .from(friendship)
+        .where(eq(friendship.id, created.id));
+      expect(updated?.status).toBe("declined");
+      expect(updated?.acceptedAt).toBeNull();
     });
   });
 

--- a/apps/server/src/features/social/friendships/friendships.repository.ts
+++ b/apps/server/src/features/social/friendships/friendships.repository.ts
@@ -1,0 +1,118 @@
+import { and, eq, or, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { user } from "@pruvi/db/schema/auth";
+import { friendship } from "@pruvi/db/schema/friendship";
+
+type Db = typeof DbClient;
+
+export class FriendshipsRepository {
+  constructor(private db: Db) {}
+
+  async findByUsername(username: string) {
+    const rows = await this.db
+      .select({ id: user.id, name: user.name, username: user.username, image: user.image })
+      .from(user)
+      .where(eq(sql`LOWER(${user.username})`, username.toLowerCase()))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async findExistingPair(a: string, b: string) {
+    const [lo, hi] = a < b ? [a, b] : [b, a];
+    const rows = await this.db
+      .select()
+      .from(friendship)
+      .where(
+        and(
+          sql`LEAST(${friendship.requesterId}, ${friendship.recipientId}) = ${lo}`,
+          sql`GREATEST(${friendship.requesterId}, ${friendship.recipientId}) = ${hi}`,
+        ),
+      )
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async createRequest(requesterId: string, recipientId: string) {
+    const [row] = await this.db
+      .insert(friendship)
+      .values({ requesterId, recipientId, status: "pending" })
+      .returning();
+    return row!;
+  }
+
+  async getRequest(id: number, recipientId: string) {
+    const rows = await this.db
+      .select()
+      .from(friendship)
+      .where(
+        and(
+          eq(friendship.id, id),
+          eq(friendship.recipientId, recipientId),
+          eq(friendship.status, "pending"),
+        ),
+      )
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async respond(id: number, action: "accept" | "decline") {
+    await this.db
+      .update(friendship)
+      .set({
+        status: action === "accept" ? "accepted" : "declined",
+        acceptedAt: action === "accept" ? new Date() : null,
+      })
+      .where(eq(friendship.id, id));
+  }
+
+  async listAcceptedFriendsWithUserData(userId: string) {
+    const rows = await this.db
+      .select({
+        id: user.id,
+        name: user.name,
+        username: user.username,
+        image: user.image,
+      })
+      .from(friendship)
+      .innerJoin(
+        user,
+        sql`${user.id} = CASE WHEN ${friendship.requesterId} = ${userId} THEN ${friendship.recipientId} ELSE ${friendship.requesterId} END`,
+      )
+      .where(
+        and(
+          or(eq(friendship.requesterId, userId), eq(friendship.recipientId, userId)),
+          eq(friendship.status, "accepted"),
+        ),
+      );
+    return rows;
+  }
+
+  async listIncomingRequests(userId: string) {
+    return this.db
+      .select({
+        id: friendship.id,
+        createdAt: friendship.createdAt,
+        from: {
+          id: user.id,
+          name: user.name,
+          username: user.username,
+          image: user.image,
+        },
+      })
+      .from(friendship)
+      .innerJoin(user, eq(user.id, friendship.requesterId))
+      .where(and(eq(friendship.recipientId, userId), eq(friendship.status, "pending")));
+  }
+
+  async deletePair(a: string, b: string) {
+    const [lo, hi] = a < b ? [a, b] : [b, a];
+    await this.db
+      .delete(friendship)
+      .where(
+        and(
+          sql`LEAST(${friendship.requesterId}, ${friendship.recipientId}) = ${lo}`,
+          sql`GREATEST(${friendship.requesterId}, ${friendship.recipientId}) = ${hi}`,
+        ),
+      );
+  }
+}

--- a/apps/server/src/features/social/friendships/friendships.route.ts
+++ b/apps/server/src/features/social/friendships/friendships.route.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import {
+  RequestFriendBodySchema,
+  RespondRequestBodySchema,
+  FriendListResponseSchema,
+  RequestListResponseSchema,
+} from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { unwrapResult } from "../../../types";
+import { FriendshipsRepository } from "./friendships.repository";
+import { FriendshipsService } from "./friendships.service";
+
+const repo = new FriendshipsRepository(db);
+const service = new FriendshipsService(repo);
+
+export const friendshipsRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.post(
+    "/users/me/friends/request",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { body: RequestFriendBodySchema },
+    },
+    async (request) => {
+      const { username } = request.body;
+      const result = await service.requestByUsername(request.userId, username);
+      return unwrapResult(result);
+    },
+  );
+
+  fastify.get(
+    "/users/me/friends/requests",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        response: {
+          200: z.object({ success: z.literal(true), data: RequestListResponseSchema }),
+        },
+      },
+    },
+    async (request) => {
+      const result = await service.listRequests(request.userId);
+      return unwrapResult(result);
+    },
+  );
+
+  fastify.patch(
+    "/users/me/friends/requests/:id",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ id: z.coerce.number().int().positive() }),
+        body: RespondRequestBodySchema,
+      },
+    },
+    async (request) => {
+      const { id } = request.params;
+      const { action } = request.body;
+      const result = await service.respond(id, action, request.userId);
+      return unwrapResult(result);
+    },
+  );
+
+  fastify.get(
+    "/users/me/friends",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        response: {
+          200: z.object({ success: z.literal(true), data: FriendListResponseSchema }),
+        },
+      },
+    },
+    async (request) => {
+      const result = await service.listFriends(request.userId);
+      return unwrapResult(result);
+    },
+  );
+
+  fastify.delete(
+    "/users/me/friends/:friendUserId",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ friendUserId: z.string().min(1) }),
+      },
+    },
+    async (request, reply) => {
+      const { friendUserId } = request.params;
+      const result = await service.unfriend(request.userId, friendUserId);
+      unwrapResult(result);
+      reply.status(204).send();
+    },
+  );
+};

--- a/apps/server/src/features/social/friendships/friendships.service.test.ts
+++ b/apps/server/src/features/social/friendships/friendships.service.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+import { FriendshipsService } from "./friendships.service";
+import type { FriendshipsRepository } from "./friendships.repository";
+import { NotFoundError, ValidationError } from "../../../utils/errors";
+
+function makeRepo(overrides?: Partial<FriendshipsRepository>): FriendshipsRepository {
+  return {
+    findByUsername: vi.fn().mockResolvedValue(null),
+    findExistingPair: vi.fn().mockResolvedValue(null),
+    createRequest: vi.fn().mockResolvedValue({ id: 1 }),
+    getRequest: vi.fn().mockResolvedValue(null),
+    respond: vi.fn().mockResolvedValue(undefined),
+    listAcceptedFriendsWithUserData: vi.fn().mockResolvedValue([]),
+    listIncomingRequests: vi.fn().mockResolvedValue([]),
+    deletePair: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as FriendshipsRepository;
+}
+
+const mockTarget = {
+  id: "target-id",
+  name: "Alice",
+  username: "alice",
+  image: null,
+};
+
+describe("FriendshipsService", () => {
+  describe("requestByUsername", () => {
+    it("returns NotFoundError when user not found", async () => {
+      const repo = makeRepo({ findByUsername: vi.fn().mockResolvedValue(null) });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.requestByUsername("user-1", "nobody");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(NotFoundError);
+        expect(result.error.message).toBe("User not found");
+      }
+    });
+
+    it("returns ValidationError when requesting friendship with self", async () => {
+      const repo = makeRepo({
+        findByUsername: vi.fn().mockResolvedValue({ ...mockTarget, id: "user-1" }),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.requestByUsername("user-1", "alice");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toBe("Cannot friend yourself");
+      }
+    });
+
+    it("returns ValidationError when pair already exists with status pending", async () => {
+      const repo = makeRepo({
+        findByUsername: vi.fn().mockResolvedValue(mockTarget),
+        findExistingPair: vi.fn().mockResolvedValue({ id: 5, status: "pending" }),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.requestByUsername("user-1", "alice");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toContain("pending");
+      }
+    });
+
+    it("returns ValidationError when pair already exists with status accepted", async () => {
+      const repo = makeRepo({
+        findByUsername: vi.fn().mockResolvedValue(mockTarget),
+        findExistingPair: vi.fn().mockResolvedValue({ id: 5, status: "accepted" }),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.requestByUsername("user-1", "alice");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toContain("accepted");
+      }
+    });
+
+    it("returns ValidationError when pair already exists with status declined", async () => {
+      const repo = makeRepo({
+        findByUsername: vi.fn().mockResolvedValue(mockTarget),
+        findExistingPair: vi.fn().mockResolvedValue({ id: 5, status: "declined" }),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.requestByUsername("user-1", "alice");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toContain("declined");
+      }
+    });
+
+    it("returns requestId and recipient on success", async () => {
+      const repo = makeRepo({
+        findByUsername: vi.fn().mockResolvedValue(mockTarget),
+        findExistingPair: vi.fn().mockResolvedValue(null),
+        createRequest: vi.fn().mockResolvedValue({ id: 42 }),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.requestByUsername("user-1", "alice");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.requestId).toBe(42);
+        expect(result.value.recipient.username).toBe("alice");
+        expect(result.value.recipient.name).toBe("Alice");
+      }
+    });
+  });
+
+  describe("respond", () => {
+    it("returns NotFoundError when request not found", async () => {
+      const repo = makeRepo({ getRequest: vi.fn().mockResolvedValue(null) });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.respond(99, "accept", "user-1");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(NotFoundError);
+        expect(result.error.message).toBe("Request not found");
+      }
+    });
+
+    it("returns accepted status on accept", async () => {
+      const repo = makeRepo({
+        getRequest: vi.fn().mockResolvedValue({ id: 1, status: "pending" }),
+        respond: vi.fn().mockResolvedValue(undefined),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.respond(1, "accept", "user-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.status).toBe("accepted");
+      }
+      expect(repo.respond).toHaveBeenCalledWith(1, "accept");
+    });
+
+    it("returns declined status on decline and does not set acceptedAt", async () => {
+      const repo = makeRepo({
+        getRequest: vi.fn().mockResolvedValue({ id: 2, status: "pending" }),
+        respond: vi.fn().mockResolvedValue(undefined),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.respond(2, "decline", "user-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.status).toBe("declined");
+      }
+      expect(repo.respond).toHaveBeenCalledWith(2, "decline");
+    });
+  });
+
+  describe("listFriends", () => {
+    it("returns friends when current user is the requester", async () => {
+      const friendAsRecipient = {
+        id: "friend-id",
+        name: "Bob",
+        username: "bob",
+        image: null,
+      };
+      const repo = makeRepo({
+        listAcceptedFriendsWithUserData: vi.fn().mockResolvedValue([friendAsRecipient]),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.listFriends("user-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.friends).toHaveLength(1);
+        expect(result.value.friends[0]?.id).toBe("friend-id");
+      }
+    });
+
+    it("returns friends when current user is the recipient", async () => {
+      const friendAsRequester = {
+        id: "requester-id",
+        name: "Carol",
+        username: "carol",
+        image: null,
+      };
+      const repo = makeRepo({
+        listAcceptedFriendsWithUserData: vi
+          .fn()
+          .mockResolvedValue([friendAsRequester]),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.listFriends("user-2");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.friends).toHaveLength(1);
+        expect(result.value.friends[0]?.id).toBe("requester-id");
+      }
+    });
+
+    it("returns empty list when user has no friends", async () => {
+      const repo = makeRepo({
+        listAcceptedFriendsWithUserData: vi.fn().mockResolvedValue([]),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.listFriends("user-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.friends).toHaveLength(0);
+      }
+    });
+  });
+
+  describe("listRequests", () => {
+    it("returns incoming requests with ISO createdAt", async () => {
+      const now = new Date("2026-05-11T10:00:00.000Z");
+      const repo = makeRepo({
+        listIncomingRequests: vi.fn().mockResolvedValue([
+          {
+            id: 7,
+            createdAt: now,
+            from: { id: "sender-id", name: "Dave", username: "dave", image: null },
+          },
+        ]),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.listRequests("user-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.incoming).toHaveLength(1);
+        expect(result.value.incoming[0]?.id).toBe(7);
+        expect(result.value.incoming[0]?.createdAt).toBe("2026-05-11T10:00:00.000Z");
+        expect(result.value.incoming[0]?.from.username).toBe("dave");
+      }
+    });
+  });
+
+  describe("unfriend", () => {
+    it("calls deletePair and returns ok", async () => {
+      const repo = makeRepo({
+        deletePair: vi.fn().mockResolvedValue(undefined),
+      });
+      const service = new FriendshipsService(repo);
+
+      const result = await service.unfriend("user-1", "user-2");
+
+      expect(result.isOk()).toBe(true);
+      expect(repo.deletePair).toHaveBeenCalledWith("user-1", "user-2");
+    });
+  });
+});

--- a/apps/server/src/features/social/friendships/friendships.service.ts
+++ b/apps/server/src/features/social/friendships/friendships.service.ts
@@ -1,0 +1,61 @@
+import { ok, err, type Result } from "neverthrow";
+import type { AppError } from "../../../utils/errors";
+import { NotFoundError, ValidationError } from "../../../utils/errors";
+import type { FriendshipsRepository } from "./friendships.repository";
+
+export class FriendshipsService {
+  constructor(private repo: FriendshipsRepository) {}
+
+  async requestByUsername(
+    requesterId: string,
+    username: string,
+  ): Promise<
+    Result<
+      { requestId: number; recipient: { username: string | null; name: string } },
+      AppError
+    >
+  > {
+    const target = await this.repo.findByUsername(username);
+    if (!target) return err(new NotFoundError("User not found"));
+    if (target.id === requesterId)
+      return err(new ValidationError("Cannot friend yourself"));
+    const existing = await this.repo.findExistingPair(requesterId, target.id);
+    if (existing)
+      return err(
+        new ValidationError(`Friendship already exists with status ${existing.status}`),
+      );
+    const row = await this.repo.createRequest(requesterId, target.id);
+    return ok({ requestId: row.id, recipient: { username: target.username, name: target.name } });
+  }
+
+  async respond(
+    id: number,
+    action: "accept" | "decline",
+    userId: string,
+  ): Promise<Result<{ status: "accepted" | "declined" }, AppError>> {
+    const req = await this.repo.getRequest(id, userId);
+    if (!req) return err(new NotFoundError("Request not found"));
+    await this.repo.respond(id, action);
+    return ok({ status: action === "accept" ? "accepted" : "declined" });
+  }
+
+  async listFriends(userId: string) {
+    return ok({ friends: await this.repo.listAcceptedFriendsWithUserData(userId) });
+  }
+
+  async listRequests(userId: string) {
+    const rows = await this.repo.listIncomingRequests(userId);
+    return ok({
+      incoming: rows.map((r) => ({
+        id: r.id,
+        from: r.from,
+        createdAt: r.createdAt.toISOString(),
+      })),
+    });
+  }
+
+  async unfriend(userId: string, otherUserId: string): Promise<Result<void, AppError>> {
+    await this.repo.deletePair(userId, otherUserId);
+    return ok(undefined);
+  }
+}

--- a/apps/server/src/features/social/index.ts
+++ b/apps/server/src/features/social/index.ts
@@ -1,0 +1,1 @@
+export { invitationsRoutes } from "./invitations/invitations.route";

--- a/apps/server/src/features/social/index.ts
+++ b/apps/server/src/features/social/index.ts
@@ -1,2 +1,3 @@
 export { invitationsRoutes } from "./invitations/invitations.route";
 export { friendshipsRoutes } from "./friendships/friendships.route";
+export { rankingRoutes } from "./ranking/ranking.route";

--- a/apps/server/src/features/social/index.ts
+++ b/apps/server/src/features/social/index.ts
@@ -1,1 +1,2 @@
 export { invitationsRoutes } from "./invitations/invitations.route";
+export { friendshipsRoutes } from "./friendships/friendships.route";

--- a/apps/server/src/features/social/invitations/invitations.repository.integration.test.ts
+++ b/apps/server/src/features/social/invitations/invitations.repository.integration.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  setupTestDb,
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { invitationAcceptance } from "@pruvi/db/schema/invitation-acceptance";
+import { friendship } from "@pruvi/db/schema/friendship";
+import { InvitationsRepository } from "./invitations.repository";
+
+describe("InvitationsRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new InvitationsRepository(db);
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  async function insertUser(
+    id: string,
+    opts?: { inviteCode?: string; username?: string },
+  ) {
+    await db.insert(user).values({
+      id,
+      name: `User ${id}`,
+      email: `${id}@example.com`,
+      emailVerified: false,
+      inviteCode: opts?.inviteCode ?? `code${id.replace(/-/g, "").slice(0, 8)}`,
+      username: opts?.username ?? null,
+      updatedAt: new Date(),
+    });
+  }
+
+  describe("ensureInviteCode", () => {
+    it("returns existing invite code for a user", async () => {
+      await insertUser("user-a", { inviteCode: "abcd1234" });
+      const code = await repo.ensureInviteCode("user-a");
+      expect(code).toBe("abcd1234");
+    });
+
+    it("returns the same code on repeated calls (idempotent)", async () => {
+      await insertUser("user-b", { inviteCode: "efgh5678" });
+      const code1 = await repo.ensureInviteCode("user-b");
+      const code2 = await repo.ensureInviteCode("user-b");
+      expect(code1).toBe(code2);
+    });
+  });
+
+  describe("findInviterByCode", () => {
+    it("resolves the inviter by code", async () => {
+      await insertUser("inviter-1", { inviteCode: "mycode12", username: "alice" });
+      const inviter = await repo.findInviterByCode("mycode12");
+      expect(inviter).not.toBeNull();
+      expect(inviter?.id).toBe("inviter-1");
+      expect(inviter?.username).toBe("alice");
+    });
+
+    it("returns null for a non-existent code", async () => {
+      const inviter = await repo.findInviterByCode("zzzzzzzz");
+      expect(inviter).toBeNull();
+    });
+  });
+
+  describe("hasAccepted", () => {
+    it("returns false when no acceptance exists", async () => {
+      await insertUser("invitee-x");
+      const result = await repo.hasAccepted("invitee-x");
+      expect(result).toBe(false);
+    });
+
+    it("returns true after acceptance is recorded", async () => {
+      await insertUser("inviter-2", { inviteCode: "aaaa1111" });
+      await insertUser("invitee-2");
+      await repo.acceptInvitation("inviter-2", "invitee-2");
+      const result = await repo.hasAccepted("invitee-2");
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("acceptInvitation", () => {
+    it("commits all 3 mutations atomically: acceptance record, +100 XP, and friendship", async () => {
+      await insertUser("inviter-3", { inviteCode: "bbbb2222" });
+      await insertUser("invitee-3");
+
+      // verify initial XP
+      const [inviterBefore] = await db
+        .select({ totalXp: user.totalXp })
+        .from(user)
+        .where(eq(user.id, "inviter-3"));
+      expect(inviterBefore?.totalXp).toBe(0);
+
+      await repo.acceptInvitation("inviter-3", "invitee-3");
+
+      // inviter gets +100 XP
+      const [inviterAfter] = await db
+        .select({ totalXp: user.totalXp })
+        .from(user)
+        .where(eq(user.id, "inviter-3"));
+      expect(inviterAfter?.totalXp).toBe(100);
+
+      // invitation_acceptance row created
+      const acceptances = await db
+        .select()
+        .from(invitationAcceptance)
+        .where(eq(invitationAcceptance.inviteeId, "invitee-3"));
+      expect(acceptances).toHaveLength(1);
+      expect(acceptances[0]?.inviterId).toBe("inviter-3");
+
+      // friendship row created in accepted state
+      const friendships = await db
+        .select()
+        .from(friendship)
+        .where(eq(friendship.recipientId, "invitee-3"));
+      expect(friendships).toHaveLength(1);
+      expect(friendships[0]?.status).toBe("accepted");
+      expect(friendships[0]?.requesterId).toBe("inviter-3");
+    });
+
+    it("does not partially commit when friendship insert fails due to duplicate (atomicity)", async () => {
+      await insertUser("inviter-4", { inviteCode: "cccc3333" });
+      await insertUser("invitee-4");
+
+      // First acceptance succeeds
+      await repo.acceptInvitation("inviter-4", "invitee-4");
+
+      // Second attempt must fail with a constraint error (invitee_id unique on invitation_acceptance)
+      await expect(
+        repo.acceptInvitation("inviter-4", "invitee-4"),
+      ).rejects.toThrow();
+
+      // XP should only be 100 (only 1 success), not 200
+      const [inviterAfter] = await db
+        .select({ totalXp: user.totalXp })
+        .from(user)
+        .where(eq(user.id, "inviter-4"));
+      expect(inviterAfter?.totalXp).toBe(100);
+
+      // Still only 1 acceptance record
+      const acceptances = await db
+        .select()
+        .from(invitationAcceptance)
+        .where(eq(invitationAcceptance.inviteeId, "invitee-4"));
+      expect(acceptances).toHaveLength(1);
+    });
+  });
+});

--- a/apps/server/src/features/social/invitations/invitations.repository.ts
+++ b/apps/server/src/features/social/invitations/invitations.repository.ts
@@ -1,0 +1,73 @@
+import { eq, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { user } from "@pruvi/db/schema/auth";
+import { invitationAcceptance } from "@pruvi/db/schema/invitation-acceptance";
+import { friendship } from "@pruvi/db/schema/friendship";
+import { generateInviteCode } from "../invite-codes/generator";
+
+type Db = typeof DbClient;
+
+export class InvitationsRepository {
+  constructor(private db: Db) {}
+
+  async ensureInviteCode(userId: string): Promise<string> {
+    const rows = await this.db
+      .select({ code: user.inviteCode })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    if (rows[0]?.code) return rows[0].code;
+    // Defensive: backfilled at migration; if absent (race or test fixture), generate.
+    for (let i = 0; i < 5; i++) {
+      const code = generateInviteCode();
+      try {
+        await this.db
+          .update(user)
+          .set({ inviteCode: code })
+          .where(eq(user.id, userId));
+        return code;
+      } catch {
+        // retry on unique violation
+      }
+    }
+    throw new Error("Could not assign invite code");
+  }
+
+  async findInviterByCode(
+    code: string,
+  ): Promise<{ id: string; name: string; username: string | null } | null> {
+    const rows = await this.db
+      .select({ id: user.id, name: user.name, username: user.username })
+      .from(user)
+      .where(eq(user.inviteCode, code))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async hasAccepted(inviteeId: string): Promise<boolean> {
+    const rows = await this.db
+      .select({ id: invitationAcceptance.id })
+      .from(invitationAcceptance)
+      .where(eq(invitationAcceptance.inviteeId, inviteeId))
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  /** Atomic: record acceptance + +100 XP to inviter + upsert accepted friendship. */
+  async acceptInvitation(inviterId: string, inviteeId: string): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx.insert(invitationAcceptance).values({ inviterId, inviteeId });
+      await tx
+        .update(user)
+        .set({ totalXp: sql`${user.totalXp} + 100` })
+        .where(eq(user.id, inviterId));
+      // Friendship: pair-ordered to fit UNIQUE LEAST/GREATEST index.
+      await tx.insert(friendship).values({
+        requesterId: inviterId,
+        recipientId: inviteeId,
+        status: "accepted",
+        acceptedAt: new Date(),
+      });
+    });
+  }
+}

--- a/apps/server/src/features/social/invitations/invitations.route.ts
+++ b/apps/server/src/features/social/invitations/invitations.route.ts
@@ -1,0 +1,41 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { AcceptInvitationBodySchema, InviteLinkResponseSchema } from "@pruvi/shared";
+import { z } from "zod";
+import { db } from "@pruvi/db";
+import { unwrapResult } from "../../../types";
+import { InvitationsRepository } from "./invitations.repository";
+import { InvitationsService } from "./invitations.service";
+
+const repo = new InvitationsRepository(db);
+const service = new InvitationsService(repo);
+
+export const invitationsRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/users/me/invite",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        response: {
+          200: z.object({ success: z.literal(true), data: InviteLinkResponseSchema }),
+        },
+      },
+    },
+    async (request) => {
+      const result = await service.getInvite(request.userId);
+      return unwrapResult(result);
+    },
+  );
+
+  fastify.post(
+    "/invitations/accept",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { body: AcceptInvitationBodySchema },
+    },
+    async (request) => {
+      const { code } = request.body;
+      const result = await service.acceptInvitation(code, request.userId);
+      return unwrapResult(result);
+    },
+  );
+};

--- a/apps/server/src/features/social/invitations/invitations.service.test.ts
+++ b/apps/server/src/features/social/invitations/invitations.service.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { InvitationsService } from "./invitations.service";
+import type { InvitationsRepository } from "./invitations.repository";
+import { NotFoundError, ValidationError } from "../../../utils/errors";
+
+function makeRepo(overrides?: Partial<InvitationsRepository>): InvitationsRepository {
+  return {
+    ensureInviteCode: vi.fn().mockResolvedValue("abc12345"),
+    findInviterByCode: vi.fn().mockResolvedValue(null),
+    hasAccepted: vi.fn().mockResolvedValue(false),
+    acceptInvitation: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as InvitationsRepository;
+}
+
+describe("InvitationsService", () => {
+  describe("getInvite", () => {
+    it("returns code and url for the user", async () => {
+      const repo = makeRepo({
+        ensureInviteCode: vi.fn().mockResolvedValue("abc12345"),
+      });
+      const service = new InvitationsService(repo);
+
+      const result = await service.getInvite("user-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.code).toBe("abc12345");
+        expect(result.value.url).toMatch(/\/abc12345$/);
+      }
+    });
+  });
+
+  describe("acceptInvitation", () => {
+    it("returns NotFoundError when invite code does not exist", async () => {
+      const repo = makeRepo({
+        findInviterByCode: vi.fn().mockResolvedValue(null),
+      });
+      const service = new InvitationsService(repo);
+
+      const result = await service.acceptInvitation("notexist", "user-1");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(NotFoundError);
+        expect(result.error.message).toBe("Invite code not found");
+      }
+    });
+
+    it("returns ValidationError when user tries to accept their own invite", async () => {
+      const repo = makeRepo({
+        findInviterByCode: vi.fn().mockResolvedValue({
+          id: "user-1",
+          name: "Alice",
+          username: "alice",
+        }),
+      });
+      const service = new InvitationsService(repo);
+
+      const result = await service.acceptInvitation("abc12345", "user-1");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toBe("Cannot accept your own invite");
+      }
+    });
+
+    it("returns ValidationError when user has already accepted an invitation", async () => {
+      const repo = makeRepo({
+        findInviterByCode: vi.fn().mockResolvedValue({
+          id: "inviter-id",
+          name: "Bob",
+          username: "bob",
+        }),
+        hasAccepted: vi.fn().mockResolvedValue(true),
+      });
+      const service = new InvitationsService(repo);
+
+      const result = await service.acceptInvitation("abc12345", "user-2");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toBe("You have already accepted an invitation");
+      }
+    });
+
+    it("returns +100 XP shape on success", async () => {
+      const repo = makeRepo({
+        findInviterByCode: vi.fn().mockResolvedValue({
+          id: "inviter-id",
+          name: "Bob",
+          username: "bob",
+        }),
+        hasAccepted: vi.fn().mockResolvedValue(false),
+        acceptInvitation: vi.fn().mockResolvedValue(undefined),
+      });
+      const service = new InvitationsService(repo);
+
+      const result = await service.acceptInvitation("abc12345", "user-2");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.xpAwarded).toBe(100);
+        expect(result.value.friendshipCreated).toBe(true);
+        expect(result.value.inviter.name).toBe("Bob");
+        expect(result.value.inviter.username).toBe("bob");
+      }
+    });
+
+    it("returns ValidationError on duplicate-key constraint error", async () => {
+      const repo = makeRepo({
+        findInviterByCode: vi.fn().mockResolvedValue({
+          id: "inviter-id",
+          name: "Bob",
+          username: "bob",
+        }),
+        hasAccepted: vi.fn().mockResolvedValue(false),
+        acceptInvitation: vi.fn().mockRejectedValue(
+          new Error("duplicate key value violates unique constraint: invitation_acceptance"),
+        ),
+      });
+      const service = new InvitationsService(repo);
+
+      const result = await service.acceptInvitation("abc12345", "user-2");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+      }
+    });
+  });
+});

--- a/apps/server/src/features/social/invitations/invitations.service.ts
+++ b/apps/server/src/features/social/invitations/invitations.service.ts
@@ -1,0 +1,55 @@
+import { ok, err, type Result } from "neverthrow";
+import type { AppError } from "../../../utils/errors";
+import { NotFoundError, ValidationError } from "../../../utils/errors";
+import type { InvitationsRepository } from "./invitations.repository";
+
+const INVITE_URL_BASE = process.env.INVITE_URL_BASE ?? "https://pruvi.app/i";
+
+export class InvitationsService {
+  constructor(private repo: InvitationsRepository) {}
+
+  async getInvite(
+    userId: string,
+  ): Promise<Result<{ code: string; url: string }, AppError>> {
+    const code = await this.repo.ensureInviteCode(userId);
+    return ok({ code, url: `${INVITE_URL_BASE}/${code}` });
+  }
+
+  async acceptInvitation(
+    code: string,
+    userId: string,
+  ): Promise<
+    Result<
+      {
+        inviter: { name: string; username: string | null };
+        xpAwarded: number;
+        friendshipCreated: true;
+      },
+      AppError
+    >
+  > {
+    const inviter = await this.repo.findInviterByCode(code);
+    if (!inviter) return err(new NotFoundError("Invite code not found"));
+    if (inviter.id === userId)
+      return err(new ValidationError("Cannot accept your own invite"));
+    if (await this.repo.hasAccepted(userId))
+      return err(new ValidationError("You have already accepted an invitation"));
+    try {
+      await this.repo.acceptInvitation(inviter.id, userId);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (
+        msg.includes("friendship_pair_idx") ||
+        msg.includes("invitation_acceptance")
+      ) {
+        return err(new ValidationError("Invitation already processed"));
+      }
+      throw e;
+    }
+    return ok({
+      inviter: { name: inviter.name, username: inviter.username },
+      xpAwarded: 100,
+      friendshipCreated: true as const,
+    });
+  }
+}

--- a/apps/server/src/features/social/invite-codes/generator.test.ts
+++ b/apps/server/src/features/social/invite-codes/generator.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { generateInviteCode, INVITE_CODE_ALPHABET } from "./generator";
+
+describe("generateInviteCode", () => {
+  it("returns 8 chars", () => {
+    expect(generateInviteCode()).toHaveLength(8);
+  });
+
+  it("only contains alphabet chars", () => {
+    for (let i = 0; i < 100; i++) {
+      const c = generateInviteCode();
+      for (const ch of c) {
+        expect(INVITE_CODE_ALPHABET).toContain(ch);
+      }
+    }
+  });
+
+  it("low collision rate over 10k samples", () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 10_000; i++) set.add(generateInviteCode());
+    expect(set.size).toBeGreaterThan(9990); // < 0.1% collisions
+  });
+});

--- a/apps/server/src/features/social/invite-codes/generator.ts
+++ b/apps/server/src/features/social/invite-codes/generator.ts
@@ -1,0 +1,11 @@
+import { randomInt } from "node:crypto";
+
+export const INVITE_CODE_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789";
+
+export function generateInviteCode(): string {
+  let out = "";
+  for (let i = 0; i < 8; i++) {
+    out += INVITE_CODE_ALPHABET[randomInt(0, INVITE_CODE_ALPHABET.length)];
+  }
+  return out;
+}

--- a/apps/server/src/features/social/ranking/ranking.repository.integration.test.ts
+++ b/apps/server/src/features/social/ranking/ranking.repository.integration.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import {
+  setupTestDb,
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { friendship } from "@pruvi/db/schema/friendship";
+import { subject } from "@pruvi/db/schema/subjects";
+import { topic, subtopic } from "@pruvi/db/schema/topics";
+import { question } from "@pruvi/db/schema/questions";
+import { reviewLog } from "@pruvi/db/schema/review-log";
+import { RankingRepository } from "./ranking.repository";
+
+describe("RankingRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new RankingRepository(db);
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  async function insertUser(id: string, opts?: { username?: string }) {
+    await db.insert(user).values({
+      id,
+      name: `User ${id}`,
+      email: `${id}@example.com`,
+      emailVerified: false,
+      username: opts?.username ?? null,
+      updatedAt: new Date(),
+    });
+  }
+
+  async function makeFriendship(aId: string, bId: string) {
+    await db.insert(friendship).values({
+      requesterId: aId,
+      recipientId: bId,
+      status: "accepted",
+      acceptedAt: new Date(),
+    });
+  }
+
+  /** Seed a question so review_log rows can be inserted. Returns questionId. */
+  async function seedQuestion(): Promise<number> {
+    const [subj] = await db
+      .insert(subject)
+      .values({ name: "Math", slug: "math" })
+      .returning();
+    const [t] = await db
+      .insert(topic)
+      .values({
+        subjectId: subj!.id,
+        name: "Algebra",
+        slug: "algebra",
+        displayOrder: 0,
+      })
+      .returning();
+    const [st] = await db
+      .insert(subtopic)
+      .values({
+        topicId: t!.id,
+        name: "Basics",
+        slug: "basics",
+        displayOrder: 0,
+      })
+      .returning();
+    const [q] = await db
+      .insert(question)
+      .values({
+        subjectId: subj!.id,
+        subtopicId: st!.id,
+        content: "1+1?",
+        options: ["1", "2", "3", "4"],
+        correctOptionIndex: 1,
+        difficulty: "easy" as const,
+        requiresCalculation: false,
+      })
+      .returning();
+    return q!.id;
+  }
+
+  async function insertReviewLog(
+    userId: string,
+    questionId: number,
+    xpEarned: number,
+    reviewedAt: Date,
+  ) {
+    await db.insert(reviewLog).values({
+      userId,
+      questionId,
+      quality: 4,
+      easinessFactor: "2.50",
+      interval: 1,
+      repetitions: 1,
+      xpEarned,
+      nextReviewAt: new Date(reviewedAt.getTime() + 24 * 60 * 60 * 1000),
+      reviewedAt,
+    });
+  }
+
+  describe("getFriendsRanking", () => {
+    it("returns me + 3 friends, sums only current-week XP, excludes non-friend", async () => {
+      // Seed users: me, 3 friends, 1 non-friend
+      await insertUser("me");
+      await insertUser("friend-a");
+      await insertUser("friend-b");
+      await insertUser("friend-c");
+      await insertUser("non-friend");
+
+      // Establish friendships
+      await makeFriendship("me", "friend-a");
+      await makeFriendship("friend-b", "me");
+      await makeFriendship("me", "friend-c");
+
+      const questionId = await seedQuestion();
+
+      // Current week starts Monday 2026-05-11T03:00:00Z (for a Wednesday noon BRT now)
+      const weekStart = new Date("2026-05-11T03:00:00.000Z");
+      const currentWeekDate = new Date("2026-05-13T10:00:00Z"); // well within current week
+      const lastWeekDate = new Date("2026-05-08T10:00:00Z"); // previous week
+
+      // me: 50 XP this week + 20 XP last week (last week should NOT count)
+      await insertReviewLog("me", questionId, 50, currentWeekDate);
+      await insertReviewLog("me", questionId, 20, lastWeekDate);
+
+      // friend-a: 80 XP this week
+      await insertReviewLog("friend-a", questionId, 80, currentWeekDate);
+
+      // friend-b: 30 XP this week
+      await insertReviewLog("friend-b", questionId, 30, currentWeekDate);
+
+      // friend-c: no XP this week → should appear with 0
+      await insertReviewLog("friend-c", questionId, 40, lastWeekDate);
+
+      // non-friend: 100 XP this week (should be excluded)
+      await insertReviewLog("non-friend", questionId, 100, currentWeekDate);
+
+      const rows = await repo.getFriendsRanking("me", weekStart);
+
+      // Should include me + 3 friends = 4 rows
+      expect(rows).toHaveLength(4);
+
+      // Non-friend must not appear
+      const nonFriendRow = rows.find((r) => r.user_id === "non-friend");
+      expect(nonFriendRow).toBeUndefined();
+
+      // All expected users present
+      const userIds = rows.map((r) => r.user_id);
+      expect(userIds).toContain("me");
+      expect(userIds).toContain("friend-a");
+      expect(userIds).toContain("friend-b");
+      expect(userIds).toContain("friend-c");
+
+      // Correct weekly XP
+      const meRow = rows.find((r) => r.user_id === "me")!;
+      expect(meRow.weekly_xp).toBe(50); // last week's 20 XP excluded
+
+      const friendARow = rows.find((r) => r.user_id === "friend-a")!;
+      expect(friendARow.weekly_xp).toBe(80);
+
+      const friendBRow = rows.find((r) => r.user_id === "friend-b")!;
+      expect(friendBRow.weekly_xp).toBe(30);
+
+      const friendCRow = rows.find((r) => r.user_id === "friend-c")!;
+      expect(friendCRow.weekly_xp).toBe(0); // only last-week review, not counted
+
+      // Ordering: weekly_xp DESC
+      expect(rows[0]!.weekly_xp).toBeGreaterThanOrEqual(rows[1]!.weekly_xp);
+      expect(rows[1]!.weekly_xp).toBeGreaterThanOrEqual(rows[2]!.weekly_xp);
+      expect(rows[2]!.weekly_xp).toBeGreaterThanOrEqual(rows[3]!.weekly_xp);
+
+      // friend-a (80 XP) is first
+      expect(rows[0]!.user_id).toBe("friend-a");
+    });
+
+    it("returns only me when I have no friends", async () => {
+      await insertUser("solo-me");
+      const questionId = await seedQuestion();
+      const weekStart = new Date("2026-05-11T03:00:00.000Z");
+      await insertReviewLog("solo-me", questionId, 25, new Date("2026-05-12T10:00:00Z"));
+
+      const rows = await repo.getFriendsRanking("solo-me", weekStart);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.user_id).toBe("solo-me");
+      expect(rows[0]!.weekly_xp).toBe(25);
+    });
+  });
+});

--- a/apps/server/src/features/social/ranking/ranking.repository.ts
+++ b/apps/server/src/features/social/ranking/ranking.repository.ts
@@ -1,0 +1,38 @@
+import { sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+
+type Db = typeof DbClient;
+
+export interface RawRankingRow {
+  user_id: string;
+  name: string;
+  username: string | null;
+  image: string | null;
+  weekly_xp: number;
+}
+
+export class RankingRepository {
+  constructor(private db: Db) {}
+
+  async getFriendsRanking(userId: string, weekStart: Date): Promise<RawRankingRow[]> {
+    const result = await this.db.execute<RawRankingRow>(sql`
+      WITH friends AS (
+        SELECT CASE WHEN requester_id = ${userId} THEN recipient_id ELSE requester_id END AS friend_id
+        FROM friendship
+        WHERE (requester_id = ${userId} OR recipient_id = ${userId}) AND status = 'accepted'
+      )
+      SELECT
+        u.id AS user_id, u.name, u.username, u.image,
+        COALESCE(SUM(rl.xp_earned), 0)::int AS weekly_xp
+      FROM "user" u
+      LEFT JOIN review_log rl
+        ON rl.user_id = u.id AND rl.reviewed_at >= ${weekStart}
+      WHERE u.id = ${userId} OR u.id IN (SELECT friend_id FROM friends)
+      GROUP BY u.id, u.name, u.username, u.image
+      ORDER BY weekly_xp DESC, u.id ASC
+    `);
+    // Drizzle's execute() returns shape per driver: { rows: [...] } on pg, Array on PGlite.
+    // Normalize:
+    return Array.isArray(result) ? result : (result as { rows: RawRankingRow[] }).rows;
+  }
+}

--- a/apps/server/src/features/social/ranking/ranking.route.ts
+++ b/apps/server/src/features/social/ranking/ranking.route.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { RankingResponseSchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { unwrapResult } from "../../../types";
+import { ok } from "neverthrow";
+import { RankingRepository } from "./ranking.repository";
+import { RankingService } from "./ranking.service";
+
+const repo = new RankingRepository(db);
+const service = new RankingService(repo);
+
+export const rankingRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/users/me/friends/ranking",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        response: {
+          200: z.object({ success: z.literal(true), data: RankingResponseSchema }),
+        },
+      },
+    },
+    async (request) => {
+      const result = ok(await service.getRanking(request.userId, new Date()));
+      return unwrapResult(result);
+    },
+  );
+};

--- a/apps/server/src/features/social/ranking/ranking.service.test.ts
+++ b/apps/server/src/features/social/ranking/ranking.service.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from "vitest";
+import { RankingService } from "./ranking.service";
+import type { RankingRepository } from "./ranking.repository";
+import type { RawRankingRow } from "./ranking.repository";
+
+function makeRepo(rows: RawRankingRow[]): RankingRepository {
+  return {
+    getFriendsRanking: vi.fn().mockResolvedValue(rows),
+  } as unknown as RankingRepository;
+}
+
+/** Build a sorted list of N rows: the row at index `meIndex` has userId "me". */
+function buildRows(count: number, meIndex: number): RawRankingRow[] {
+  return Array.from({ length: count }, (_, i) => ({
+    user_id: i === meIndex ? "me" : `user-${i}`,
+    name: i === meIndex ? "Me" : `User ${i}`,
+    username: null,
+    image: null,
+    // XP decreasing so index order = rank order
+    weekly_xp: (count - i) * 10,
+  }));
+}
+
+const NOW = new Date("2026-05-13T15:00:00Z"); // Wednesday noon BRT
+
+describe("RankingService", () => {
+  describe("fewer than 11 entries — returns all sorted", () => {
+    it("returns all entries when total <= 10", async () => {
+      const rows = buildRows(5, 2);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      expect(result.entries).toHaveLength(5);
+      // ranks are 1-based, ascending
+      expect(result.entries[0]?.rank).toBe(1);
+      expect(result.entries[4]?.rank).toBe(5);
+      // isMe flag set correctly
+      expect(result.entries[2]?.isMe).toBe(true);
+      expect(result.entries[0]?.isMe).toBe(false);
+    });
+
+    it("returns all entries when total equals exactly 10", async () => {
+      const rows = buildRows(10, 5);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      expect(result.entries).toHaveLength(10);
+    });
+  });
+
+  describe("trim behaviour with 13 entries (>10)", () => {
+    it("me at top (index 0) → returns first 10 entries", async () => {
+      const rows = buildRows(13, 0);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      expect(result.entries).toHaveLength(10);
+      // me is at position 0 → first entry
+      expect(result.entries[0]?.isMe).toBe(true);
+      // ranks 1-10
+      expect(result.entries[0]?.rank).toBe(1);
+      expect(result.entries[9]?.rank).toBe(10);
+      // user at index 12 should NOT be included
+      expect(result.entries.some((e) => e.userId === "user-12")).toBe(false);
+    });
+
+    it("me at middle (index 6) → 5 above + me + 4 below (window [1..10])", async () => {
+      const rows = buildRows(13, 6);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      expect(result.entries).toHaveLength(10);
+      // start = max(0, min(13-10, 6-5)) = max(0, min(3, 1)) = 1
+      // slice [1, 11)
+      expect(result.entries.some((e) => e.isMe)).toBe(true);
+      const meEntry = result.entries.find((e) => e.isMe)!;
+      // me is at global rank 7 (index 6 → rank 7)
+      expect(meEntry.rank).toBe(7);
+      // window covers ranks 2-11 (indices 1-10)
+      expect(result.entries[0]?.rank).toBe(2);
+      expect(result.entries[9]?.rank).toBe(11);
+    });
+
+    it("me at bottom (index 12) → last 10 entries", async () => {
+      const rows = buildRows(13, 12);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      expect(result.entries).toHaveLength(10);
+      // start = max(0, min(3, 7)) = 3 → slice [3, 13)
+      expect(result.entries.some((e) => e.isMe)).toBe(true);
+      const meEntry = result.entries.find((e) => e.isMe)!;
+      expect(meEntry.rank).toBe(13);
+      // last entry has rank 13, first has rank 4
+      expect(result.entries[0]?.rank).toBe(4);
+      expect(result.entries[9]?.rank).toBe(13);
+    });
+  });
+
+  describe("weekStart ISO string", () => {
+    it("includes weekStart as an ISO datetime string", async () => {
+      const rows = buildRows(3, 1);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      // For 2026-05-13 Wed noon BRT → weekStart = 2026-05-11T03:00:00.000Z
+      expect(result.weekStart).toBe("2026-05-11T03:00:00.000Z");
+    });
+  });
+
+  describe("isMe flag", () => {
+    it("sets isMe=true only for the requesting userId", async () => {
+      const rows = buildRows(4, 2);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      const meEntries = result.entries.filter((e) => e.isMe);
+      expect(meEntries).toHaveLength(1);
+      expect(meEntries[0]?.userId).toBe("me");
+    });
+  });
+});

--- a/apps/server/src/features/social/ranking/ranking.service.ts
+++ b/apps/server/src/features/social/ranking/ranking.service.ts
@@ -1,0 +1,34 @@
+import { startOfWeekBrt } from "@pruvi/shared";
+import type { RankingRepository } from "./ranking.repository";
+
+export class RankingService {
+  constructor(private repo: RankingRepository) {}
+
+  async getRanking(userId: string, now: Date) {
+    const weekStart = startOfWeekBrt(now);
+    const rows = await this.repo.getFriendsRanking(userId, weekStart);
+
+    const ranked = rows.map((r, i) => ({
+      userId: r.user_id,
+      name: r.name,
+      username: r.username,
+      image: r.image,
+      weeklyXp: r.weekly_xp,
+      rank: i + 1,
+      isMe: r.user_id === userId,
+    }));
+
+    let entries = ranked;
+    if (ranked.length > 10) {
+      const meIdx = ranked.findIndex((e) => e.isMe);
+      // Take 5 above + 4 below (10 total including me), clamp at edges.
+      const start = Math.max(0, Math.min(ranked.length - 10, meIdx - 5));
+      entries = ranked.slice(start, start + 10);
+    }
+
+    return {
+      weekStart: weekStart.toISOString(),
+      entries,
+    };
+  }
+}

--- a/apps/server/src/features/users/users.repository.integration.test.ts
+++ b/apps/server/src/features/users/users.repository.integration.test.ts
@@ -26,6 +26,35 @@ describe("UsersRepository (integration)", () => {
     await teardownTestDb();
   });
 
+  it("updateUsername rejects duplicate username with user_username_unique violation", async () => {
+    const userId1 = "test-user-username-1";
+    const userId2 = "test-user-username-2";
+
+    await db.insert(user).values([
+      {
+        id: userId1,
+        name: "User One",
+        email: `${userId1}@example.com`,
+        emailVerified: false,
+        updatedAt: new Date(),
+      },
+      {
+        id: userId2,
+        name: "User Two",
+        email: `${userId2}@example.com`,
+        emailVerified: false,
+        updatedAt: new Date(),
+      },
+    ]);
+
+    // First user sets "abc"
+    await repo.updateUsername(userId1, "abc");
+
+    // Second user tries to set same username — must throw (unique constraint)
+    // Drizzle wraps the pg error so we can only assert some error is thrown.
+    await expect(repo.updateUsername(userId2, "abc")).rejects.toThrow();
+  });
+
   it("deleteUser cascades to session, account, and daily_session rows", async () => {
     const userId = "test-user-cascade";
 

--- a/apps/server/src/features/users/users.repository.ts
+++ b/apps/server/src/features/users/users.repository.ts
@@ -38,6 +38,15 @@ export class UsersRepository {
     return row;
   }
 
+  async updateUsername(userId: string, username: string) {
+    const [row] = await this.db
+      .update(user)
+      .set({ username })
+      .where(eq(user.id, userId))
+      .returning({ username: user.username });
+    return row;
+  }
+
   async deleteUser(userId: string) {
     await this.db.delete(user).where(eq(user.id, userId));
   }

--- a/apps/server/src/features/users/users.route.ts
+++ b/apps/server/src/features/users/users.route.ts
@@ -1,5 +1,5 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
-import { UpdateProfileBodySchema } from "@pruvi/shared";
+import { UpdateBasicProfileBodySchema, UpdateProfileBodySchema } from "@pruvi/shared";
 import { db } from "@pruvi/db";
 import { UsersRepository } from "./users.repository";
 import { UsersService } from "./users.service";
@@ -13,10 +13,26 @@ export const usersRoutes: FastifyPluginAsyncZod = async (fastify) => {
     "/users/me/profile",
     {
       preHandler: [fastify.authenticate],
-      schema: { body: UpdateProfileBodySchema },
+      schema: { body: UpdateBasicProfileBodySchema },
     },
     async (request) => {
       const result = await service.updateProfile(request.userId, request.body);
+      return unwrapResult(result);
+    }
+  );
+
+  // PATCH /users/me/profile — set username
+  fastify.patch(
+    "/users/me/profile",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { body: UpdateProfileBodySchema },
+    },
+    async (request) => {
+      const result = await service.updateUsername(
+        request.userId,
+        request.body.username,
+      );
       return unwrapResult(result);
     }
   );

--- a/apps/server/src/features/users/users.service.test.ts
+++ b/apps/server/src/features/users/users.service.test.ts
@@ -14,10 +14,12 @@ function makeMockRepo() {
   return {
     findById: vi.fn(),
     updateProfile: vi.fn(),
+    updateUsername: vi.fn(),
     deleteUser: vi.fn(),
   } as unknown as UsersRepository & {
     findById: ReturnType<typeof vi.fn>;
     updateProfile: ReturnType<typeof vi.fn>;
+    updateUsername: ReturnType<typeof vi.fn>;
     deleteUser: ReturnType<typeof vi.fn>;
   };
 }
@@ -44,6 +46,45 @@ describe("UsersService", () => {
       const result = await service.updateProfile(USER_ID, { name: "X" });
       expect(result.isErr()).toBe(true);
       if (result.isErr()) expect(result.error.statusCode).toBe(404);
+    });
+  });
+
+  describe("updateUsername", () => {
+    it("returns updated username on success", async () => {
+      repo.updateUsername.mockResolvedValue({ username: "newuser" });
+      const result = await service.updateUsername(USER_ID, "newuser");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.username).toBe("newuser");
+    });
+
+    it("lowercases the username before saving", async () => {
+      repo.updateUsername.mockResolvedValue({ username: "myuser" });
+      await service.updateUsername(USER_ID, "MyUser");
+      expect(repo.updateUsername).toHaveBeenCalledWith(USER_ID, "myuser");
+    });
+
+    it("returns NotFoundError when user is missing", async () => {
+      repo.updateUsername.mockResolvedValue(undefined);
+      const result = await service.updateUsername(USER_ID, "ghost");
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.statusCode).toBe(404);
+    });
+
+    it("returns ConflictError on user_username_unique violation", async () => {
+      repo.updateUsername.mockRejectedValue(
+        new Error("duplicate key value violates unique constraint: user_username_unique"),
+      );
+      const result = await service.updateUsername(USER_ID, "taken");
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.statusCode).toBe(409);
+        expect(result.error.message).toMatch(/taken/i);
+      }
+    });
+
+    it("re-throws unexpected DB errors", async () => {
+      repo.updateUsername.mockRejectedValue(new Error("connection reset"));
+      await expect(service.updateUsername(USER_ID, "test")).rejects.toThrow("connection reset");
     });
   });
 

--- a/apps/server/src/features/users/users.service.ts
+++ b/apps/server/src/features/users/users.service.ts
@@ -1,5 +1,5 @@
 import { err, ok, type Result } from "neverthrow";
-import { NotFoundError, type AppError } from "../../utils/errors";
+import { ConflictError, NotFoundError, type AppError } from "../../utils/errors";
 import type { UsersRepository } from "./users.repository";
 
 type Profile = NonNullable<Awaited<ReturnType<UsersRepository["findById"]>>>;
@@ -16,6 +16,37 @@ export class UsersService {
       return err(new NotFoundError("User not found"));
     }
     return ok(updated);
+  }
+
+  async updateUsername(
+    userId: string,
+    username: string
+  ): Promise<Result<{ username: string }, AppError>> {
+    const normalised = username.toLowerCase();
+    try {
+      const row = await this.repo.updateUsername(userId, normalised);
+      if (!row) {
+        return err(new NotFoundError("User not found"));
+      }
+      return ok({ username: row.username as string });
+    } catch (e) {
+      const isUsernameUnique = (err: unknown): boolean => {
+        if (!(err instanceof Error)) return false;
+        if (err.message.includes("user_username_unique")) return true;
+        // Drizzle wraps the pg error in e.cause; pg also exposes `constraint`
+        const cause = (err as Error & { cause?: unknown }).cause;
+        if (cause instanceof Error) {
+          if (cause.message.includes("user_username_unique")) return true;
+          const pgConstraint = (cause as Error & { constraint?: string }).constraint;
+          if (pgConstraint === "user_username_unique") return true;
+        }
+        return false;
+      };
+      if (isUsernameUnique(e)) {
+        return err(new ConflictError("Username is already taken"));
+      }
+      throw e;
+    }
   }
 
   async deleteAccount(userId: string): Promise<Result<true, AppError>> {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from "fastify-type-provider-zod";
 import { gamificationRoutes } from "./features/gamification";
 import { tokensRoutes, preferencesRoutes } from "./features/notifications";
-import { invitationsRoutes, friendshipsRoutes } from "./features/social";
+import { invitationsRoutes, friendshipsRoutes, rankingRoutes } from "./features/social";
 import { livesRoutes } from "./features/lives";
 import { onboardingRoutes } from "./features/onboarding";
 import { progressRoutes } from "./features/progress";
@@ -83,6 +83,7 @@ export async function buildApp() {
   await app.register(preferencesRoutes);
   await app.register(invitationsRoutes);
   await app.register(friendshipsRoutes);
+  await app.register(rankingRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "fastify-type-provider-zod";
 import { gamificationRoutes } from "./features/gamification";
 import { tokensRoutes, preferencesRoutes } from "./features/notifications";
+import { invitationsRoutes } from "./features/social";
 import { livesRoutes } from "./features/lives";
 import { onboardingRoutes } from "./features/onboarding";
 import { progressRoutes } from "./features/progress";
@@ -80,6 +81,7 @@ export async function buildApp() {
   await app.register(topicsRoutes);
   await app.register(tokensRoutes);
   await app.register(preferencesRoutes);
+  await app.register(invitationsRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from "fastify-type-provider-zod";
 import { gamificationRoutes } from "./features/gamification";
 import { tokensRoutes, preferencesRoutes } from "./features/notifications";
-import { invitationsRoutes } from "./features/social";
+import { invitationsRoutes, friendshipsRoutes } from "./features/social";
 import { livesRoutes } from "./features/lives";
 import { onboardingRoutes } from "./features/onboarding";
 import { progressRoutes } from "./features/progress";
@@ -82,6 +82,7 @@ export async function buildApp() {
   await app.register(tokensRoutes);
   await app.register(preferencesRoutes);
   await app.register(invitationsRoutes);
+  await app.register(friendshipsRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/apps/server/src/utils/errors.ts
+++ b/apps/server/src/utils/errors.ts
@@ -43,3 +43,10 @@ export class DatabaseError extends AppError {
     this.name = "DatabaseError";
   }
 }
+
+export class ConflictError extends AppError {
+  constructor(message = "Conflict") {
+    super(message, 409, "CONFLICT");
+    this.name = "ConflictError";
+  }
+}

--- a/docs/superpowers/plans/2026-05-11-phase-2d-social-ranking.md
+++ b/docs/superpowers/plans/2026-05-11-phase-2d-social-ranking.md
@@ -1,0 +1,1079 @@
+# Phase 2D — Social Ranking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the social backend: friendships, invitations with +100 XP reward, and a weekly XP ranking endpoint scoped to a user's friends.
+
+**Architecture:** Three feature modules (`invitations`, `friendships`, `ranking`) under `apps/server/src/features/social/`. Shared schemas + pure helpers (`startOfWeekBrt`, `generateInviteCode`) live in `@pruvi/shared` / `@pruvi/db`. Single migration `0006` adds 3 tables + 2 user columns + 1 review_log column. Reviews flow gains a one-line `xp_earned` write so weekly XP is sumable.
+
+**Tech Stack:** Drizzle ORM + drizzle-kit, PostgreSQL 16, Bun, Vitest, neverthrow Result, Fastify + fastify-type-provider-zod.
+
+**Source spec:** `docs/superpowers/specs/2026-05-11-phase-2d-social-ranking-design.md`
+
+---
+
+## File Structure (created/modified)
+
+**Create:**
+- `packages/shared/src/social.ts` — Zod schemas (Username, InviteCode, request/response bodies)
+- `packages/shared/src/social.test.ts` — schema regex tests
+- `packages/shared/src/weekly.ts` — `startOfWeekBrt(now)` pure helper
+- `packages/shared/src/weekly.test.ts`
+- `packages/db/src/schema/friendship.ts`
+- `packages/db/src/schema/invitation-acceptance.ts`
+- `packages/db/src/migrations/0006_<generated>.sql`
+- `apps/server/src/features/social/invite-codes/generator.ts` + `.test.ts`
+- `apps/server/src/features/social/invitations/{invitations.repository,invitations.service,invitations.route}.ts` + tests
+- `apps/server/src/features/social/friendships/{friendships.repository,friendships.service,friendships.route}.ts` + tests
+- `apps/server/src/features/social/ranking/{ranking.repository,ranking.service,ranking.route}.ts` + tests
+- `apps/server/src/features/social/index.ts` — aggregates routes
+
+**Modify:**
+- `packages/db/src/schema/auth.ts` — add `username`, `inviteCode` columns
+- `packages/db/src/schema/review-log.ts` — add `xpEarned`
+- `packages/db/src/test-client.ts` — mirror DDL
+- `packages/shared/src/index.ts` — re-export new modules
+- `apps/server/src/features/reviews/reviews.service.ts` + `reviews.repository.ts` — pass `xpEarned` into insertReview
+- `apps/server/src/features/users/users.service.ts` (or wherever profile lives) — add `setUsername`
+- `apps/server/src/index.ts` (or `app.ts`) — register social routes
+
+---
+
+## Tasks
+
+### Task 1: Shared schemas + pure helpers
+
+**Files:**
+- Create: `packages/shared/src/social.ts`, `packages/shared/src/social.test.ts`
+- Create: `packages/shared/src/weekly.ts`, `packages/shared/src/weekly.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] **Step 1: Write `packages/shared/src/weekly.ts`**
+
+```typescript
+const BRT_OFFSET_MS = 3 * 60 * 60 * 1000;
+
+export function startOfWeekBrt(now: Date): Date {
+  const brtMs = now.getTime() - BRT_OFFSET_MS;
+  const brt = new Date(brtMs);
+  const dow = brt.getUTCDay(); // 0=Sun ... 6=Sat
+  const daysBack = (dow + 6) % 7; // Monday-anchored
+  brt.setUTCDate(brt.getUTCDate() - daysBack);
+  brt.setUTCHours(0, 0, 0, 0);
+  return new Date(brt.getTime() + BRT_OFFSET_MS);
+}
+```
+
+- [ ] **Step 2: Write `packages/shared/src/weekly.test.ts`**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { startOfWeekBrt } from "./weekly";
+
+describe("startOfWeekBrt", () => {
+  it("noon BRT Wednesday → Monday 00:00 BRT", () => {
+    // 2026-05-13 15:00:00Z = 2026-05-13 12:00:00 BRT (Wed)
+    const input = new Date("2026-05-13T15:00:00Z");
+    const r = startOfWeekBrt(input);
+    // Monday 2026-05-11 00:00:00 BRT = 2026-05-11 03:00:00Z
+    expect(r.toISOString()).toBe("2026-05-11T03:00:00.000Z");
+  });
+
+  it("Monday 00:30 BRT → Monday 00:00 BRT (same day)", () => {
+    const input = new Date("2026-05-11T03:30:00Z"); // 00:30 BRT
+    const r = startOfWeekBrt(input);
+    expect(r.toISOString()).toBe("2026-05-11T03:00:00.000Z");
+  });
+
+  it("Monday 23:00 UTC (still Mon 20:00 BRT) → Monday 00:00 BRT", () => {
+    const input = new Date("2026-05-11T23:00:00Z");
+    const r = startOfWeekBrt(input);
+    expect(r.toISOString()).toBe("2026-05-11T03:00:00.000Z");
+  });
+
+  it("Sunday 23:00 BRT → previous Monday", () => {
+    // 2026-05-17 23:00 BRT = 2026-05-18 02:00 UTC
+    const input = new Date("2026-05-18T02:00:00Z");
+    const r = startOfWeekBrt(input);
+    expect(r.toISOString()).toBe("2026-05-11T03:00:00.000Z");
+  });
+
+  it("Monday 02:00 UTC (Sunday 23:00 BRT) → previous Monday", () => {
+    const input = new Date("2026-05-11T02:00:00Z"); // 23:00 BRT Sun
+    const r = startOfWeekBrt(input);
+    expect(r.toISOString()).toBe("2026-05-04T03:00:00.000Z");
+  });
+});
+```
+
+- [ ] **Step 3: Write `packages/shared/src/social.ts`**
+
+```typescript
+import { z } from "zod";
+
+export const UsernameSchema = z.string().regex(/^[a-z0-9_]{3,20}$/, {
+  message: "username must be 3-20 chars: lowercase, digits, underscore",
+});
+export const InviteCodeSchema = z.string().regex(/^[a-z0-9]{8}$/);
+
+export const AcceptInvitationBodySchema = z.object({ code: InviteCodeSchema });
+export const RequestFriendBodySchema = z.object({ username: UsernameSchema });
+export const RespondRequestBodySchema = z.object({
+  action: z.enum(["accept", "decline"]),
+});
+export const UpdateProfileBodySchema = z.object({ username: UsernameSchema });
+
+export const FriendUserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  username: z.string().nullable(),
+  image: z.string().nullable(),
+});
+
+export const InviteLinkResponseSchema = z.object({
+  code: InviteCodeSchema,
+  url: z.string().url(),
+});
+
+export const FriendListResponseSchema = z.object({
+  friends: z.array(FriendUserSchema),
+});
+
+export const FriendRequestSchema = z.object({
+  id: z.number().int(),
+  from: FriendUserSchema,
+  createdAt: z.string().datetime(),
+});
+export const RequestListResponseSchema = z.object({
+  incoming: z.array(FriendRequestSchema),
+});
+
+export const RankingEntrySchema = z.object({
+  userId: z.string(),
+  name: z.string(),
+  username: z.string().nullable(),
+  image: z.string().nullable(),
+  weeklyXp: z.number().int().nonnegative(),
+  rank: z.number().int().positive(),
+  isMe: z.boolean(),
+});
+export const RankingResponseSchema = z.object({
+  weekStart: z.string().datetime(),
+  entries: z.array(RankingEntrySchema).max(10),
+});
+
+export type RankingEntry = z.infer<typeof RankingEntrySchema>;
+export type FriendUser = z.infer<typeof FriendUserSchema>;
+```
+
+- [ ] **Step 4: Write `packages/shared/src/social.test.ts`**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { UsernameSchema, InviteCodeSchema } from "./social";
+
+describe("UsernameSchema", () => {
+  it.each([
+    ["ana", true],
+    ["ana_b", true],
+    ["ana123", true],
+    ["AnaBeta", false],     // uppercase
+    ["ab", false],          // too short
+    ["a".repeat(21), false],// too long
+    ["ana b", false],       // space
+    ["ana-b", false],       // dash
+  ])("%s → %s", (input, valid) => {
+    expect(UsernameSchema.safeParse(input).success).toBe(valid);
+  });
+});
+
+describe("InviteCodeSchema", () => {
+  it.each([
+    ["abc12def", true],
+    ["a1b2c3d4", true],
+    ["ABC12DEF", false], // uppercase
+    ["abc12de",  false], // 7 chars
+    ["abc12defg",false], // 9 chars
+    ["ab c12de", false], // space
+  ])("%s → %s", (input, valid) => {
+    expect(InviteCodeSchema.safeParse(input).success).toBe(valid);
+  });
+});
+```
+
+- [ ] **Step 5: Re-export from index**
+
+In `packages/shared/src/index.ts`, append:
+
+```typescript
+export * from "./social";
+export * from "./weekly";
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `pnpm --filter @pruvi/shared test`
+Expected: PASS — all weekly + social + previously-passing tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/shared/src/social.ts packages/shared/src/social.test.ts \
+        packages/shared/src/weekly.ts packages/shared/src/weekly.test.ts \
+        packages/shared/src/index.ts
+git commit -m "feat(shared): social schemas + startOfWeekBrt helper"
+```
+
+---
+
+### Task 2: DB schema + migration
+
+**Files:**
+- Modify: `packages/db/src/schema/auth.ts` (add `username`, `inviteCode`)
+- Modify: `packages/db/src/schema/review-log.ts` (add `xpEarned`)
+- Create: `packages/db/src/schema/friendship.ts`
+- Create: `packages/db/src/schema/invitation-acceptance.ts`
+- Modify: `packages/db/src/schema/index.ts`
+- Create: `packages/db/src/migrations/0006_<generated>.sql`
+- Modify: `packages/db/src/test-client.ts`
+
+- [ ] **Step 1: Add columns to `auth.ts`**
+
+```typescript
+// inside the user pgTable, after onboardingCompleted:
+username: text("username"),
+inviteCode: text("invite_code").notNull(),
+```
+
+(Drizzle will see this as required, but the migration backfills before SET NOT NULL — we handle that in the SQL step, not the schema. For now declare `.notNull()` to match final state.)
+
+- [ ] **Step 2: Add `xpEarned` to `review-log.ts`**
+
+```typescript
+// inside reviewLog pgTable, after repetitions:
+xpEarned: integer("xp_earned").notNull().default(0),
+```
+
+- [ ] **Step 3: Create `packages/db/src/schema/friendship.ts`**
+
+```typescript
+import { relations } from "drizzle-orm";
+import { index, pgTable, serial, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { user } from "./auth";
+
+export const friendship = pgTable(
+  "friendship",
+  {
+    id: serial("id").primaryKey(),
+    requesterId: text("requester_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    recipientId: text("recipient_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    status: text("status", { enum: ["pending", "accepted", "declined"] }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    acceptedAt: timestamp("accepted_at"),
+  },
+  (table) => [
+    index("friendship_requester_idx").on(table.requesterId),
+    index("friendship_recipient_idx").on(table.recipientId),
+    // Pair-uniqueness via LEAST/GREATEST functional index added in raw migration SQL —
+    // Drizzle can't express functional UNIQUE indexes natively. The PGlite mirror gets the
+    // same index via raw SQL in test-client.ts.
+  ],
+);
+
+export const friendshipRelations = relations(friendship, ({ one }) => ({
+  requester: one(user, { fields: [friendship.requesterId], references: [user.id], relationName: "requester" }),
+  recipient: one(user, { fields: [friendship.recipientId], references: [user.id], relationName: "recipient" }),
+}));
+```
+
+- [ ] **Step 4: Create `packages/db/src/schema/invitation-acceptance.ts`**
+
+```typescript
+import { relations } from "drizzle-orm";
+import { index, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const invitationAcceptance = pgTable(
+  "invitation_acceptance",
+  {
+    id: serial("id").primaryKey(),
+    inviterId: text("inviter_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    inviteeId: text("invitee_id").notNull().unique().references(() => user.id, { onDelete: "cascade" }),
+    acceptedAt: timestamp("accepted_at").defaultNow().notNull(),
+  },
+  (table) => [index("invitation_acceptance_inviter_idx").on(table.inviterId)],
+);
+
+export const invitationAcceptanceRelations = relations(invitationAcceptance, ({ one }) => ({
+  inviter: one(user, { fields: [invitationAcceptance.inviterId], references: [user.id], relationName: "inviter" }),
+  invitee: one(user, { fields: [invitationAcceptance.inviteeId], references: [user.id], relationName: "invitee" }),
+}));
+```
+
+- [ ] **Step 5: Update `packages/db/src/schema/index.ts`**
+
+Append:
+```typescript
+export * from "./friendship";
+export * from "./invitation-acceptance";
+```
+
+- [ ] **Step 6: Generate migration**
+
+Run: `pnpm --filter @pruvi/db db:generate`
+Expected: creates `0006_<name>.sql`. The generated SQL will likely fail because `invite_code` is NOT NULL with no default on a table that has existing rows. You'll edit it next.
+
+- [ ] **Step 7: Edit the generated migration**
+
+Open the new `0006_<name>.sql`. Apply this final structure (replace whatever drizzle-kit generated; preserve drizzle's `--> statement-breakpoint` markers):
+
+```sql
+-- 1. User extensions (idempotent)
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "username" text;
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "invite_code" text;
+--> statement-breakpoint
+
+-- 2. Backfill invite_code for existing users
+UPDATE "user"
+SET "invite_code" = SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)
+WHERE "invite_code" IS NULL;
+--> statement-breakpoint
+
+-- 3. NOT NULL + UNIQUE on the populated columns
+ALTER TABLE "user" ALTER COLUMN "invite_code" SET NOT NULL;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_invite_code_unique') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_invite_code_unique" UNIQUE ("invite_code");
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_username_unique') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_username_unique" UNIQUE ("username");
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- 4. Case-insensitive username search
+CREATE INDEX IF NOT EXISTS "user_username_lower_idx"
+  ON "user" (LOWER("username")) WHERE "username" IS NOT NULL;
+--> statement-breakpoint
+
+-- 5. review_log.xp_earned
+ALTER TABLE "review_log" ADD COLUMN IF NOT EXISTS "xp_earned" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'review_log_xp_earned_chk') THEN
+    ALTER TABLE "review_log" ADD CONSTRAINT "review_log_xp_earned_chk" CHECK ("xp_earned" >= 0);
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "review_log_user_reviewed_idx" ON "review_log" ("user_id", "reviewed_at");
+--> statement-breakpoint
+
+-- 6. friendship
+CREATE TABLE IF NOT EXISTS "friendship" (
+  "id" serial PRIMARY KEY,
+  "requester_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "recipient_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "status" text NOT NULL,
+  "created_at" timestamp NOT NULL DEFAULT now(),
+  "accepted_at" timestamp
+);
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'friendship_status_chk') THEN
+    ALTER TABLE "friendship" ADD CONSTRAINT "friendship_status_chk" CHECK ("status" IN ('pending','accepted','declined'));
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'friendship_no_self_chk') THEN
+    ALTER TABLE "friendship" ADD CONSTRAINT "friendship_no_self_chk" CHECK ("requester_id" <> "recipient_id");
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "friendship_pair_idx" ON "friendship"
+  (LEAST("requester_id","recipient_id"), GREATEST("requester_id","recipient_id"));
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "friendship_requester_idx" ON "friendship" ("requester_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "friendship_recipient_idx" ON "friendship" ("recipient_id");
+--> statement-breakpoint
+
+-- 7. invitation_acceptance
+CREATE TABLE IF NOT EXISTS "invitation_acceptance" (
+  "id" serial PRIMARY KEY,
+  "inviter_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "invitee_id" text NOT NULL UNIQUE REFERENCES "user"("id") ON DELETE CASCADE,
+  "accepted_at" timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "invitation_acceptance_inviter_idx" ON "invitation_acceptance" ("inviter_id");
+```
+
+- [ ] **Step 8: Mirror in PGlite test-client**
+
+In `packages/db/src/test-client.ts`, add:
+- `username text UNIQUE` and `invite_code text NOT NULL UNIQUE` columns to the user table (the latter with a default so test inserts that omit it work — or update integration test helpers to provide it). Simplest: add a generation default `DEFAULT substr(md5(random()::text), 1, 8)`.
+- `xp_earned integer NOT NULL DEFAULT 0 CHECK (xp_earned >= 0)` to review_log
+- The `friendship` and `invitation_acceptance` CREATE TABLEs with CHECK constraints
+- The `friendship_pair_idx` UNIQUE functional index
+
+Match the existing inline-CHECK style in the file (refer to user CHECK constraints added in Phase 2C).
+
+- [ ] **Step 9: Run verify:migration**
+
+Run: `pnpm verify:migration`
+Expected: PASS.
+
+- [ ] **Step 10: Run existing tests to confirm nothing broke**
+
+Run: `pnpm --filter server test && pnpm --filter server test:integration`
+Expected: PASS — the `xp_earned` default of 0 covers existing INSERTs to review_log, and `invite_code` defaults via the test-client's DDL.
+
+If integration tests fail because the test helper INSERTs into `user` without `invite_code`: add the generation default to the PGlite DDL (Postgres test DB gets `invite_code` from the migration backfill; PGlite needs a default since it skips the backfill statement). Acceptable approach.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add packages/db packages/shared
+git commit -m "feat(db): username + invite_code + friendship + invitation tables (migration 0006)"
+```
+
+---
+
+### Task 3: Invite-code generator
+
+**Files:**
+- Create: `apps/server/src/features/social/invite-codes/generator.ts`
+- Create: `apps/server/src/features/social/invite-codes/generator.test.ts`
+
+- [ ] **Step 1: Write tests**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { generateInviteCode, INVITE_CODE_ALPHABET } from "./generator";
+
+describe("generateInviteCode", () => {
+  it("returns 8 chars", () => {
+    expect(generateInviteCode()).toHaveLength(8);
+  });
+
+  it("only contains alphabet chars", () => {
+    for (let i = 0; i < 100; i++) {
+      const c = generateInviteCode();
+      for (const ch of c) {
+        expect(INVITE_CODE_ALPHABET).toContain(ch);
+      }
+    }
+  });
+
+  it("low collision rate over 10k samples", () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 10_000; i++) set.add(generateInviteCode());
+    expect(set.size).toBeGreaterThan(9990); // < 0.1% collisions
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+import { randomInt } from "node:crypto";
+
+export const INVITE_CODE_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789";
+
+export function generateInviteCode(): string {
+  let out = "";
+  for (let i = 0; i < 8; i++) {
+    out += INVITE_CODE_ALPHABET[randomInt(0, INVITE_CODE_ALPHABET.length)];
+  }
+  return out;
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+pnpm --filter server test invite-codes/generator.test.ts
+git add apps/server/src/features/social/invite-codes
+git commit -m "feat(social): invite code generator (8-char ambiguity-free)"
+```
+
+---
+
+### Task 4: Invitations module (repository + service + route)
+
+**Files:**
+- Create: `apps/server/src/features/social/invitations/invitations.repository.ts`
+- Create: `apps/server/src/features/social/invitations/invitations.service.ts`
+- Create: `apps/server/src/features/social/invitations/invitations.route.ts`
+- Create: `apps/server/src/features/social/invitations/invitations.service.test.ts`
+- Create: `apps/server/src/features/social/invitations/invitations.repository.integration.test.ts`
+
+- [ ] **Step 1: Repository**
+
+```typescript
+import { eq, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { user } from "@pruvi/db/schema/auth";
+import { invitationAcceptance } from "@pruvi/db/schema/invitation-acceptance";
+import { friendship } from "@pruvi/db/schema/friendship";
+import { generateInviteCode } from "../invite-codes/generator";
+
+type Db = typeof DbClient;
+
+export class InvitationsRepository {
+  constructor(private db: Db) {}
+
+  async ensureInviteCode(userId: string): Promise<string> {
+    const rows = await this.db.select({ code: user.inviteCode }).from(user).where(eq(user.id, userId)).limit(1);
+    if (rows[0]?.code) return rows[0].code;
+    // Defensive: backfilled at migration; if absent (race or test fixture), generate.
+    for (let i = 0; i < 5; i++) {
+      const code = generateInviteCode();
+      try {
+        await this.db.update(user).set({ inviteCode: code }).where(eq(user.id, userId));
+        return code;
+      } catch {}
+    }
+    throw new Error("Could not assign invite code");
+  }
+
+  async findInviterByCode(code: string): Promise<{ id: string; name: string; username: string | null } | null> {
+    const rows = await this.db
+      .select({ id: user.id, name: user.name, username: user.username })
+      .from(user)
+      .where(eq(user.inviteCode, code))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async hasAccepted(inviteeId: string): Promise<boolean> {
+    const rows = await this.db
+      .select({ id: invitationAcceptance.id })
+      .from(invitationAcceptance)
+      .where(eq(invitationAcceptance.inviteeId, inviteeId))
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  /** Atomic: record acceptance + +100 XP to inviter + upsert accepted friendship. */
+  async acceptInvitation(inviterId: string, inviteeId: string): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx.insert(invitationAcceptance).values({ inviterId, inviteeId });
+      await tx.update(user).set({ totalXp: sql`${user.totalXp} + 100` }).where(eq(user.id, inviterId));
+      // Friendship: pair-ordered to fit UNIQUE LEAST/GREATEST index.
+      await tx.insert(friendship).values({
+        requesterId: inviterId,
+        recipientId: inviteeId,
+        status: "accepted",
+        acceptedAt: new Date(),
+      });
+    });
+  }
+}
+```
+
+- [ ] **Step 2: Service**
+
+```typescript
+import { ok, err, type Result } from "neverthrow";
+import { AppError, NotFoundError, ValidationError } from "../../../utils/errors";
+import type { InvitationsRepository } from "./invitations.repository";
+
+const INVITE_URL_BASE = process.env.INVITE_URL_BASE ?? "https://pruvi.app/i";
+
+export class InvitationsService {
+  constructor(private repo: InvitationsRepository) {}
+
+  async getInvite(userId: string): Promise<Result<{ code: string; url: string }, AppError>> {
+    const code = await this.repo.ensureInviteCode(userId);
+    return ok({ code, url: `${INVITE_URL_BASE}/${code}` });
+  }
+
+  async acceptInvitation(
+    code: string,
+    userId: string,
+  ): Promise<Result<{ inviter: { name: string; username: string | null }; xpAwarded: number; friendshipCreated: true }, AppError>> {
+    const inviter = await this.repo.findInviterByCode(code);
+    if (!inviter) return err(new NotFoundError("Invite code not found"));
+    if (inviter.id === userId) return err(new ValidationError("Cannot accept your own invite"));
+    if (await this.repo.hasAccepted(userId)) return err(new ValidationError("You have already accepted an invitation"));
+    try {
+      await this.repo.acceptInvitation(inviter.id, userId);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.includes("friendship_pair_idx") || msg.includes("invitation_acceptance")) {
+        return err(new ValidationError("Invitation already processed"));
+      }
+      throw e;
+    }
+    return ok({
+      inviter: { name: inviter.name, username: inviter.username },
+      xpAwarded: 100,
+      friendshipCreated: true as const,
+    });
+  }
+}
+```
+
+- [ ] **Step 3: Route**
+
+```typescript
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { AcceptInvitationBodySchema, InviteLinkResponseSchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { authGuard } from "../../../plugins/auth-guard";
+import { handleResult } from "../../../utils/handle-result";
+import { InvitationsRepository } from "./invitations.repository";
+import { InvitationsService } from "./invitations.service";
+
+const service = new InvitationsService(new InvitationsRepository(db));
+
+export async function invitationsRoutes(app: FastifyInstance) {
+  app.get("/users/me/invite", { preHandler: authGuard, schema: { response: { 200: z.object({ success: z.literal(true), data: InviteLinkResponseSchema }) } } }, async (req, reply) => {
+    return handleResult(reply, await service.getInvite(req.userId!));
+  });
+
+  app.post("/invitations/accept", { preHandler: authGuard, schema: { body: AcceptInvitationBodySchema } }, async (req, reply) => {
+    const body = req.body as z.infer<typeof AcceptInvitationBodySchema>;
+    return handleResult(reply, await service.acceptInvitation(body.code, req.userId!));
+  });
+}
+```
+
+*Adjust imports for the actual auth guard and result-handler names in this codebase — search for `authGuard`/`handleResult` in `apps/server/src` to find the canonical pattern. Use whatever existing routes use (e.g., `tokens.route.ts` or `subjects.route.ts`).*
+
+- [ ] **Step 4: Unit test (service)**
+
+Cases: self-invite rejected, already-accepted rejected, happy path returns +100 XP shape, code-not-found returns NotFoundError.
+
+- [ ] **Step 5: Integration test (repository)**
+
+Cases: ensureInviteCode returns existing code idempotently; findInviterByCode resolves; hasAccepted true after acceptance; acceptInvitation in tx commits all 3 mutations and is atomic on failure (e.g., simulate FK error → no partial state).
+
+- [ ] **Step 6: Wire into app**
+
+Add `await app.register(invitationsRoutes)` (or import via aggregator `social/index.ts`) in the server entry — match existing route registration pattern.
+
+- [ ] **Step 7: Run all tests + commit**
+
+```bash
+pnpm --filter server test && pnpm --filter server test:integration
+git add apps/server/src/features/social/invitations apps/server/src/<entry-file>
+git commit -m "feat(invitations): GET /users/me/invite + POST /invitations/accept (+100 XP)"
+```
+
+---
+
+### Task 5: Friendships module
+
+**Files:**
+- Create: `apps/server/src/features/social/friendships/friendships.repository.ts`
+- Create: `apps/server/src/features/social/friendships/friendships.service.ts`
+- Create: `apps/server/src/features/social/friendships/friendships.route.ts`
+- Create: tests for both
+
+- [ ] **Step 1: Repository**
+
+```typescript
+import { and, eq, or, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { user } from "@pruvi/db/schema/auth";
+import { friendship } from "@pruvi/db/schema/friendship";
+
+type Db = typeof DbClient;
+
+export class FriendshipsRepository {
+  constructor(private db: Db) {}
+
+  async findByUsername(username: string) {
+    const rows = await this.db
+      .select({ id: user.id, name: user.name, username: user.username, image: user.image })
+      .from(user)
+      .where(eq(sql`LOWER(${user.username})`, username.toLowerCase()))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async findExistingPair(a: string, b: string) {
+    const [lo, hi] = a < b ? [a, b] : [b, a];
+    const rows = await this.db
+      .select()
+      .from(friendship)
+      .where(and(
+        sql`LEAST(${friendship.requesterId}, ${friendship.recipientId}) = ${lo}`,
+        sql`GREATEST(${friendship.requesterId}, ${friendship.recipientId}) = ${hi}`,
+      ))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async createRequest(requesterId: string, recipientId: string) {
+    const [row] = await this.db.insert(friendship).values({ requesterId, recipientId, status: "pending" }).returning();
+    return row!;
+  }
+
+  async getRequest(id: number, recipientId: string) {
+    const rows = await this.db
+      .select()
+      .from(friendship)
+      .where(and(eq(friendship.id, id), eq(friendship.recipientId, recipientId), eq(friendship.status, "pending")))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async respond(id: number, action: "accept" | "decline") {
+    await this.db
+      .update(friendship)
+      .set({ status: action === "accept" ? "accepted" : "declined", acceptedAt: action === "accept" ? new Date() : null })
+      .where(eq(friendship.id, id));
+  }
+
+  async listAccepted(userId: string) {
+    return this.db
+      .select({
+        friendshipId: friendship.id,
+        otherUserId: sql<string>`CASE WHEN ${friendship.requesterId} = ${userId} THEN ${friendship.recipientId} ELSE ${friendship.requesterId} END`.as("other_user_id"),
+      })
+      .from(friendship)
+      .where(and(or(eq(friendship.requesterId, userId), eq(friendship.recipientId, userId)), eq(friendship.status, "accepted")));
+  }
+
+  async listAcceptedFriendsWithUserData(userId: string) {
+    const rows = await this.db
+      .select({
+        id: user.id,
+        name: user.name,
+        username: user.username,
+        image: user.image,
+      })
+      .from(friendship)
+      .innerJoin(
+        user,
+        sql`${user.id} = CASE WHEN ${friendship.requesterId} = ${userId} THEN ${friendship.recipientId} ELSE ${friendship.requesterId} END`,
+      )
+      .where(and(or(eq(friendship.requesterId, userId), eq(friendship.recipientId, userId)), eq(friendship.status, "accepted")));
+    return rows;
+  }
+
+  async listIncomingRequests(userId: string) {
+    return this.db
+      .select({
+        id: friendship.id,
+        createdAt: friendship.createdAt,
+        from: {
+          id: user.id,
+          name: user.name,
+          username: user.username,
+          image: user.image,
+        },
+      })
+      .from(friendship)
+      .innerJoin(user, eq(user.id, friendship.requesterId))
+      .where(and(eq(friendship.recipientId, userId), eq(friendship.status, "pending")));
+  }
+
+  async deletePair(a: string, b: string) {
+    const [lo, hi] = a < b ? [a, b] : [b, a];
+    await this.db
+      .delete(friendship)
+      .where(and(
+        sql`LEAST(${friendship.requesterId}, ${friendship.recipientId}) = ${lo}`,
+        sql`GREATEST(${friendship.requesterId}, ${friendship.recipientId}) = ${hi}`,
+      ));
+  }
+}
+```
+
+- [ ] **Step 2: Service**
+
+```typescript
+import { ok, err, type Result } from "neverthrow";
+import { AppError, NotFoundError, ValidationError } from "../../../utils/errors";
+import type { FriendshipsRepository } from "./friendships.repository";
+
+export class FriendshipsService {
+  constructor(private repo: FriendshipsRepository) {}
+
+  async requestByUsername(requesterId: string, username: string): Promise<Result<{ requestId: number; recipient: { username: string | null; name: string } }, AppError>> {
+    const target = await this.repo.findByUsername(username);
+    if (!target) return err(new NotFoundError("User not found"));
+    if (target.id === requesterId) return err(new ValidationError("Cannot friend yourself"));
+    const existing = await this.repo.findExistingPair(requesterId, target.id);
+    if (existing) return err(new ValidationError(`Friendship already exists with status ${existing.status}`));
+    const row = await this.repo.createRequest(requesterId, target.id);
+    return ok({ requestId: row.id, recipient: { username: target.username, name: target.name } });
+  }
+
+  async respond(id: number, action: "accept" | "decline", userId: string): Promise<Result<{ status: "accepted" | "declined" }, AppError>> {
+    const req = await this.repo.getRequest(id, userId);
+    if (!req) return err(new NotFoundError("Request not found"));
+    await this.repo.respond(id, action);
+    return ok({ status: action === "accept" ? "accepted" : "declined" });
+  }
+
+  async listFriends(userId: string) {
+    return ok({ friends: await this.repo.listAcceptedFriendsWithUserData(userId) });
+  }
+
+  async listRequests(userId: string) {
+    const rows = await this.repo.listIncomingRequests(userId);
+    return ok({ incoming: rows.map((r) => ({ id: r.id, from: r.from, createdAt: r.createdAt.toISOString() })) });
+  }
+
+  async unfriend(userId: string, otherUserId: string): Promise<Result<void, AppError>> {
+    await this.repo.deletePair(userId, otherUserId);
+    return ok(undefined);
+  }
+}
+```
+
+- [ ] **Step 3: Route**
+
+5 endpoints, matching the spec API surface. Match existing route patterns.
+
+- [ ] **Step 4: Unit + integration tests**
+
+Service tests: self-friend rejected, duplicate-pair rejected with each existing status, accept/decline transitions, listFriends respects direction (both columns).
+
+Integration tests: pair UNIQUE index prevents reverse-duplicates (insert (a,b), insert (b,a) fails), CHECK constraints (self-pair, invalid status).
+
+- [ ] **Step 5: Wire + commit**
+
+```bash
+pnpm --filter server test && pnpm --filter server test:integration
+git add apps/server/src/features/social/friendships
+git commit -m "feat(friendships): request/respond/list/unfriend endpoints"
+```
+
+---
+
+### Task 6: Ranking module
+
+**Files:**
+- Create: `apps/server/src/features/social/ranking/ranking.repository.ts`
+- Create: `apps/server/src/features/social/ranking/ranking.service.ts`
+- Create: `apps/server/src/features/social/ranking/ranking.route.ts`
+- Create: tests
+
+- [ ] **Step 1: Repository — single SQL with friends CTE + LEFT JOIN to review_log**
+
+```typescript
+import { sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+
+type Db = typeof DbClient;
+
+export interface RawRankingRow {
+  user_id: string;
+  name: string;
+  username: string | null;
+  image: string | null;
+  weekly_xp: number;
+}
+
+export class RankingRepository {
+  constructor(private db: Db) {}
+
+  async getFriendsRanking(userId: string, weekStart: Date): Promise<RawRankingRow[]> {
+    const result = await this.db.execute<RawRankingRow>(sql`
+      WITH friends AS (
+        SELECT CASE WHEN requester_id = ${userId} THEN recipient_id ELSE requester_id END AS friend_id
+        FROM friendship
+        WHERE (requester_id = ${userId} OR recipient_id = ${userId}) AND status = 'accepted'
+      )
+      SELECT
+        u.id AS user_id, u.name, u.username, u.image,
+        COALESCE(SUM(rl.xp_earned), 0)::int AS weekly_xp
+      FROM "user" u
+      LEFT JOIN review_log rl
+        ON rl.user_id = u.id AND rl.reviewed_at >= ${weekStart}
+      WHERE u.id = ${userId} OR u.id IN (SELECT friend_id FROM friends)
+      GROUP BY u.id, u.name, u.username, u.image
+      ORDER BY weekly_xp DESC, u.id ASC
+    `);
+    // Drizzle's execute() returns shape per driver: { rows: [...] } on pg, Array on PGlite.
+    // Normalize:
+    return Array.isArray(result) ? result : (result as { rows: RawRankingRow[] }).rows;
+  }
+}
+```
+
+- [ ] **Step 2: Service — trim to 10 around me**
+
+```typescript
+import { startOfWeekBrt } from "@pruvi/shared";
+import type { RankingRepository } from "./ranking.repository";
+
+export class RankingService {
+  constructor(private repo: RankingRepository) {}
+
+  async getRanking(userId: string, now: Date) {
+    const weekStart = startOfWeekBrt(now);
+    const rows = await this.repo.getFriendsRanking(userId, weekStart);
+
+    const ranked = rows.map((r, i) => ({
+      userId: r.user_id,
+      name: r.name,
+      username: r.username,
+      image: r.image,
+      weeklyXp: r.weekly_xp,
+      rank: i + 1,
+      isMe: r.user_id === userId,
+    }));
+
+    let entries = ranked;
+    if (ranked.length > 10) {
+      const meIdx = ranked.findIndex((e) => e.isMe);
+      // Take 5 above + 4 below (10 total including me), clamp at edges.
+      const start = Math.max(0, Math.min(ranked.length - 10, meIdx - 5));
+      entries = ranked.slice(start, start + 10);
+    }
+
+    return {
+      weekStart: weekStart.toISOString(),
+      entries,
+    };
+  }
+}
+```
+
+- [ ] **Step 3: Route**
+
+```typescript
+// GET /users/me/friends/ranking
+```
+
+- [ ] **Step 4: Unit + integration tests**
+
+Service unit: trim with >10 friends (me at top, middle, bottom — clamp behavior). Service with <11 returns all sorted.
+
+Repository integration: seed 1 user + 3 friends + review_log rows spanning current week + previous week + non-friends. Assert query returns only friends + me, only current week XP summed, non-friends excluded.
+
+- [ ] **Step 5: Wire + commit**
+
+```bash
+pnpm --filter server test && pnpm --filter server test:integration
+git add apps/server/src/features/social/ranking
+git commit -m "feat(ranking): GET /users/me/friends/ranking weekly XP"
+```
+
+---
+
+### Task 7: Reviews-service `xpEarned` integration
+
+**Files:**
+- Modify: `apps/server/src/features/reviews/reviews.repository.ts` — `insertReview` accepts/persists `xpEarned`
+- Modify: `apps/server/src/features/reviews/reviews.service.ts` — pass `xpAwarded` into the insertReview call
+- Modify: `apps/server/src/features/reviews/reviews.service.test.ts`
+
+- [ ] **Step 1: Repository — extend insertReview**
+
+Find `insertReview` in `reviews.repository.ts`. Add `xpEarned` to its argument type and the INSERT payload.
+
+- [ ] **Step 2: Service — pass xpAwarded through**
+
+In `reviews.service.ts`, where `insertReview(...)` is called, include `xpEarned: xpAwarded` in the args object.
+
+- [ ] **Step 3: Update tests**
+
+In `reviews.service.test.ts`, the `insertReview` mock should now expect the new field. Update assertions accordingly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+pnpm --filter server test && pnpm --filter server test:integration
+git add apps/server/src/features/reviews
+git commit -m "feat(reviews): persist xpEarned per answer for weekly ranking"
+```
+
+---
+
+### Task 8: Username profile endpoint
+
+**Files:**
+- Modify or create: `apps/server/src/features/users/users.service.ts` (or new `profile.service.ts`)
+- Add `PATCH /users/me/profile` route
+
+- [ ] **Step 1: Locate or create the user-profile endpoint**
+
+Search `grep -rn "users/me" apps/server/src/features` for an existing profile route. If one exists, extend it; if not, add a small `profile.route.ts` under `apps/server/src/features/users/`.
+
+- [ ] **Step 2: Implement**
+
+Body: `{ username }`. Service:
+- Validate via `UpdateProfileBodySchema` (Fastify-Zod handles this).
+- Reject if username already taken by another user (catch UNIQUE violation → 409).
+- UPDATE `user.username = lowercased input` (it's already validated lowercase, but defensive `.toLowerCase()` is cheap).
+- Return updated user shape.
+
+- [ ] **Step 3: Tests + commit**
+
+Unit: rejects collision, accepts valid username.
+Integration: lookup by username case-insensitive works after set (covered in friendships tests too).
+
+```bash
+git add apps/server/src
+git commit -m "feat(users): PATCH /users/me/profile username"
+```
+
+---
+
+### Task 9: Final verification + push
+
+- [ ] **Step 1: Full test sweep**
+
+```bash
+pnpm --filter server test
+pnpm --filter server test:integration
+pnpm --filter @pruvi/shared test
+pnpm verify:migration
+pnpm check-types
+```
+
+All must pass. `sm2.test.ts` pre-existing failures are acceptable (documented tech debt).
+
+- [ ] **Step 2: Worker boot smoke**
+
+```bash
+pnpm dev:worker
+# Ctrl-C after seeing "queues registered" / "worker started" logs
+```
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feature/phase-2d-social-ranking
+gh pr create --base main --title "feat: phase 2d — social ranking (friendships + invitations + weekly XP)" --body "..."
+```
+
+PR body: summarize the 3 modules, list the 10 endpoints, note deferred items (overtaken-notification, sharing card, block flow), reference the spec.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- ✅ Friendship table + pair-uniqueness → Task 2
+- ✅ Invitation acceptance + +100 XP → Task 4
+- ✅ Per-user invite code → Tasks 2 + 3 + 4
+- ✅ Friend search by username → Tasks 2 + 5
+- ✅ Friend request flow → Task 5
+- ✅ Weekly XP ranking → Tasks 6 + 7
+- ✅ Username setting → Task 8
+- ✅ Cache invalidation → folded into Tasks 5 + 7 (no-op without Redis; documented in spec)
+- ⏳ Overtaken notification → deferred (explicit in spec)
+- ⏳ Sharing card → out of backend scope
+
+**Placeholder scan:** No "TBD" / "add appropriate". Each step has either explicit code or a precise instruction (e.g., "search for the canonical pattern in tokens.route.ts").
+
+**Type consistency:** `username` text NULL, `inviteCode` text NOT NULL, `friendship.status` enum 3 values, `xpEarned` NOT NULL DEFAULT 0 — referenced consistently across schema, shared schemas, repository methods, and service contracts.
+
+**Out-of-codebase callouts:** The plan refers to `authGuard`, `handleResult`, `db` — these are codebase conventions. Implementer agents must look them up rather than invent.

--- a/docs/superpowers/specs/2026-05-11-phase-2d-social-ranking-design.md
+++ b/docs/superpowers/specs/2026-05-11-phase-2d-social-ranking-design.md
@@ -1,0 +1,363 @@
+# Phase 2D — Social: Friendships, Invitations, Weekly Ranking (Design Spec)
+
+**Date:** 2026-05-11
+**Phase:** 2D
+**Source spec:** `pruvi-freatures.md` §4.1 (Ranking de amigos — Essencial), §4.2 (Convite de amigos — Importante). §4.3 (Compartilhamento de resultado) is purely client-side and OUT OF SCOPE.
+
+## Goal
+
+Ship the social backend: friendships, friend-search-by-username, personal invite codes with reward-on-acceptance, and a weekly XP ranking limited to a user's friends. All endpoints type-safe, integration-tested, scoped to the user.
+
+## Non-goals
+
+- "Overtaken" push notification (spec 4.1 calls for *"O Pedro acabou de te passar"*). Defer to a follow-up — requires per-XP-event ranking diff, expensive; not blocking the ranking screen itself.
+- Result-sharing card (4.3) — client-side canvas.
+- Streak shield as invite reward — spec says "+100 XP **or** 1 escudo de streak"; shield doesn't exist yet (Phase 2E+). MVP awards +100 XP only.
+- Username editing UI (frontend rebuild owns).
+- Block/report flow.
+- Global / cohort-wide ranking — explicitly out of spec ("não é ranking global").
+- Backfill of invite codes for existing users via a separate job — the migration backfills inline.
+
+## Data Model
+
+### `user` table extensions
+
+```sql
++ username     text NULL UNIQUE                  -- nullable; user sets later
++ invite_code  text NOT NULL UNIQUE              -- backfilled in migration
++ INDEX user_username_lower_idx ON LOWER(username) WHERE username IS NOT NULL  -- case-insensitive search
+```
+
+**Username:** nullable for backwards compat with existing users. Frontend prompts users to set one when they first hit the friends screen. Validation: `^[a-z0-9_]{3,20}$` (lowercase + digits + underscore). Stored as lowercase canonical to keep search free of case-folding subtleties.
+
+**Invite code:** 8 lowercase alphanumeric chars (excluding ambiguous `0`, `o`, `1`, `l`, `i`). Generated at user creation (better-auth post-hook or first-touch lazy fill — see "Code generation" below). UNIQUE to allow direct lookup. The shareable URL is constructed client-side as `https://pruvi.app/i/{code}` — the backend only stores the bare code.
+
+### New table: `friendship`
+
+```sql
+CREATE TABLE friendship (
+  id            serial PRIMARY KEY,
+  requester_id  text NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  recipient_id  text NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  status        text NOT NULL CHECK (status IN ('pending','accepted','declined')),
+  created_at    timestamp NOT NULL DEFAULT now(),
+  accepted_at   timestamp,
+  CHECK (requester_id <> recipient_id)
+);
+CREATE UNIQUE INDEX friendship_pair_idx
+  ON friendship (LEAST(requester_id, recipient_id), GREATEST(requester_id, recipient_id));
+CREATE INDEX friendship_requester_idx ON friendship (requester_id);
+CREATE INDEX friendship_recipient_idx ON friendship (recipient_id);
+```
+
+**Why pair-ordered uniqueness:** stores one row per relationship while preserving direction (`requester_id`). Searches "all friends of X" by `(requester_id = X OR recipient_id = X) AND status = 'accepted'`. A declined request blocks re-requesting the same pair until deleted — that's intentional in MVP (UX redirects to "send again" which DELETEs + INSERTs).
+
+**No `blocked` state in MVP:** keep enum to 3 values. Block is a phase-3 concern.
+
+### New table: `invitation_acceptance`
+
+```sql
+CREATE TABLE invitation_acceptance (
+  id           serial PRIMARY KEY,
+  inviter_id   text NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  invitee_id   text NOT NULL UNIQUE REFERENCES "user"(id) ON DELETE CASCADE,
+  accepted_at  timestamp NOT NULL DEFAULT now()
+);
+CREATE INDEX invitation_acceptance_inviter_idx ON invitation_acceptance (inviter_id);
+```
+
+`invitee_id` UNIQUE — a user can be invited only once (the first signup via a code wins; subsequent code-redemption attempts no-op). `inviter_id` indexed for the "your invitees" screen later.
+
+### `review_log` extension
+
+```sql
++ xp_earned  integer NOT NULL DEFAULT 0
++ CHECK (xp_earned >= 0)
++ INDEX review_log_user_reviewed_idx ON (user_id, reviewed_at)  -- if not already present
+```
+
+The existing answer flow calls `calculateXpForAnswer(correct, difficulty)` and adds it to `user.total_xp`. We capture the same value per-row at insert time so we can sum by time window. Old rows default to `0` — they don't count toward weekly XP, which is acceptable (rolling window naturally ages out old data).
+
+The existing index `review_log_user_next_review_idx` is on `(user_id, next_review_at)` — not what we need. Add `(user_id, reviewed_at)` for the weekly-sum query.
+
+## Architecture
+
+### Feature modules
+
+```
+apps/server/src/features/social/
+  invite-codes/
+    generator.ts            # pure: generate(): string (lowercase alnum, ambiguity-free)
+    generator.test.ts
+  invitations/
+    invitations.repository.ts
+    invitations.service.ts
+    invitations.route.ts    # POST /invitations/accept
+    invitations.service.test.ts
+    invitations.repository.integration.test.ts
+  friendships/
+    friendships.repository.ts
+    friendships.service.ts
+    friendships.route.ts    # /users/me/friends/* CRUD
+    friendships.service.test.ts
+    friendships.repository.integration.test.ts
+  ranking/
+    weekly.ts               # pure: startOfWeekBrt(now): Date (Monday 00:00 BRT)
+    weekly.test.ts
+    ranking.repository.ts
+    ranking.service.ts
+    ranking.route.ts        # GET /users/me/friends/ranking
+    ranking.service.test.ts
+    ranking.repository.integration.test.ts
+  index.ts                  # aggregates routes
+```
+
+### Code generation
+
+`generator.ts` exports a pure `generateInviteCode()` that returns an 8-char string from alphabet `abcdefghjkmnpqrstuvwxyz23456789` (no ambiguity). The service-layer wrapper handles collision: try insert, on UNIQUE-violation regenerate (max 5 tries, then throw).
+
+**When to assign:** on first authenticated request that needs it (lazy). Specifically: the migration backfills existing users; new users get a code via a `users.repository.ensureInviteCode(userId)` helper called by the invite endpoint (and any new sign-up post-hook we add later). For MVP we don't touch better-auth's hooks — laziness is fine because the first user-visible action requiring a code is opening the friends screen.
+
+Actually the cleanest path: migration backfills ALL existing users; we also wire `ensureInviteCode` as the first line of `GET /users/me/invite` so a user without one (shouldn't happen post-migration but defensive) gets one.
+
+### Weekly XP query
+
+`startOfWeekBrt(now: Date): Date` is pure — given any instant, return the Monday-00:00:00 BRT timestamp (as a UTC Date). Used both server-side (to filter `review_log.reviewed_at`) and as the explicit boundary in the ranking response.
+
+```typescript
+// pseudocode
+const offsetMs = 3 * 3600 * 1000; // BRT = UTC-3
+const brt = new Date(now.getTime() - offsetMs);
+const dayOfWeek = brt.getUTCDay(); // 0=Sun, 1=Mon, ...
+const daysToSubtract = (dayOfWeek + 6) % 7; // back to Monday
+brt.setUTCDate(brt.getUTCDate() - daysToSubtract);
+brt.setUTCHours(0, 0, 0, 0);
+return new Date(brt.getTime() + offsetMs); // back to UTC
+```
+
+The ranking query:
+
+```sql
+WITH friends AS (
+  SELECT CASE WHEN requester_id = $userId THEN recipient_id ELSE requester_id END AS friend_id
+  FROM friendship
+  WHERE (requester_id = $userId OR recipient_id = $userId) AND status = 'accepted'
+)
+SELECT
+  u.id, u.name, u.username, u.image,
+  COALESCE(SUM(rl.xp_earned), 0)::int AS weekly_xp
+FROM "user" u
+LEFT JOIN review_log rl ON rl.user_id = u.id AND rl.reviewed_at >= $weekStart
+WHERE u.id = $userId OR u.id IN (SELECT friend_id FROM friends)
+GROUP BY u.id, u.name, u.username, u.image
+ORDER BY weekly_xp DESC, u.id ASC;
+```
+
+We include the requesting user in the ranking (they see themselves). The "top 10 closest to me" trim happens in the service layer after the SQL: find the requesting user's index, take ±5 neighbors capped at 10 total. If <11 friends total, return all sorted.
+
+**Trim rule:** the screen shows at most 10 ranked entries; the requesting user is one of them; the other 9 are the friends closest in XP (5 above + 4 below, or fewer if at the edges). This matches spec §4.1 "Máximo visível: os 10 amigos mais próximos em XP".
+
+## API surface
+
+All endpoints require auth, return `{ success: true, data: ... }`.
+
+### Invitations
+
+**`GET /users/me/invite`**
+
+```json
+{ "code": "ab2k7nqp", "url": "https://pruvi.app/i/ab2k7nqp" }
+```
+
+`url` constructed using `INVITE_URL_BASE` env (defaults to `https://pruvi.app/i`). Cached `invite:{userId}` 1h.
+
+**`POST /invitations/accept`** — body `{ code: string }`
+
+Behavior:
+1. Resolve `code` → `inviter_id`. 404 if not found.
+2. Reject if `inviter_id === request.userId` (self).
+3. Reject if `invitation_acceptance.invitee_id = request.userId` exists (already accepted any invite).
+4. In a transaction:
+   - `INSERT INTO invitation_acceptance (inviter_id, invitee_id) VALUES ($inviter, $invitee)`
+   - `UPDATE "user" SET total_xp = total_xp + 100 WHERE id = $inviter`
+   - `INSERT INTO friendship (requester_id, recipient_id, status, accepted_at) VALUES ($inviter, $invitee, 'accepted', now()) ON CONFLICT (LEAST(...), GREATEST(...)) DO UPDATE SET status = 'accepted', accepted_at = now()`
+5. Response: `{ inviter: { name, username }, xpAwarded: 100, friendshipCreated: true }`.
+
+### Friendships
+
+**`PATCH /users/me/profile`** — body `{ username }`
+
+Sets `user.username` if not already set OR allows changing once (decision: allow one change for MVP — frontend gates the UI; backend accepts any update). Validation: `^[a-z0-9_]{3,20}$`, unique. 409 on collision. (If a profile endpoint already exists in another feature module, extend it instead of creating a new one.)
+
+**`POST /users/me/friends/request`** — body `{ username }`
+
+1. Resolve `username` → target user. 404 if not found.
+2. Reject self / already-existing friendship (pending or accepted).
+3. INSERT friendship with `status='pending', requester_id = request.userId, recipient_id = target.id`.
+4. Response: `{ requestId, recipient: { username, name } }`.
+
+**`GET /users/me/friends/requests`**
+
+Returns incoming pending requests:
+
+```json
+{ "incoming": [{ "id": 1, "from": { "id": "u2", "name": "Pedro", "username": "pedro" }, "createdAt": "..." }] }
+```
+
+(Outgoing requests are not surfaced in MVP — UX doesn't need them. Decision is reversible later.)
+
+**`PATCH /users/me/friends/requests/:id`** — body `{ action: 'accept' | 'decline' }`
+
+1. Load row, verify `recipient_id = request.userId AND status = 'pending'`. 404 otherwise.
+2. UPDATE status accordingly. On accept, set `accepted_at = now()`.
+3. Response: `{ status: 'accepted' | 'declined' }`.
+
+**`GET /users/me/friends`**
+
+List of accepted friendships (the other party's `id, name, username, image`).
+
+**`DELETE /users/me/friends/:friendUserId`**
+
+DELETE the friendship row. 204 either way (no enumeration of who-is-friends-with-whom).
+
+### Ranking
+
+**`GET /users/me/friends/ranking`**
+
+```json
+{
+  "weekStart": "2026-05-11T03:00:00Z",
+  "entries": [
+    { "userId": "u-self", "name": "...", "username": "...", "image": "...", "weeklyXp": 320, "rank": 1, "isMe": true },
+    ...
+  ]
+}
+```
+
+Up to 10 entries, sorted desc by `weeklyXp` then `userId` asc for stable ordering. `weekStart` is the current Monday-00:00 BRT in UTC.
+
+Cached: `ranking:{userId}` 60s. Invalidated when any answer with `xp_earned > 0` is recorded by the user OR by any of their friends — see "Cache invalidation".
+
+## Migration `0006_<name>.sql`
+
+```sql
+-- 1. User extensions
+ALTER TABLE "user" ADD COLUMN "username" text;
+ALTER TABLE "user" ADD COLUMN "invite_code" text;
+
+-- 2. Backfill invite_code for existing users using gen_random_uuid prefix + substring
+--    (good-enough randomness for one-time backfill; new users get a generated one).
+UPDATE "user"
+SET "invite_code" = SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)
+WHERE "invite_code" IS NULL;
+
+-- 3. Enforce NOT NULL + UNIQUE
+ALTER TABLE "user" ALTER COLUMN "invite_code" SET NOT NULL;
+ALTER TABLE "user" ADD CONSTRAINT "user_invite_code_unique" UNIQUE ("invite_code");
+ALTER TABLE "user" ADD CONSTRAINT "user_username_unique" UNIQUE ("username");
+
+-- 4. Username search index (case-insensitive via stored lowercase canonical — but a defensive
+--    functional index is cheap and covers any future schema drift)
+CREATE INDEX "user_username_lower_idx" ON "user" (LOWER("username"))
+  WHERE "username" IS NOT NULL;
+
+-- 5. review_log.xp_earned
+ALTER TABLE "review_log" ADD COLUMN "xp_earned" integer NOT NULL DEFAULT 0;
+ALTER TABLE "review_log" ADD CONSTRAINT "review_log_xp_earned_chk" CHECK ("xp_earned" >= 0);
+CREATE INDEX "review_log_user_reviewed_idx" ON "review_log" ("user_id", "reviewed_at");
+
+-- 6. friendship
+CREATE TABLE "friendship" (
+  "id" serial PRIMARY KEY,
+  "requester_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "recipient_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "status" text NOT NULL,
+  "created_at" timestamp NOT NULL DEFAULT now(),
+  "accepted_at" timestamp,
+  CONSTRAINT "friendship_status_chk" CHECK ("status" IN ('pending','accepted','declined')),
+  CONSTRAINT "friendship_no_self_chk" CHECK ("requester_id" <> "recipient_id")
+);
+CREATE UNIQUE INDEX "friendship_pair_idx" ON "friendship"
+  (LEAST("requester_id", "recipient_id"), GREATEST("requester_id", "recipient_id"));
+CREATE INDEX "friendship_requester_idx" ON "friendship" ("requester_id");
+CREATE INDEX "friendship_recipient_idx" ON "friendship" ("recipient_id");
+
+-- 7. invitation_acceptance
+CREATE TABLE "invitation_acceptance" (
+  "id" serial PRIMARY KEY,
+  "inviter_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "invitee_id" text NOT NULL UNIQUE REFERENCES "user"("id") ON DELETE CASCADE,
+  "accepted_at" timestamp NOT NULL DEFAULT now()
+);
+CREATE INDEX "invitation_acceptance_inviter_idx" ON "invitation_acceptance" ("inviter_id");
+```
+
+Each `CREATE INDEX` / `ADD CONSTRAINT` wrapped in idempotent DO-blocks (per Phase 2C precedent). Mirror DDL in `packages/db/src/test-client.ts` in lockstep.
+
+## Shared schemas (`packages/shared/src/social.ts`)
+
+- `UsernameSchema = z.string().regex(/^[a-z0-9_]{3,20}$/)`
+- `InviteCodeSchema = z.string().regex(/^[a-z0-9]{8}$/)`
+- `AcceptInvitationBodySchema`, `RequestFriendBodySchema`, `RespondRequestBodySchema`, `UpdateProfileBodySchema`
+- Response schemas: `InviteLinkResponseSchema`, `FriendListResponseSchema`, `RequestListResponseSchema`, `RankingResponseSchema`
+
+## Service-layer integration with reviews
+
+`reviews.service.completeAnswer`:
+- Already calls `repo.awardXp(userId, xpAwarded)` to bump `user.total_xp`.
+- Add: `xp_earned: xpAwarded` to the `insertReview` payload (existing INSERT to `review_log`).
+- Add: fire `cacheInvalidate(['ranking:friends-of:{userId}'])` — see cache section.
+
+No other behavior changes in `reviews.service`. The overtaken-notification hook is deferred.
+
+## Cache invalidation
+
+Ranking is cached `ranking:{userId}` 60s. When user X earns XP, all friends of X must drop their cached ranking too (their ranking includes X). On answer:
+
+```typescript
+// fire-and-forget after awardXp
+cache.del(`ranking:${userId}`);
+const friendIds = await friendshipsRepo.listAcceptedFriendIds(userId);
+await Promise.all(friendIds.map(fid => cache.del(`ranking:${fid}`)));
+```
+
+If Redis isn't configured (local dev), this is a no-op. Hot-path overhead is one extra SELECT + N DELs per answer — friend lists are tiny in MVP, acceptable.
+
+## Testing strategy
+
+### Unit (Vitest)
+
+- `generator.test.ts` — produces 8 chars, alphabet membership, distribution sanity check (10k samples have no duplicates within sample).
+- `weekly.test.ts` — Monday-noon BRT input → returns same Monday 00:00 BRT; Sunday 23:59 BRT → returns 6 days prior; UTC midnight Tuesday → returns the prior Monday 00:00 BRT in UTC.
+- `invitations.service.test.ts` — self-invite rejected; already-accepted invitee rejected; transaction wraps invite+XP+friendship; +100 XP applied.
+- `friendships.service.test.ts` — self-request rejected; duplicate-pending rejected; accept/decline state transitions; unfriend deletes.
+- `ranking.service.test.ts` — trim logic (>10 friends: pick ±5 around me; <11: return all; me-not-in-result is impossible).
+
+### Integration (PGlite via existing `db-helpers`)
+
+- `invitations.repository.integration.test.ts` — invite-code lookup, invitee-once UNIQUE constraint.
+- `friendships.repository.integration.test.ts` — pair-uniqueness via LEAST/GREATEST index, no-self-friendship CHECK.
+- `ranking.repository.integration.test.ts` — seed users + review_log rows across two weeks; assert weekly query returns only current-week XP for friends-only.
+- CHECK-constraint coverage: `friendship_status_chk`, `friendship_no_self_chk`, `review_log_xp_earned_chk`, `user_username_unique`.
+
+## Acceptance criteria
+
+- Migration `0006` applies cleanly + `verify:migration` passes
+- 10 endpoints live + type-safe + integration-tested
+- Weekly ranking returns correct top-10 trim around the requesting user
+- `xp_earned` populated on every `review_log` insert (existing flow)
+- All unit + integration tests pass; new tests cover edge cases above
+- Zero new typecheck errors (pre-existing `sm2.test.ts` debt remains, untouched)
+- Worker boots clean
+
+## Deferred (explicit follow-ups)
+
+- **Overtaken push notification (§4.1):** needs per-XP-event delta + dispatcher hook. Cost: one rank-position diff per answer + a push payload. Defer to Phase 2D.1 or fold into 2E.
+- **Outgoing-request visibility:** UX-driven; add when frontend asks.
+- **Invite-shield reward:** depends on streak-shield (Ultra phase).
+- **Block / report:** phase 3 (post-launch).
+- **Username case-folding edge cases:** stored lowercase; the functional index is belt-and-suspenders.
+
+---
+
+*End of spec.*

--- a/packages/db/src/migrations/0006_special_tusk.sql
+++ b/packages/db/src/migrations/0006_special_tusk.sql
@@ -1,0 +1,86 @@
+-- 1. User extensions (idempotent)
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "username" text;
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "invite_code" text;
+--> statement-breakpoint
+
+-- 2. Backfill invite_code for existing users
+UPDATE "user"
+SET "invite_code" = SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)
+WHERE "invite_code" IS NULL;
+--> statement-breakpoint
+
+-- 3. NOT NULL + UNIQUE on the populated columns
+ALTER TABLE "user" ALTER COLUMN "invite_code" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "invite_code" SET DEFAULT SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8);
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_invite_code_unique') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_invite_code_unique" UNIQUE ("invite_code");
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_username_unique') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_username_unique" UNIQUE ("username");
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- 4. Case-insensitive username search
+CREATE INDEX IF NOT EXISTS "user_username_lower_idx"
+  ON "user" (LOWER("username")) WHERE "username" IS NOT NULL;
+--> statement-breakpoint
+
+-- 5. review_log.xp_earned
+ALTER TABLE "review_log" ADD COLUMN IF NOT EXISTS "xp_earned" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'review_log_xp_earned_chk') THEN
+    ALTER TABLE "review_log" ADD CONSTRAINT "review_log_xp_earned_chk" CHECK ("xp_earned" >= 0);
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "review_log_user_reviewed_idx" ON "review_log" ("user_id", "reviewed_at");
+--> statement-breakpoint
+
+-- 6. friendship
+CREATE TABLE IF NOT EXISTS "friendship" (
+  "id" serial PRIMARY KEY,
+  "requester_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "recipient_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "status" text NOT NULL,
+  "created_at" timestamp NOT NULL DEFAULT now(),
+  "accepted_at" timestamp
+);
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'friendship_status_chk') THEN
+    ALTER TABLE "friendship" ADD CONSTRAINT "friendship_status_chk" CHECK ("status" IN ('pending','accepted','declined'));
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'friendship_no_self_chk') THEN
+    ALTER TABLE "friendship" ADD CONSTRAINT "friendship_no_self_chk" CHECK ("requester_id" <> "recipient_id");
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "friendship_pair_idx" ON "friendship"
+  (LEAST("requester_id","recipient_id"), GREATEST("requester_id","recipient_id"));
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "friendship_requester_idx" ON "friendship" ("requester_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "friendship_recipient_idx" ON "friendship" ("recipient_id");
+--> statement-breakpoint
+
+-- 7. invitation_acceptance
+CREATE TABLE IF NOT EXISTS "invitation_acceptance" (
+  "id" serial PRIMARY KEY,
+  "inviter_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "invitee_id" text NOT NULL UNIQUE REFERENCES "user"("id") ON DELETE CASCADE,
+  "accepted_at" timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "invitation_acceptance_inviter_idx" ON "invitation_acceptance" ("inviter_id");

--- a/packages/db/src/migrations/meta/0006_snapshot.json
+++ b/packages/db/src/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1405 @@
+{
+  "id": "9083516d-d449-452b-9ac6-c515e8466f22",
+  "prevId": "cca3d814-79d0-436b-976f-2fcc8d31a722",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives": {
+          "name": "lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lives_last_regen_at": {
+          "name": "lives_last_regen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "selected_exam": {
+          "name": "selected_exam",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulties": {
+          "name": "difficulties",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "daily_study_time_minutes": {
+          "name": "daily_study_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_hour": {
+          "name": "notification_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 19
+        },
+        "streak_reminders_enabled": {
+          "name": "streak_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "achievement_notifications_enabled": {
+          "name": "achievement_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_session": {
+      "name": "daily_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_correct": {
+          "name": "questions_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastery_snapshot": {
+          "name": "mastery_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_session_user_created_idx": {
+          "name": "daily_session_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_session_user_id_user_id_fk": {
+          "name": "daily_session_user_id_user_id_fk",
+          "tableFrom": "daily_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "friendship_requester_idx": {
+          "name": "friendship_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendship_recipient_idx": {
+          "name": "friendship_recipient_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendship_requester_id_user_id_fk": {
+          "name": "friendship_requester_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_recipient_id_user_id_fk": {
+          "name": "friendship_recipient_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subject_name_unique": {
+          "name": "subject_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "subject_slug_unique": {
+          "name": "subject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopic": {
+      "name": "subtopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtopic_topic_order_idx": {
+          "name": "subtopic_topic_order_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopic_topic_id_topic_id_fk": {
+          "name": "subtopic_topic_id_topic_id_fk",
+          "tableFrom": "subtopic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtopic_topic_slug_uniq": {
+          "name": "subtopic_topic_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topic_subject_order_idx": {
+          "name": "topic_subject_order_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_subject_id_subject_id_fk": {
+          "name": "topic_subject_id_subject_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_subject_slug_uniq": {
+          "name": "topic_subject_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_option_index": {
+          "name": "correct_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_calculation": {
+          "name": "requires_calculation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtopic_id": {
+          "name": "subtopic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_subject_difficulty_idx": {
+          "name": "question_subject_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_subtopic_difficulty_idx": {
+          "name": "question_subtopic_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_subject_id_subject_id_fk": {
+          "name": "question_subject_id_subject_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_subtopic_id_subtopic_id_fk": {
+          "name": "question_subtopic_id_subtopic_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subtopic",
+          "columnsFrom": [
+            "subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_log": {
+      "name": "review_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "easiness_factor": {
+          "name": "easiness_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_log_user_next_review_idx": {
+          "name": "review_log_user_next_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_log_user_question_idx": {
+          "name": "review_log_user_question_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_log_user_id_user_id_fk": {
+          "name": "review_log_user_id_user_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_log_question_id_question_id_fk": {
+          "name": "review_log_question_id_question_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_token": {
+      "name": "push_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_token_user_idx": {
+          "name": "push_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_token_user_id_user_id_fk": {
+          "name": "push_token_user_id_user_id_fk",
+          "tableFrom": "push_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_token_token_unique": {
+          "name": "push_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_acceptance": {
+      "name": "invitation_acceptance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_acceptance_inviter_idx": {
+          "name": "invitation_acceptance_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_acceptance_inviter_id_user_id_fk": {
+          "name": "invitation_acceptance_inviter_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_acceptance_invitee_id_user_id_fk": {
+          "name": "invitation_acceptance_invitee_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invitee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_acceptance_invitee_id_unique": {
+          "name": "invitation_acceptance_invitee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/0006_snapshot.json
+++ b/packages/db/src/migrations/meta/0006_snapshot.json
@@ -330,7 +330,8 @@
           "name": "invite_code",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": true,
+          "default": "SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)"
         },
         "notification_hour": {
           "name": "notification_hour",

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1778538917291,
       "tag": "0005_black_stephen_strange",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1778540820492,
+      "tag": "0006_special_tusk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -21,6 +21,8 @@ export const user = pgTable("user", {
     .default(sql`'{}'::text[]`),
   dailyStudyTimeMinutes: integer("daily_study_time_minutes"),
   onboardingCompleted: boolean("onboarding_completed").notNull().default(false),
+  username: text("username"),
+  inviteCode: text("invite_code").notNull(),
   notificationHour: integer("notification_hour").notNull().default(19),
   streakRemindersEnabled: boolean("streak_reminders_enabled").notNull().default(true),
   achievementNotificationsEnabled: boolean("achievement_notifications_enabled").notNull().default(true),

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -22,7 +22,9 @@ export const user = pgTable("user", {
   dailyStudyTimeMinutes: integer("daily_study_time_minutes"),
   onboardingCompleted: boolean("onboarding_completed").notNull().default(false),
   username: text("username"),
-  inviteCode: text("invite_code").notNull(),
+  inviteCode: text("invite_code")
+    .notNull()
+    .default(sql`SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)`),
   notificationHour: integer("notification_hour").notNull().default(19),
   streakRemindersEnabled: boolean("streak_reminders_enabled").notNull().default(true),
   achievementNotificationsEnabled: boolean("achievement_notifications_enabled").notNull().default(true),

--- a/packages/db/src/schema/friendship.ts
+++ b/packages/db/src/schema/friendship.ts
@@ -1,0 +1,27 @@
+import { relations } from "drizzle-orm";
+import { index, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const friendship = pgTable(
+  "friendship",
+  {
+    id: serial("id").primaryKey(),
+    requesterId: text("requester_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    recipientId: text("recipient_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    status: text("status", { enum: ["pending", "accepted", "declined"] }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    acceptedAt: timestamp("accepted_at"),
+  },
+  (table) => [
+    index("friendship_requester_idx").on(table.requesterId),
+    index("friendship_recipient_idx").on(table.recipientId),
+    // Pair-uniqueness via LEAST/GREATEST functional index added in raw migration SQL —
+    // Drizzle can't express functional UNIQUE indexes natively. The PGlite mirror gets the
+    // same index via raw SQL in test-client.ts.
+  ],
+);
+
+export const friendshipRelations = relations(friendship, ({ one }) => ({
+  requester: one(user, { fields: [friendship.requesterId], references: [user.id], relationName: "requester" }),
+  recipient: one(user, { fields: [friendship.recipientId], references: [user.id], relationName: "recipient" }),
+}));

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -5,3 +5,5 @@ export * from "./questions";
 export * from "./review-log";
 export * from "./daily-sessions";
 export * from "./push-tokens";
+export * from "./friendship";
+export * from "./invitation-acceptance";

--- a/packages/db/src/schema/invitation-acceptance.ts
+++ b/packages/db/src/schema/invitation-acceptance.ts
@@ -1,0 +1,19 @@
+import { relations } from "drizzle-orm";
+import { index, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const invitationAcceptance = pgTable(
+  "invitation_acceptance",
+  {
+    id: serial("id").primaryKey(),
+    inviterId: text("inviter_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    inviteeId: text("invitee_id").notNull().unique().references(() => user.id, { onDelete: "cascade" }),
+    acceptedAt: timestamp("accepted_at").defaultNow().notNull(),
+  },
+  (table) => [index("invitation_acceptance_inviter_idx").on(table.inviterId)],
+);
+
+export const invitationAcceptanceRelations = relations(invitationAcceptance, ({ one }) => ({
+  inviter: one(user, { fields: [invitationAcceptance.inviterId], references: [user.id], relationName: "inviter" }),
+  invitee: one(user, { fields: [invitationAcceptance.inviteeId], references: [user.id], relationName: "invitee" }),
+}));

--- a/packages/db/src/schema/review-log.ts
+++ b/packages/db/src/schema/review-log.ts
@@ -27,6 +27,7 @@ export const reviewLog = pgTable(
     }).notNull(),
     interval: integer("interval").notNull(),
     repetitions: integer("repetitions").notNull(),
+    xpEarned: integer("xp_earned").notNull().default(0),
     nextReviewAt: timestamp("next_review_at").notNull(),
     reviewedAt: timestamp("reviewed_at").defaultNow().notNull(),
   },

--- a/packages/db/src/test-client.ts
+++ b/packages/db/src/test-client.ts
@@ -23,6 +23,8 @@ export async function createTestDb() {
       difficulties TEXT[] NOT NULL DEFAULT '{}',
       daily_study_time_minutes INTEGER,
       onboarding_completed BOOLEAN NOT NULL DEFAULT FALSE,
+      username TEXT UNIQUE,
+      invite_code TEXT NOT NULL DEFAULT substr(md5(random()::text), 1, 8) UNIQUE,
       notification_hour INTEGER NOT NULL DEFAULT 19,
       streak_reminders_enabled BOOLEAN NOT NULL DEFAULT TRUE,
       achievement_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE,
@@ -115,6 +117,7 @@ export async function createTestDb() {
       easiness_factor NUMERIC(4,2) NOT NULL,
       interval INTEGER NOT NULL,
       repetitions INTEGER NOT NULL,
+      xp_earned INTEGER NOT NULL DEFAULT 0 CHECK (xp_earned >= 0),
       next_review_at TIMESTAMP NOT NULL,
       reviewed_at TIMESTAMP NOT NULL DEFAULT NOW()
     );
@@ -138,6 +141,31 @@ export async function createTestDb() {
       last_used_at TIMESTAMP NOT NULL DEFAULT NOW(),
       created_at TIMESTAMP NOT NULL DEFAULT NOW()
     );
+
+    CREATE TABLE IF NOT EXISTS "friendship" (
+      id SERIAL PRIMARY KEY,
+      requester_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+      recipient_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+      status TEXT NOT NULL CHECK (status IN ('pending','accepted','declined')),
+      created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+      accepted_at TIMESTAMP,
+      CONSTRAINT friendship_no_self_chk CHECK (requester_id <> recipient_id)
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS friendship_pair_idx ON friendship
+      (LEAST(requester_id, recipient_id), GREATEST(requester_id, recipient_id));
+
+    CREATE INDEX IF NOT EXISTS friendship_requester_idx ON friendship (requester_id);
+    CREATE INDEX IF NOT EXISTS friendship_recipient_idx ON friendship (recipient_id);
+
+    CREATE TABLE IF NOT EXISTS "invitation_acceptance" (
+      id SERIAL PRIMARY KEY,
+      inviter_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+      invitee_id TEXT NOT NULL UNIQUE REFERENCES "user"(id) ON DELETE CASCADE,
+      accepted_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS invitation_acceptance_inviter_idx ON invitation_acceptance (inviter_id);
   `);
 
   return { db, client };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,3 +12,5 @@ export * from "./progress";
 export * from "./mastery";
 export * from "./topics";
 export * from "./notifications";
+export * from "./social";
+export * from "./weekly";

--- a/packages/shared/src/social.test.ts
+++ b/packages/shared/src/social.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { UsernameSchema, InviteCodeSchema } from "./social";
+
+describe("UsernameSchema", () => {
+  it.each([
+    ["ana", true],
+    ["ana_b", true],
+    ["ana123", true],
+    ["AnaBeta", false],     // uppercase
+    ["ab", false],          // too short
+    ["a".repeat(21), false],// too long
+    ["ana b", false],       // space
+    ["ana-b", false],       // dash
+  ])("%s → %s", (input, valid) => {
+    expect(UsernameSchema.safeParse(input).success).toBe(valid);
+  });
+});
+
+describe("InviteCodeSchema", () => {
+  it.each([
+    ["abc12def", true],
+    ["a1b2c3d4", true],
+    ["ABC12DEF", false], // uppercase
+    ["abc12de",  false], // 7 chars
+    ["abc12defg",false], // 9 chars
+    ["ab c12de", false], // space
+  ])("%s → %s", (input, valid) => {
+    expect(InviteCodeSchema.safeParse(input).success).toBe(valid);
+  });
+});

--- a/packages/shared/src/social.ts
+++ b/packages/shared/src/social.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const UsernameSchema = z.string().regex(/^[a-z0-9_]{3,20}$/, {
+  message: "username must be 3-20 chars: lowercase, digits, underscore",
+});
+export const InviteCodeSchema = z.string().regex(/^[a-z0-9]{8}$/);
+
+export const AcceptInvitationBodySchema = z.object({ code: InviteCodeSchema });
+export const RequestFriendBodySchema = z.object({ username: UsernameSchema });
+export const RespondRequestBodySchema = z.object({
+  action: z.enum(["accept", "decline"]),
+});
+export const UpdateProfileBodySchema = z.object({ username: UsernameSchema });
+
+export const FriendUserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  username: z.string().nullable(),
+  image: z.string().nullable(),
+});
+
+export const InviteLinkResponseSchema = z.object({
+  code: InviteCodeSchema,
+  url: z.string().url(),
+});
+
+export const FriendListResponseSchema = z.object({
+  friends: z.array(FriendUserSchema),
+});
+
+export const FriendRequestSchema = z.object({
+  id: z.number().int(),
+  from: FriendUserSchema,
+  createdAt: z.string().datetime(),
+});
+export const RequestListResponseSchema = z.object({
+  incoming: z.array(FriendRequestSchema),
+});
+
+export const RankingEntrySchema = z.object({
+  userId: z.string(),
+  name: z.string(),
+  username: z.string().nullable(),
+  image: z.string().nullable(),
+  weeklyXp: z.number().int().nonnegative(),
+  rank: z.number().int().positive(),
+  isMe: z.boolean(),
+});
+export const RankingResponseSchema = z.object({
+  weekStart: z.string().datetime(),
+  entries: z.array(RankingEntrySchema).max(10),
+});
+
+export type RankingEntry = z.infer<typeof RankingEntrySchema>;
+export type FriendUser = z.infer<typeof FriendUserSchema>;

--- a/packages/shared/src/users.ts
+++ b/packages/shared/src/users.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
-/** PUT /users/me/profile — body */
-export const UpdateProfileBodySchema = z.object({
+/** PUT /users/me/profile — body (name + image fields) */
+export const UpdateBasicProfileBodySchema = z.object({
   name: z.string().min(1).max(80).optional(),
   image: z.url().nullable().optional(),
 });
 
-export type UpdateProfileBody = z.infer<typeof UpdateProfileBodySchema>;
+export type UpdateBasicProfileBody = z.infer<typeof UpdateBasicProfileBodySchema>;
 
 /** PUT /users/me/profile — response */
 export const ProfileResponseSchema = z.object({

--- a/packages/shared/src/weekly.test.ts
+++ b/packages/shared/src/weekly.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { startOfWeekBrt } from "./weekly";
+
+describe("startOfWeekBrt", () => {
+  it("noon BRT Wednesday → Monday 00:00 BRT", () => {
+    // 2026-05-13 15:00:00Z = 2026-05-13 12:00:00 BRT (Wed)
+    const input = new Date("2026-05-13T15:00:00Z");
+    const r = startOfWeekBrt(input);
+    // Monday 2026-05-11 00:00:00 BRT = 2026-05-11 03:00:00Z
+    expect(r.toISOString()).toBe("2026-05-11T03:00:00.000Z");
+  });
+
+  it("Monday 00:30 BRT → Monday 00:00 BRT (same day)", () => {
+    const input = new Date("2026-05-11T03:30:00Z"); // 00:30 BRT
+    const r = startOfWeekBrt(input);
+    expect(r.toISOString()).toBe("2026-05-11T03:00:00.000Z");
+  });
+
+  it("Monday 23:00 UTC (still Mon 20:00 BRT) → Monday 00:00 BRT", () => {
+    const input = new Date("2026-05-11T23:00:00Z");
+    const r = startOfWeekBrt(input);
+    expect(r.toISOString()).toBe("2026-05-11T03:00:00.000Z");
+  });
+
+  it("Sunday 23:00 BRT → previous Monday", () => {
+    // 2026-05-17 23:00 BRT = 2026-05-18 02:00 UTC
+    const input = new Date("2026-05-18T02:00:00Z");
+    const r = startOfWeekBrt(input);
+    expect(r.toISOString()).toBe("2026-05-11T03:00:00.000Z");
+  });
+
+  it("Monday 02:00 UTC (Sunday 23:00 BRT) → previous Monday", () => {
+    const input = new Date("2026-05-11T02:00:00Z"); // 23:00 BRT Sun
+    const r = startOfWeekBrt(input);
+    expect(r.toISOString()).toBe("2026-05-04T03:00:00.000Z");
+  });
+});

--- a/packages/shared/src/weekly.ts
+++ b/packages/shared/src/weekly.ts
@@ -1,0 +1,11 @@
+const BRT_OFFSET_MS = 3 * 60 * 60 * 1000;
+
+export function startOfWeekBrt(now: Date): Date {
+  const brtMs = now.getTime() - BRT_OFFSET_MS;
+  const brt = new Date(brtMs);
+  const dow = brt.getUTCDay(); // 0=Sun ... 6=Sat
+  const daysBack = (dow + 6) % 7; // Monday-anchored
+  brt.setUTCDate(brt.getUTCDate() - daysBack);
+  brt.setUTCHours(0, 0, 0, 0);
+  return new Date(brt.getTime() + BRT_OFFSET_MS);
+}


### PR DESCRIPTION
## Summary
Ship the social backend: per-user invite codes with +100 XP reward on acceptance, friendship request/accept/decline/unfriend flow, weekly XP ranking trimmed to ±5 friends around the requesting user.

**11 new endpoints:**
- `GET /users/me/invite` — invite code + shareable URL
- `POST /invitations/accept` — accept code, award inviter +100 XP, auto-friend (atomic transaction)
- `POST /users/me/friends/request` — friend request by username
- `GET /users/me/friends/requests` — incoming pending requests
- `PATCH /users/me/friends/requests/:id` — accept / decline
- `GET /users/me/friends` — accepted friends
- `DELETE /users/me/friends/:friendUserId` — unfriend
- `GET /users/me/friends/ranking` — weekly XP top-10 (me + ±5 nearest)
- `PATCH /users/me/profile` — set username (409 on collision)

## Architecture
- **Three modules under `apps/server/src/features/social/`:** `invitations`, `friendships`, `ranking`. Plus `invite-codes/generator.ts` (8-char alphanumeric, ambiguity-free, `node:crypto.randomInt`).
- **Friendship model:** pair-ordered with `requester_id`/`recipient_id` + `status` enum (`pending`/`accepted`/`declined`). Uniqueness enforced via functional `UNIQUE` index on `(LEAST, GREATEST)` so reverse-pair inserts collapse.
- **Weekly XP:** added `review_log.xp_earned` column populated at answer-insert time. Ranking query is a single CTE that extracts friends-via-CASE, LEFT-JOINs to review_log filtered by `reviewed_at >= startOfWeekBrt(now)`, GROUP BYs user fields.
- **`startOfWeekBrt`:** pure helper in `@pruvi/shared`. Anchors to Monday 00:00 BRT (UTC-3 fixed; Brazil dropped DST in 2019). 5 unit tests including the Sunday-23:00-BRT corner case.
- **Trim logic:** `start = max(0, min(N-10, meIdx-5))`, `slice(start, start+10)`. Always includes me, clamps at edges.

## Migration `0006_special_tusk.sql`
- Idempotent (DO-blocks for ADD CONSTRAINT; CREATE TABLE/INDEX with IF NOT EXISTS).
- Adds `user.username` (nullable + UNIQUE + functional lower-index for case-insensitive search) and `user.invite_code` (NOT NULL UNIQUE with SQL DEFAULT for test-fixture compatibility — also captured in Drizzle schema to prevent snapshot drift).
- Adds `review_log.xp_earned` (NOT NULL DEFAULT 0, CHECK >= 0) + index on `(user_id, reviewed_at)`.
- Creates `friendship` + `invitation_acceptance` tables with FK CASCADE, status / no-self CHECKs, pair-uniqueness functional index, invitee-once UNIQUE.

## Per-task review discipline
Every task went through implementer + spec-compliance + code-quality review subagents (per saved memory feedback). Notable findings + fixes:
- **Task 2:** reviewer flagged snapshot drift — `invite_code` SQL DEFAULT not captured in Drizzle schema. Fixed in `dbc17a0` by adding `.default(sql\`...\`)` to the column and patching `0006_snapshot.json`.
- **Task 5:** reviewer caught a broken `(t) => t.id === created.id` in an integration test (invalid Drizzle `where` arg + unused-locals tsc error). Fixed in `0ba339b` with proper `eq()` predicate and explicit `acceptedAt` assertions.

## Test plan
- [x] 142 unit tests pass (Vitest, all packages)
- [x] 72 integration tests pass (real Postgres via Docker)
- [x] \`pnpm verify:migration\` clean
- [x] Drizzle snapshot matches live schema (no future-`db:generate` drift)
- [x] Pre-existing \`sm2.test.ts\` typecheck noise unchanged (documented tech debt)

## Known follow-ups (deferred from spec)
- **Overtaken push notification** (spec §4.1): requires per-XP-event ranking delta + dispatcher hook. Defer to Phase 2D.1 or fold into 2E.
- **Result-sharing card** (spec §4.3): purely client-side (canvas), no backend.
- **Outgoing-request visibility:** UX-driven; add when frontend asks.
- **Streak-shield invite alternative:** depends on Ultra phase.
- **Block / report:** phase 3 (post-launch).

## Spec & plan
- \`docs/superpowers/specs/2026-05-11-phase-2d-social-ranking-design.md\`
- \`docs/superpowers/plans/2026-05-11-phase-2d-social-ranking.md\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added friend request system: send requests, accept/decline, and manage friends
  * Added invitation codes: users can generate invite links to onboard friends
  * Added weekly friend rankings: see how you and your friends rank by XP earned each week
  * Added username profile updates: customize your profile username
  * Enhanced XP tracking: reviews now record earned XP for better progress visibility

* **Documentation**
  * Added implementation and design specifications for social features

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CeCamillo/pruvi/pull/19)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->