### PR TITLE
feat: phase 2d.1 — overtaken push notification

### DIFF
--- a/apps/server/src/features/notifications/dispatcher.test.ts
+++ b/apps/server/src/features/notifications/dispatcher.test.ts
@@ -56,6 +56,40 @@ describe("Dispatcher.sendAchievementNotification", () => {
   });
 });
 
+describe("Dispatcher.sendOvertakenNotification", () => {
+  it("skips when achievement_notifications_enabled is false", async () => {
+    const deps = makeDeps({
+      prefsRepo: {
+        get: vi.fn().mockResolvedValue({ notificationHour: 19, streakRemindersEnabled: true, achievementNotificationsEnabled: false }),
+      },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.sendOvertakenNotification("u", "Pedro");
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("skips when user has no tokens", async () => {
+    const deps = makeDeps({
+      tokensService: { listTokensForUser: vi.fn().mockResolvedValue([]) },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.sendOvertakenNotification("u", "Pedro");
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("enqueues a send job with the overtaken template payload", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.sendOvertakenNotification("u", "Pedro");
+    expect(deps.sendQueue.add).toHaveBeenCalledTimes(1);
+    const [, payload] = deps.sendQueue.add.mock.calls[0];
+    expect(payload.tokens).toEqual(["ExponentPushToken[a]"]);
+    expect(payload.title).toBe("Você foi ultrapassado!");
+    expect(payload.body).toContain("Pedro");
+    expect(payload.data).toEqual({ kind: "overtaken" });
+  });
+});
+
 describe("Dispatcher.dispatchStreakReminder", () => {
   it("calls the eligibility query with hour and enqueues a send per chunk", async () => {
     const deps = makeDeps();

--- a/apps/server/src/features/notifications/dispatcher.ts
+++ b/apps/server/src/features/notifications/dispatcher.ts
@@ -4,6 +4,7 @@ import {
   streakReminderLate,
   streakMilestone,
   masteryAchievement,
+  overtaken,
   type PushPayload,
 } from "./templates";
 import type { TokensService } from "./tokens.service";
@@ -56,6 +57,26 @@ export class Dispatcher {
         title: payload.title,
         body: payload.body,
         data: { kind },
+      });
+    }
+  }
+
+  async sendOvertakenNotification(overtakenUserId: string, overtakerName: string): Promise<void> {
+    const prefs = await this.deps.prefsRepo.get(overtakenUserId);
+    if (!prefs?.achievementNotificationsEnabled) return;
+
+    const tokens = await this.deps.tokensService.listTokensForUser(overtakenUserId);
+    if (tokens.length === 0) return;
+
+    const payload = overtaken(overtakerName);
+
+    for (let i = 0; i < tokens.length; i += EXPO_BATCH_SIZE) {
+      const chunk = tokens.slice(i, i + EXPO_BATCH_SIZE);
+      await this.deps.sendQueue.add("send", {
+        tokens: chunk,
+        title: payload.title,
+        body: payload.body,
+        data: { kind: "overtaken" },
       });
     }
   }

--- a/apps/server/src/features/notifications/templates.test.ts
+++ b/apps/server/src/features/notifications/templates.test.ts
@@ -4,6 +4,7 @@ import {
   streakReminderLate,
   streakMilestone,
   masteryAchievement,
+  overtaken,
   type PushPayload,
 } from "./templates";
 
@@ -30,5 +31,13 @@ describe("notification templates", () => {
   it("masteryAchievement includes the subtopic name", () => {
     const p = masteryAchievement("Membrana plasmática");
     expect(p.body).toContain("Membrana plasmática");
+  });
+});
+
+describe("overtaken", () => {
+  it("includes the overtaker name in the body", () => {
+    const p = overtaken("Pedro");
+    expect(p.title).toBe("Você foi ultrapassado!");
+    expect(p.body).toContain("Pedro");
   });
 });

--- a/apps/server/src/features/notifications/templates.ts
+++ b/apps/server/src/features/notifications/templates.ts
@@ -33,3 +33,10 @@ export function masteryAchievement(subtopicName: string): PushPayload {
     body: `Você está dominando ${subtopicName}.`,
   };
 }
+
+export function overtaken(overtakerName: string): PushPayload {
+  return {
+    title: "Você foi ultrapassado!",
+    body: `${overtakerName} acabou de te passar no ranking 🔥`,
+  };
+}

--- a/apps/server/src/features/reviews/reviews.repository.ts
+++ b/apps/server/src/features/reviews/reviews.repository.ts
@@ -75,4 +75,14 @@ export class ReviewsRepository {
       .where(eq(user.id, userId));
   }
 
+  /** Look up a user's display name */
+  async findUserName(userId: string): Promise<{ name: string } | null> {
+    const rows = await this.db
+      .select({ name: user.name })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
 }

--- a/apps/server/src/features/reviews/reviews.route.ts
+++ b/apps/server/src/features/reviews/reviews.route.ts
@@ -4,12 +4,14 @@ import { AnswerQuestionBodySchema } from "@pruvi/shared";
 import { ReviewsService } from "./reviews.service";
 import { ReviewsRepository } from "./reviews.repository";
 import { LivesRepository } from "../lives/lives.repository";
+import { FriendshipsRepository } from "../social/friendships/friendships.repository";
 import { db } from "@pruvi/db";
 import { unwrapResult, successResponse } from "../../types";
 
 const repo = new ReviewsRepository(db);
 const livesRepo = new LivesRepository(db);
-const service = new ReviewsService(repo, livesRepo);
+const friendshipsRepo = new FriendshipsRepository(db);
+const service = new ReviewsService(repo, livesRepo, undefined, friendshipsRepo);
 
 export const reviewsRoutes: FastifyPluginAsyncZod = async (fastify) => {
   // POST /questions/:questionId/answer

--- a/apps/server/src/features/reviews/reviews.route.ts
+++ b/apps/server/src/features/reviews/reviews.route.ts
@@ -5,15 +5,31 @@ import { ReviewsService } from "./reviews.service";
 import { ReviewsRepository } from "./reviews.repository";
 import { LivesRepository } from "../lives/lives.repository";
 import { FriendshipsRepository } from "../social/friendships/friendships.repository";
+import { TokensRepository } from "../notifications/tokens.repository";
+import { TokensService } from "../notifications/tokens.service";
+import { PreferencesRepository } from "../notifications/preferences.repository";
+import { SweepRepository } from "../notifications/sweep.repository";
+import { Dispatcher } from "../notifications/dispatcher";
 import { db } from "@pruvi/db";
 import { unwrapResult, successResponse } from "../../types";
 
-const repo = new ReviewsRepository(db);
-const livesRepo = new LivesRepository(db);
-const friendshipsRepo = new FriendshipsRepository(db);
-const service = new ReviewsService(repo, livesRepo, undefined, friendshipsRepo);
-
 export const reviewsRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const repo = new ReviewsRepository(db);
+  const livesRepo = new LivesRepository(db);
+  const friendshipsRepo = new FriendshipsRepository(db);
+  const tokensRepo = new TokensRepository(db);
+  const tokensService = new TokensService(tokensRepo);
+  const prefsRepo = new PreferencesRepository(db);
+  const sweepRepo = new SweepRepository(db);
+  const dispatcher = fastify.queues.notificationsSend
+    ? new Dispatcher({
+        tokensService,
+        prefsRepo,
+        sweepRepo,
+        sendQueue: fastify.queues.notificationsSend,
+      })
+    : undefined;
+  const service = new ReviewsService(repo, livesRepo, dispatcher, friendshipsRepo, fastify.log);
   // POST /questions/:questionId/answer
   fastify.post(
     "/questions/:questionId/answer",

--- a/apps/server/src/features/reviews/reviews.service.test.ts
+++ b/apps/server/src/features/reviews/reviews.service.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ReviewsService } from "./reviews.service";
 import { NotFoundError, ValidationError } from "../../utils/errors";
 
+// Flush the microtask + macrotask queues so fire-and-forget hooks resolve
+const flushAsync = () => new Promise<void>((r) => setTimeout(r, 0));
+
 const mockRepo = {
   findQuestionById: vi.fn(),
   findLatestReview: vi.fn(),
@@ -183,5 +186,116 @@ describe("ReviewsService.answerQuestion", () => {
     if (result.isOk()) {
       expect(result.value.answer.explanation).toBeNull();
     }
+  });
+});
+
+describe("completeAnswer — overtaken notification hook", () => {
+  const mockFriendshipsRepo = {
+    getWeeklyXp: vi.fn(),
+    findOvertakenFriendIds: vi.fn(),
+  };
+
+  const mockDispatcher = {
+    sendOvertakenNotification: vi.fn(),
+  };
+
+  let serviceWithHook: ReviewsService;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    mockRepo.findQuestionById.mockResolvedValue(makeQuestion({ difficulty: "hard" }));
+    mockRepo.findLatestReview.mockResolvedValue(null);
+    mockRepo.insertReview.mockResolvedValue(undefined);
+    mockRepo.awardXp.mockResolvedValue(undefined);
+    mockRepo.findUserName = vi.fn().mockResolvedValue({ name: "Ana" });
+    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null });
+    mockLivesRepo.tryDecrement.mockResolvedValue({ ok: true, livesAfter: 4, lastRegenAt: null });
+
+    mockFriendshipsRepo.getWeeklyXp.mockResolvedValue(50);
+    mockFriendshipsRepo.findOvertakenFriendIds.mockResolvedValue([
+      { friendId: "f1", weeklyXp: 25 },
+      { friendId: "f2", weeklyXp: 40 },
+    ]);
+    mockDispatcher.sendOvertakenNotification.mockResolvedValue(undefined);
+
+    serviceWithHook = new ReviewsService(
+      mockRepo as any,
+      mockLivesRepo as any,
+      mockDispatcher as any,
+      mockFriendshipsRepo as any,
+    );
+  });
+
+  it("invokes dispatcher.sendOvertakenNotification for each overtaken friend on xpAwarded > 0", async () => {
+    // correct answer → xpAwarded > 0 (hard = 35 XP)
+    const result = await serviceWithHook.answerQuestion(USER_ID, QUESTION_ID, 2);
+
+    expect(result.isOk()).toBe(true);
+
+    // Flush the fire-and-forget promise
+    await flushAsync();
+
+    expect(mockFriendshipsRepo.getWeeklyXp).toHaveBeenCalledOnce();
+    expect(mockFriendshipsRepo.findOvertakenFriendIds).toHaveBeenCalledOnce();
+    expect(mockDispatcher.sendOvertakenNotification).toHaveBeenCalledWith("f1", "Ana");
+    expect(mockDispatcher.sendOvertakenNotification).toHaveBeenCalledWith("f2", "Ana");
+    expect(mockDispatcher.sendOvertakenNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to 'Alguém' when findUserName returns null", async () => {
+    (mockRepo as any).findUserName.mockResolvedValue(null);
+
+    await serviceWithHook.answerQuestion(USER_ID, QUESTION_ID, 2);
+    await flushAsync();
+
+    expect(mockDispatcher.sendOvertakenNotification).toHaveBeenCalledWith("f1", "Alguém");
+  });
+
+  it("does not invoke dispatcher when xpAwarded === 0 (wrong answer)", async () => {
+    // wrong answer → xpAwarded = 0
+    const result = await serviceWithHook.answerQuestion(USER_ID, QUESTION_ID, 0);
+
+    expect(result.isOk()).toBe(true);
+    await flushAsync();
+
+    expect(mockFriendshipsRepo.getWeeklyXp).not.toHaveBeenCalled();
+    expect(mockDispatcher.sendOvertakenNotification).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke dispatcher when no friends are overtaken", async () => {
+    mockFriendshipsRepo.findOvertakenFriendIds.mockResolvedValue([]);
+
+    const result = await serviceWithHook.answerQuestion(USER_ID, QUESTION_ID, 2);
+    expect(result.isOk()).toBe(true);
+    await flushAsync();
+
+    expect(mockDispatcher.sendOvertakenNotification).not.toHaveBeenCalled();
+  });
+
+  it("does not throw if dispatcher.sendOvertakenNotification rejects (fire-and-forget swallows error)", async () => {
+    mockDispatcher.sendOvertakenNotification.mockRejectedValue(new Error("network error"));
+
+    const result = await serviceWithHook.answerQuestion(USER_ID, QUESTION_ID, 2);
+
+    // The HTTP response must still succeed
+    expect(result.isOk()).toBe(true);
+
+    // Let the rejected promise settle — should not throw
+    await flushAsync();
+  });
+
+  it("does not call hook when dispatcher is not provided", async () => {
+    const serviceNoDispatcher = new ReviewsService(
+      mockRepo as any,
+      mockLivesRepo as any,
+      undefined,
+      mockFriendshipsRepo as any,
+    );
+
+    await serviceNoDispatcher.answerQuestion(USER_ID, QUESTION_ID, 2);
+    await flushAsync();
+
+    expect(mockFriendshipsRepo.getWeeklyXp).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/features/reviews/reviews.service.ts
+++ b/apps/server/src/features/reviews/reviews.service.ts
@@ -7,6 +7,7 @@ import {
   type QualityScore,
   type Difficulty,
 } from "@pruvi/shared";
+import type { FastifyBaseLogger } from "fastify";
 import type { AppError } from "../../utils/errors";
 import { NotFoundError, ValidationError } from "../../utils/errors";
 import type { ReviewsRepository } from "./reviews.repository";
@@ -20,6 +21,7 @@ export class ReviewsService {
     private livesRepo: LivesRepository,
     private dispatcher?: Dispatcher,
     private friendshipsRepo?: FriendshipsRepository,
+    private logger?: FastifyBaseLogger,
   ) {}
 
   /** Record an answer to a question */
@@ -94,7 +96,7 @@ export class ReviewsService {
     // 6d. Fire-and-forget overtaken notification hook
     if (xpAwarded > 0 && this.dispatcher && this.friendshipsRepo) {
       void this.maybeNotifyOvertakenFriends(userId, xpAwarded).catch((e) => {
-        console.error({ err: e, userId }, "overtaken notification dispatch failed");
+        this.logger?.error({ err: e, userId }, "overtaken notification dispatch failed");
       });
     }
 

--- a/apps/server/src/features/reviews/reviews.service.ts
+++ b/apps/server/src/features/reviews/reviews.service.ts
@@ -3,6 +3,7 @@ import {
   calculateSM2,
   INITIAL_SM2_STATE,
   calculateXpForAnswer,
+  startOfWeekBrt,
   type QualityScore,
   type Difficulty,
 } from "@pruvi/shared";
@@ -10,11 +11,15 @@ import type { AppError } from "../../utils/errors";
 import { NotFoundError, ValidationError } from "../../utils/errors";
 import type { ReviewsRepository } from "./reviews.repository";
 import type { LivesRepository } from "../lives/lives.repository";
+import type { Dispatcher } from "../notifications/dispatcher";
+import type { FriendshipsRepository } from "../social/friendships/friendships.repository";
 
 export class ReviewsService {
   constructor(
     private repo: ReviewsRepository,
     private livesRepo: LivesRepository,
+    private dispatcher?: Dispatcher,
+    private friendshipsRepo?: FriendshipsRepository,
   ) {}
 
   /** Record an answer to a question */
@@ -86,6 +91,13 @@ export class ReviewsService {
       await this.repo.awardXp(userId, xpAwarded);
     }
 
+    // 6d. Fire-and-forget overtaken notification hook
+    if (xpAwarded > 0 && this.dispatcher && this.friendshipsRepo) {
+      void this.maybeNotifyOvertakenFriends(userId, xpAwarded).catch((e) => {
+        console.error({ err: e, userId }, "overtaken notification dispatch failed");
+      });
+    }
+
     // 7. Handle lives — materialize regen, then atomic decrement on wrong answer
     const now = new Date();
     const materialized = await this.livesRepo.materializeRegen(userId, now);
@@ -109,5 +121,23 @@ export class ReviewsService {
       },
       cacheTargets: { subjectId: q.subjectId, topicId: q.topicId },
     });
+  }
+
+  private async maybeNotifyOvertakenFriends(userId: string, xpAwarded: number): Promise<void> {
+    const weekStart = startOfWeekBrt(new Date());
+    const newWeeklyXp = await this.friendshipsRepo!.getWeeklyXp(userId, weekStart);
+    const previousWeeklyXp = newWeeklyXp - xpAwarded;
+    const overtaken = await this.friendshipsRepo!.findOvertakenFriendIds(
+      userId,
+      weekStart,
+      previousWeeklyXp,
+      newWeeklyXp,
+    );
+    if (overtaken.length === 0) return;
+    const me = await this.repo.findUserName(userId);
+    const overtakerName = me?.name ?? "Alguém";
+    await Promise.allSettled(
+      overtaken.map((f) => this.dispatcher!.sendOvertakenNotification(f.friendId, overtakerName)),
+    );
   }
 }

--- a/apps/server/src/features/social/friendships/friendships.repository.integration.test.ts
+++ b/apps/server/src/features/social/friendships/friendships.repository.integration.test.ts
@@ -8,6 +8,10 @@ import {
 import { eq } from "drizzle-orm";
 import { user } from "@pruvi/db/schema/auth";
 import { friendship } from "@pruvi/db/schema/friendship";
+import { subject } from "@pruvi/db/schema/subjects";
+import { topic, subtopic } from "@pruvi/db/schema/topics";
+import { question } from "@pruvi/db/schema/questions";
+import { reviewLog } from "@pruvi/db/schema/review-log";
 import { FriendshipsRepository } from "./friendships.repository";
 
 describe("FriendshipsRepository (integration)", () => {
@@ -250,6 +254,160 @@ describe("FriendshipsRepository (integration)", () => {
 
       const pair = await repo.findExistingPair("del-a", "del-b");
       expect(pair).toBeNull();
+    });
+  });
+
+  /** Seed a question so review_log rows can be inserted. Returns questionId. */
+  async function seedQuestion(): Promise<number> {
+    const [subj] = await db
+      .insert(subject)
+      .values({ name: "Math", slug: "math" })
+      .returning();
+    const [t] = await db
+      .insert(topic)
+      .values({
+        subjectId: subj!.id,
+        name: "Algebra",
+        slug: "algebra",
+        displayOrder: 0,
+      })
+      .returning();
+    const [st] = await db
+      .insert(subtopic)
+      .values({
+        topicId: t!.id,
+        name: "Basics",
+        slug: "basics",
+        displayOrder: 0,
+      })
+      .returning();
+    const [q] = await db
+      .insert(question)
+      .values({
+        subjectId: subj!.id,
+        subtopicId: st!.id,
+        content: "1+1?",
+        options: ["1", "2", "3", "4"],
+        correctOptionIndex: 1,
+        difficulty: "easy" as const,
+        requiresCalculation: false,
+      })
+      .returning();
+    return q!.id;
+  }
+
+  async function insertReviewLog(
+    userId: string,
+    questionId: number,
+    xpEarned: number,
+    reviewedAt: Date,
+  ) {
+    await db.insert(reviewLog).values({
+      userId,
+      questionId,
+      quality: 4,
+      easinessFactor: "2.50",
+      interval: 1,
+      repetitions: 1,
+      xpEarned,
+      nextReviewAt: new Date(reviewedAt.getTime() + 24 * 60 * 60 * 1000),
+      reviewedAt,
+    });
+  }
+
+  async function makeFriendship(aId: string, bId: string) {
+    await db.insert(friendship).values({
+      requesterId: aId,
+      recipientId: bId,
+      status: "accepted",
+      acceptedAt: new Date(),
+    });
+  }
+
+  describe("findOvertakenFriendIds", () => {
+    it("returns friends with weekly XP in [previousWeeklyXp, newWeeklyXp)", async () => {
+      await insertUser("ot-me-001");
+      await insertUser("ot-fa-002");
+      await insertUser("ot-fb-003");
+      await insertUser("ot-fc-004");
+      await insertUser("ot-nf-005");
+
+      await makeFriendship("ot-me-001", "ot-fa-002");
+      await makeFriendship("ot-me-001", "ot-fb-003");
+      await makeFriendship("ot-me-001", "ot-fc-004");
+
+      const questionId = await seedQuestion();
+      const weekStart = new Date("2026-05-11T03:00:00.000Z");
+      const currentWeekDate = new Date("2026-05-13T10:00:00.000Z");
+
+      // ot-fa-002: 25 XP (in range [20, 50))
+      await insertReviewLog("ot-fa-002", questionId, 25, currentWeekDate);
+      // ot-fb-003: 50 XP (NOT - upper bound exclusive)
+      await insertReviewLog("ot-fb-003", questionId, 50, currentWeekDate);
+      // ot-fc-004: 15 XP (NOT - below previousWeeklyXp=20)
+      await insertReviewLog("ot-fc-004", questionId, 15, currentWeekDate);
+      // ot-nf-005: 25 XP (NOT - not a friend)
+      await insertReviewLog("ot-nf-005", questionId, 25, currentWeekDate);
+
+      const result = await repo.findOvertakenFriendIds("ot-me-001", weekStart, 20, 50);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.friendId).toBe("ot-fa-002");
+      expect(result[0]!.weeklyXp).toBe(25);
+    });
+
+    it("lower bound is inclusive", async () => {
+      await insertUser("me-lb");
+      await insertUser("friend-lb");
+
+      await makeFriendship("me-lb", "friend-lb");
+
+      const questionId = await seedQuestion();
+      const weekStart = new Date("2026-05-11T03:00:00.000Z");
+      const currentWeekDate = new Date("2026-05-13T10:00:00.000Z");
+
+      // friend-lb at exactly previousWeeklyXp=20 → should be returned
+      await insertReviewLog("friend-lb", questionId, 20, currentWeekDate);
+
+      const result = await repo.findOvertakenFriendIds("me-lb", weekStart, 20, 50);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.friendId).toBe("friend-lb");
+      expect(result[0]!.weeklyXp).toBe(20);
+    });
+
+    it("returns empty array when newWeeklyXp <= previousWeeklyXp", async () => {
+      const result = await repo.findOvertakenFriendIds("me-eq", new Date(), 50, 50);
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when user has no friends", async () => {
+      const result = await repo.findOvertakenFriendIds("solo", new Date(), 0, 100);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getWeeklyXp", () => {
+    it("sums xp_earned for the user within the week", async () => {
+      await insertUser("me-xp");
+
+      const questionId = await seedQuestion();
+      const weekStart = new Date("2026-05-11T03:00:00.000Z");
+      const currentWeekDate = new Date("2026-05-13T10:00:00.000Z");
+      const lastWeekDate = new Date("2026-05-08T10:00:00.000Z");
+
+      // 30 XP this week
+      await insertReviewLog("me-xp", questionId, 30, currentWeekDate);
+      // 100 XP last week (should NOT be counted)
+      await insertReviewLog("me-xp", questionId, 100, lastWeekDate);
+
+      const result = await repo.getWeeklyXp("me-xp", weekStart);
+      expect(result).toBe(30);
+    });
+
+    it("returns 0 when user has no reviews", async () => {
+      const result = await repo.getWeeklyXp("solo-xp", new Date());
+      expect(result).toBe(0);
     });
   });
 });

--- a/apps/server/src/features/social/friendships/friendships.repository.ts
+++ b/apps/server/src/features/social/friendships/friendships.repository.ts
@@ -115,4 +115,39 @@ export class FriendshipsRepository {
         ),
       );
   }
+
+  async getWeeklyXp(userId: string, weekStart: Date): Promise<number> {
+    const rows = await this.db.execute<{ weekly_xp: number }>(sql`
+      SELECT COALESCE(SUM(xp_earned), 0)::int AS weekly_xp
+      FROM review_log
+      WHERE user_id = ${userId} AND reviewed_at >= ${weekStart}
+    `);
+    const normalized = Array.isArray(rows) ? rows : (rows as { rows: Array<{ weekly_xp: number }> }).rows;
+    return normalized[0]?.weekly_xp ?? 0;
+  }
+
+  async findOvertakenFriendIds(
+    userId: string,
+    weekStart: Date,
+    previousWeeklyXp: number,
+    newWeeklyXp: number,
+  ): Promise<Array<{ friendId: string; weeklyXp: number }>> {
+    if (newWeeklyXp <= previousWeeklyXp) return [];
+    const result = await this.db.execute<{ friend_id: string; weekly_xp: number }>(sql`
+      WITH friends AS (
+        SELECT CASE WHEN requester_id = ${userId} THEN recipient_id ELSE requester_id END AS friend_id
+        FROM friendship
+        WHERE (requester_id = ${userId} OR recipient_id = ${userId}) AND status = 'accepted'
+      )
+      SELECT f.friend_id, COALESCE(SUM(rl.xp_earned), 0)::int AS weekly_xp
+      FROM friends f
+      LEFT JOIN review_log rl
+        ON rl.user_id = f.friend_id AND rl.reviewed_at >= ${weekStart}
+      GROUP BY f.friend_id
+      HAVING COALESCE(SUM(rl.xp_earned), 0) >= ${previousWeeklyXp}
+         AND COALESCE(SUM(rl.xp_earned), 0) < ${newWeeklyXp}
+    `);
+    const normalized = Array.isArray(result) ? result : (result as { rows: Array<{ friend_id: string; weekly_xp: number }> }).rows;
+    return normalized.map((r) => ({ friendId: r.friend_id, weeklyXp: r.weekly_xp }));
+  }
 }

--- a/docs/superpowers/plans/2026-05-12-phase-2d1-overtaken-notification.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2d1-overtaken-notification.md
@@ -1,0 +1,352 @@
+# Phase 2D.1 — Overtaken Push Notification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Fire a push notification to user B when user A's answer-XP-increment causes A's weekly XP to cross above B's.
+
+**Architecture:** Add `findOvertakenFriendIds` to `FriendshipsRepository` (single SQL with HAVING on the weekly-XP sum in `[previousWeeklyXp, newWeeklyXp)`). Add `getWeeklyXp` helper. Add `templates.overtaken` + `dispatcher.sendOvertakenNotification`. Wire as a fire-and-forget hook in `reviews.service.completeAnswer` after a successful `awardXp` when `xpAwarded > 0`.
+
+**Tech Stack:** Drizzle ORM, Vitest, PGlite (integration), neverthrow, BullMQ (existing `notifications-send` queue), Expo SDK.
+
+**Source spec:** `docs/superpowers/specs/2026-05-12-phase-2d1-overtaken-notification-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `apps/server/src/features/social/friendships/friendships.repository.ts` — add `findOvertakenFriendIds`, `getWeeklyXp`
+- `apps/server/src/features/social/friendships/friendships.repository.integration.test.ts` — add integration tests for the new methods
+- `apps/server/src/features/notifications/templates.ts` — add `overtaken(name)` builder
+- `apps/server/src/features/notifications/templates.test.ts` — cover the new template
+- `apps/server/src/features/notifications/dispatcher.ts` — add `sendOvertakenNotification(overtakenUserId, overtakerName)`
+- `apps/server/src/features/notifications/dispatcher.test.ts` — cover prefs-gating + token-load + enqueue
+- `apps/server/src/features/reviews/reviews.service.ts` — inject `friendshipsRepo`; add fire-and-forget hook
+- `apps/server/src/features/reviews/reviews.service.test.ts` — cover hook invocation on xp > 0, no-op on xp = 0, fire-and-forget swallows errors
+- `apps/server/src/features/reviews/reviews.route.ts` — wire `friendshipsRepo` into ReviewsService constructor
+
+---
+
+## Tasks
+
+### Task 1: Repository methods
+
+**Files:**
+- Modify: `apps/server/src/features/social/friendships/friendships.repository.ts`
+- Modify: `apps/server/src/features/social/friendships/friendships.repository.integration.test.ts`
+
+- [ ] **Step 1: Add `getWeeklyXp` + `findOvertakenFriendIds` methods**
+
+In `friendships.repository.ts`, add:
+
+```typescript
+async getWeeklyXp(userId: string, weekStart: Date): Promise<number> {
+  const rows = await this.db.execute<{ weekly_xp: number }>(sql`
+    SELECT COALESCE(SUM(xp_earned), 0)::int AS weekly_xp
+    FROM review_log
+    WHERE user_id = ${userId} AND reviewed_at >= ${weekStart}
+  `);
+  const normalized = Array.isArray(rows) ? rows : (rows as { rows: Array<{ weekly_xp: number }> }).rows;
+  return normalized[0]?.weekly_xp ?? 0;
+}
+
+async findOvertakenFriendIds(
+  userId: string,
+  weekStart: Date,
+  previousWeeklyXp: number,
+  newWeeklyXp: number,
+): Promise<Array<{ friendId: string; weeklyXp: number }>> {
+  if (newWeeklyXp <= previousWeeklyXp) return [];
+  const result = await this.db.execute<{ friend_id: string; weekly_xp: number }>(sql`
+    WITH friends AS (
+      SELECT CASE WHEN requester_id = ${userId} THEN recipient_id ELSE requester_id END AS friend_id
+      FROM friendship
+      WHERE (requester_id = ${userId} OR recipient_id = ${userId}) AND status = 'accepted'
+    )
+    SELECT f.friend_id, COALESCE(SUM(rl.xp_earned), 0)::int AS weekly_xp
+    FROM friends f
+    LEFT JOIN review_log rl
+      ON rl.user_id = f.friend_id AND rl.reviewed_at >= ${weekStart}
+    GROUP BY f.friend_id
+    HAVING COALESCE(SUM(rl.xp_earned), 0) >= ${previousWeeklyXp}
+       AND COALESCE(SUM(rl.xp_earned), 0) < ${newWeeklyXp}
+  `);
+  const normalized = Array.isArray(result) ? result : (result as { rows: Array<{ friend_id: string; weekly_xp: number }> }).rows;
+  return normalized.map((r) => ({ friendId: r.friend_id, weeklyXp: r.weekly_xp }));
+}
+```
+
+Add appropriate imports (`sql` from drizzle-orm already there for other methods).
+
+- [ ] **Step 2: Integration tests**
+
+Append cases to `friendships.repository.integration.test.ts`:
+
+```typescript
+describe("findOvertakenFriendIds", () => {
+  // helper to seed a review_log row at a specific reviewedAt with xpEarned
+  async function seedReview(userId: string, xp: number, when: Date) {
+    // use the test-db helper to insert review_log row with userId, questionId=existing, xp_earned, reviewed_at
+    // see existing test patterns
+  }
+
+  it("returns friends with weekly XP in [previousWeeklyXp, newWeeklyXp)", async () => {
+    // me + 3 friends + 1 non-friend
+    // friend-a: 25 XP (in range), friend-b: 50 XP (NOT - upper exclusive),
+    // friend-c: 15 XP (NOT - below previous), non-friend: 25 XP (NOT - not a friend)
+    // call with previousWeeklyXp=20, newWeeklyXp=50
+    // assert [friend-a] only
+  });
+
+  it("lower bound is inclusive", async () => {
+    // friend at exactly previousWeeklyXp=20 → returned
+  });
+
+  it("returns empty array when newWeeklyXp <= previousWeeklyXp", async () => {
+    const r = await repo.findOvertakenFriendIds("me", new Date(), 50, 50);
+    expect(r).toEqual([]);
+  });
+
+  it("returns empty array when user has no friends", async () => {
+    const r = await repo.findOvertakenFriendIds("solo", new Date(), 0, 100);
+    expect(r).toEqual([]);
+  });
+});
+
+describe("getWeeklyXp", () => {
+  it("sums xp_earned for the user within the week", async () => {
+    // seed 30 XP this week, 100 XP last week, on same user
+    // assert getWeeklyXp returns 30
+  });
+
+  it("returns 0 when user has no reviews", async () => {
+    const r = await repo.getWeeklyXp("solo", new Date());
+    expect(r).toBe(0);
+  });
+});
+```
+
+NOTE: review_log inserts require a valid `questionId` FK. Check the existing `friendships.repository.integration.test.ts` setup — if there's already a helper for seeding review_log, reuse it. If not, the simplest path is to insert a fixture question once in `beforeAll` and reuse its ID.
+
+- [ ] **Step 3: Run tests + commit**
+
+```bash
+pnpm --filter server test:integration friendships.repository.integration.test.ts
+git add apps/server/src/features/social/friendships
+git commit -m "feat(friendships): findOvertakenFriendIds + getWeeklyXp repository methods"
+```
+
+---
+
+### Task 2: Template + dispatcher
+
+**Files:**
+- Modify: `apps/server/src/features/notifications/templates.ts`
+- Modify: `apps/server/src/features/notifications/templates.test.ts`
+- Modify: `apps/server/src/features/notifications/dispatcher.ts`
+- Modify: `apps/server/src/features/notifications/dispatcher.test.ts`
+
+- [ ] **Step 1: Add template**
+
+In `templates.ts`:
+
+```typescript
+export const overtaken = (overtakerName: string): PushPayload => ({
+  title: "Você foi ultrapassado!",
+  body: `${overtakerName} acabou de te passar no ranking 🔥`,
+});
+```
+
+- [ ] **Step 2: Template test**
+
+In `templates.test.ts`, add:
+
+```typescript
+describe("overtaken", () => {
+  it("includes the overtaker name in the body", () => {
+    const p = overtaken("Pedro");
+    expect(p.title).toBe("Você foi ultrapassado!");
+    expect(p.body).toContain("Pedro");
+  });
+});
+```
+
+- [ ] **Step 3: Dispatcher method**
+
+In `dispatcher.ts`, add a method matching the existing `sendAchievementNotification` pattern. The exact signature:
+
+```typescript
+async sendOvertakenNotification(overtakenUserId: string, overtakerName: string): Promise<void>
+```
+
+Behavior:
+1. Read prefs via `preferencesRepo`. If `achievement_notifications_enabled === false` → return.
+2. Load tokens for `overtakenUserId` via `tokensRepo`.
+3. If no tokens → return.
+4. Build payload via `templates.overtaken(overtakerName)`.
+5. Enqueue via `notifications-send` queue (existing helper). Match the exact enqueue shape used by `sendAchievementNotification`.
+
+- [ ] **Step 4: Dispatcher test**
+
+In `dispatcher.test.ts`, add:
+
+```typescript
+describe("sendOvertakenNotification", () => {
+  it("skips when achievement_notifications_enabled is false", async () => { ... });
+  it("skips when user has no tokens", async () => { ... });
+  it("enqueues a send job with the overtaken template", async () => { ... });
+});
+```
+
+Mirror the existing `sendAchievementNotification` test cases for structure.
+
+- [ ] **Step 5: Run tests + commit**
+
+```bash
+pnpm --filter server test templates dispatcher
+git add apps/server/src/features/notifications
+git commit -m "feat(notifications): overtaken template + dispatcher method"
+```
+
+---
+
+### Task 3: Reviews-service hook
+
+**Files:**
+- Modify: `apps/server/src/features/reviews/reviews.service.ts`
+- Modify: `apps/server/src/features/reviews/reviews.service.test.ts`
+- Modify: `apps/server/src/features/reviews/reviews.route.ts`
+
+- [ ] **Step 1: Constructor**
+
+Add optional `friendshipsRepo` parameter to `ReviewsService` constructor. Existing optional `dispatcher` is already there.
+
+- [ ] **Step 2: Hook**
+
+After the existing `awardXp` block in `completeAnswer`, add:
+
+```typescript
+if (xpAwarded > 0 && this.dispatcher && this.friendshipsRepo) {
+  void this.maybeNotifyOvertakenFriends(userId, xpAwarded).catch((e) => {
+    this.logger?.error?.({ err: e, userId }, "overtaken notification dispatch failed");
+  });
+}
+```
+
+Where `maybeNotifyOvertakenFriends` is a private async method:
+
+```typescript
+private async maybeNotifyOvertakenFriends(userId: string, xpAwarded: number): Promise<void> {
+  const weekStart = startOfWeekBrt(new Date());
+  const newWeeklyXp = await this.friendshipsRepo!.getWeeklyXp(userId, weekStart);
+  const previousWeeklyXp = newWeeklyXp - xpAwarded;
+  const overtaken = await this.friendshipsRepo!.findOvertakenFriendIds(userId, weekStart, previousWeeklyXp, newWeeklyXp);
+  if (overtaken.length === 0) return;
+  const me = await this.repo.findUserName(userId); // see below
+  const overtakerName = me?.name ?? "Alguém";
+  await Promise.allSettled(
+    overtaken.map((f) => this.dispatcher!.sendOvertakenNotification(f.friendId, overtakerName)),
+  );
+}
+```
+
+The `findUserName` method on `ReviewsRepository` — if it doesn't exist, add a simple one:
+
+```typescript
+async findUserName(userId: string): Promise<{ name: string } | null> {
+  const rows = await this.db.select({ name: user.name }).from(user).where(eq(user.id, userId)).limit(1);
+  return rows[0] ?? null;
+}
+```
+
+Use the canonical `user` import and existing `eq`.
+
+Import `startOfWeekBrt` from `@pruvi/shared`.
+
+- [ ] **Step 3: Route wiring**
+
+In `reviews.route.ts`, where `new ReviewsService(...)` is constructed (currently passes `repo, livesRepo, dispatcher?, streaksService?` — match the actual existing arguments), add `new FriendshipsRepository(db)` as the next argument.
+
+- [ ] **Step 4: Service tests**
+
+Extend `reviews.service.test.ts`:
+
+```typescript
+describe("completeAnswer — overtaken notification hook", () => {
+  it("invokes dispatcher.sendOvertakenNotification for each overtaken friend on xpAwarded > 0", async () => {
+    // mock friendshipsRepo.getWeeklyXp → 50
+    // mock friendshipsRepo.findOvertakenFriendIds → [{friendId: 'f1', weeklyXp: 25}, {friendId: 'f2', weeklyXp: 40}]
+    // mock dispatcher.sendOvertakenNotification = vi.fn()
+    // call completeAnswer with correct=true (so xpAwarded > 0)
+    // await microtasks (fire-and-forget!)
+    // expect dispatcher.sendOvertakenNotification to have been called with 'f1' and 'f2'
+  });
+
+  it("does not invoke dispatcher when xpAwarded === 0 (wrong answer)", async () => { ... });
+
+  it("does not throw if dispatcher.sendOvertakenNotification rejects", async () => {
+    // mock dispatcher to throw
+    // call completeAnswer
+    // expect result.isOk() = true
+  });
+});
+```
+
+For the fire-and-forget await: use `await new Promise(setImmediate)` or `await new Promise((r) => setTimeout(r, 0))` to flush microtasks before asserting.
+
+- [ ] **Step 5: Run tests + commit**
+
+```bash
+pnpm --filter server test reviews.service
+pnpm --filter server test:integration  # ensure no regression
+git add apps/server/src/features/reviews
+git commit -m "feat(reviews): fire-and-forget overtaken-notification hook"
+```
+
+---
+
+### Task 4: Final verification + push
+
+- [ ] **Step 1: Full sweep**
+
+```bash
+pnpm --filter server test
+pnpm --filter server test:integration
+pnpm --filter @pruvi/shared test
+pnpm verify:migration
+pnpm --filter server check-types
+```
+
+All must pass. Pre-existing test-file strict-null noise is acceptable.
+
+- [ ] **Step 2: Boot worker smoke**
+
+```bash
+pnpm dev:worker  # then Ctrl-C after seeing queue-registered log
+```
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feature/phase-2d1-overtaken-notification
+gh pr create --base main --title "feat: phase 2d.1 — overtaken push notification" --body "..."
+```
+
+PR body: summarize the detection model (`[previousWeeklyXp, newWeeklyXp)` half-open interval), the hook placement (post-awardXp, fire-and-forget), reference the spec.
+
+---
+
+## Self-review
+
+- ✅ Detection model in `findOvertakenFriendIds` matches spec (half-open interval, friends-only) → Task 1
+- ✅ Template + dispatcher → Task 2
+- ✅ Hook invocation, fire-and-forget, xpAwarded gate → Task 3
+- ✅ Tests cover edges: lower bound inclusive, upper bound exclusive, no-friends, xpAwarded=0, dispatcher-throw doesn't crash answer
+- ✅ Prefs gating via `achievement_notifications_enabled` (no new column needed)
+- ✅ No migration in this phase
+- ✅ No placeholders ("TBD"/"add appropriate")
+
+Type consistency check:
+- `findOvertakenFriendIds` returns `Array<{ friendId: string; weeklyXp: number }>` — matches the consumer's loop in the hook.
+- `dispatcher.sendOvertakenNotification(overtakenUserId, overtakerName)` — `overtakerName: string` (no null; service falls back to "Alguém").
+- All Date inputs use the same `startOfWeekBrt(now)` convention from Phase 2D.

--- a/docs/superpowers/specs/2026-05-12-phase-2d1-overtaken-notification-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2d1-overtaken-notification-design.md
@@ -1,0 +1,159 @@
+# Phase 2D.1 — Overtaken Push Notification (Design Spec)
+
+**Date:** 2026-05-12
+**Phase:** 2D.1 (follow-up to Phase 2D)
+**Source spec:** `pruvi-freatures.md` §4.1: *"Notificação quando alguém te ultrapassa: 'O Pedro acabou de te passar no ranking!'"*
+
+## Goal
+
+Fire a push notification to user B when user A's weekly XP increment causes them to cross over B's weekly XP in the ranking. Closes the explicit deferred item from Phase 2D.
+
+## Non-goals
+
+- Streak/rank-summary digest notifications.
+- Notification when *I* overtake someone (only the overtaken party gets notified — per spec).
+- A separate `overtaken_notifications_enabled` preference column (use the existing `achievement_notifications_enabled` for MVP; split later if user research demands).
+- Frontend UI for opt-out (frontend rebuild handles).
+- Cohort-wide / non-friend overtake detection.
+- Sub-minute coalescing (rapid back-and-forth answers may fire multiple pushes — acceptable for MVP).
+
+## Detection model
+
+**The signal:** user A earns `xpAwarded` (> 0) on an answer, transitioning from `previousWeeklyXp` to `newWeeklyXp = previousWeeklyXp + xpAwarded`. Any friend B whose weekly XP falls in the half-open interval `[previousWeeklyXp, newWeeklyXp)` was just overtaken by A.
+
+**Why a half-open interval:**
+- Lower bound inclusive (`>= previousWeeklyXp`): if B was tied with A before, A's increment puts A ahead → B was overtaken.
+- Upper bound exclusive (`< newWeeklyXp`): if B has weekly XP exactly equal to A's new value, they're tied — not overtaken.
+
+**Atomicity caveat:** between the `awardXp` UPDATE and the friend-weekly-XP SELECT, B may have answered too. We accept this race: the worst outcome is a phantom or missed notification on a millisecond-scale tie. The query reads B's current state, which is by definition correct.
+
+## Architecture
+
+### New repository method on `FriendshipsRepository`
+
+```typescript
+async findOvertakenFriendIds(
+  userId: string,
+  weekStart: Date,
+  previousWeeklyXp: number,
+  newWeeklyXp: number,
+): Promise<Array<{ friendId: string; weeklyXp: number }>>
+```
+
+Single SQL:
+
+```sql
+WITH friends AS (
+  SELECT CASE WHEN requester_id = $userId THEN recipient_id ELSE requester_id END AS friend_id
+  FROM friendship
+  WHERE (requester_id = $userId OR recipient_id = $userId) AND status = 'accepted'
+)
+SELECT f.friend_id, COALESCE(SUM(rl.xp_earned), 0)::int AS weekly_xp
+FROM friends f
+LEFT JOIN review_log rl
+  ON rl.user_id = f.friend_id AND rl.reviewed_at >= $weekStart
+GROUP BY f.friend_id
+HAVING COALESCE(SUM(rl.xp_earned), 0) >= $previousWeeklyXp
+   AND COALESCE(SUM(rl.xp_earned), 0) < $newWeeklyXp
+```
+
+### Hook in `reviews.service.completeAnswer`
+
+After `awardXp` succeeds AND `xpAwarded > 0`, fire-and-forget:
+
+```typescript
+if (xpAwarded > 0 && this.dispatcher) {
+  const weekStart = startOfWeekBrt(new Date());
+  void this.maybeNotifyOvertakenFriends(userId, weekStart, xpAwarded).catch((e) =>
+    logger.error({ err: e }, "overtaken notification dispatch failed"),
+  );
+}
+```
+
+The internal helper:
+
+1. Computes `newWeeklyXp` by querying current sum (or, optimization: read the `user.total_xp` delta — but weekly XP is its own SUM, not derivable from `total_xp`, so a query is needed).
+2. `previousWeeklyXp = newWeeklyXp - xpAwarded`.
+3. Calls `friendshipsRepo.findOvertakenFriendIds(...)`.
+4. For each result, requests `dispatcher.sendOvertakenNotification(friendId, overtakerName)`.
+
+The "user's current name" is loaded once per answer (or cached on `req.user` if available). The dispatcher reads the friend's prefs and tokens.
+
+### Dispatcher addition
+
+`Dispatcher.sendOvertakenNotification(overtakenUserId: string, overtakerName: string)`:
+1. Read `achievement_notifications_enabled` for `overtakenUserId`. If false → skip.
+2. Load tokens.
+3. Build payload via `templates.overtaken(overtakerName)`.
+4. Enqueue `notifications-send` job.
+
+### Template
+
+`templates.ts`:
+
+```typescript
+export const overtaken = (overtakerName: string): PushPayload => ({
+  title: "Você foi ultrapassado!",
+  body: `${overtakerName} acabou de te passar no ranking 🔥`,
+});
+```
+
+Matches spec voice. PT-BR. No spam — fires only on the precise crossover moment.
+
+### Reviews-service constructor
+
+`ReviewsService` already accepts an optional `dispatcher` and `streaksService` (Phase 2B). Add an optional `friendshipsRepo` constructor arg. When absent (older tests), the hook is a no-op.
+
+### `getCurrentWeeklyXp` helper
+
+A small repository method on `FriendshipsRepository` (or a new `WeeklyXpRepository`):
+
+```typescript
+async getWeeklyXp(userId: string, weekStart: Date): Promise<number>
+```
+
+Simple SUM. Used by the service for `newWeeklyXp`.
+
+Actually — let's avoid an extra round-trip. The hook can compute previous + new from a single query that also includes the user's own row, but the cleanest factoring is to query once for the user's new weekly XP and once for the overtaken friends. Two SELECTs total, both fast (indexed).
+
+## Push notification preferences
+
+The dispatcher gates on `achievement_notifications_enabled` (existing column). No new pref column for MVP. Spec §4.1 implies the notification is "essencial", so default-on is correct.
+
+## Testing strategy
+
+### Unit (Vitest)
+
+- `templates.test.ts` — `overtaken("Pedro")` returns title + PT-BR body containing "Pedro".
+- `dispatcher.test.ts` — `sendOvertakenNotification` bails when prefs disabled; loads tokens; enqueues one send job.
+- `reviews.service.test.ts` — extend existing tests:
+  - With `dispatcher + friendshipsRepo` injected: on correct answer, `xpAwarded > 0`, the overtaken-notification path is invoked.
+  - When `xpAwarded === 0` (wrong answer), the path is NOT invoked.
+  - Fire-and-forget: if the path throws, `completeAnswer` still returns ok.
+
+### Integration (PGlite)
+
+- `friendships.repository.integration.test.ts` — extend with `findOvertakenFriendIds` cases:
+  - User has 3 friends; previous=20, new=50; friend at 25 is returned; friend at 50 is NOT (upper bound exclusive); friend at 15 is NOT.
+  - Edge case: previous=0, new=10 → matches friend at 0 (lower bound inclusive).
+  - Non-friend with weekly_xp in range is excluded.
+
+## Acceptance criteria
+
+- `findOvertakenFriendIds` repository method shipped + unit + integration tests
+- `dispatcher.sendOvertakenNotification` shipped + unit test
+- `templates.overtaken` shipped + unit test
+- `reviews.service.completeAnswer` invokes the hook fire-and-forget on `xpAwarded > 0`
+- `achievement_notifications_enabled` correctly gates dispatch
+- All existing tests still pass
+- `pnpm check-types` clean for production code
+- `pnpm verify:migration` clean (no migration in this phase)
+
+## Open questions (resolved)
+
+- **Should we de-duplicate overtake notifications within a session?** No. Each genuine crossover is a discrete moment. If A passes B, falls back, passes again — that's two events worth notifying. Spam concern is theoretical; per-answer XP is bounded (3-12 XP), so multi-crossover within one answer would only happen across a tightly-packed leaderboard.
+- **Display name source?** Use `user.name` (already populated by better-auth). If null, fall back to "Alguém". Both unlikely-edge handled in the dispatcher.
+
+---
+
+*End of spec.*


### PR DESCRIPTION
## Summary
Closes the deferred social-loop item from Phase 2D §4.1: fire a push notification to user B when user A's answer-XP-increment causes A's weekly XP to cross above B's. *"O Pedro acabou de te passar no ranking!"*

## Detection model
On every answer where `xpAwarded > 0`, the service computes:
- `newWeeklyXp` = `SUM(review_log.xp_earned)` for the user in this BRT week (post-`awardXp`)
- `previousWeeklyXp = newWeeklyXp - xpAwarded`

Any friend B whose own weekly XP falls in the half-open interval `[previousWeeklyXp, newWeeklyXp)` was just overtaken by A:
- Lower bound **inclusive** (`>=`): if B was tied with A, A's increment overtakes B
- Upper bound **exclusive** (`<`): if B's weekly XP equals A's new value, they're tied — not overtaken

Single SQL with CTE for friends + LEFT JOIN to review_log + `HAVING` on the weekly sum. Pre-merge guard `if (newWeeklyXp <= previousWeeklyXp) return []` keeps the hot path cheap.

## Architecture
- New repository methods on `FriendshipsRepository`: `getWeeklyXp(userId, weekStart)` and `findOvertakenFriendIds(userId, weekStart, previousWeeklyXp, newWeeklyXp)`.
- New template `overtaken(name)` in `apps/server/src/features/notifications/templates.ts`.
- New dispatcher method `Dispatcher.sendOvertakenNotification(overtakenUserId, overtakerName)` mirroring `sendAchievementNotification` exactly — same prefs gate (`achievement_notifications_enabled`), same token-load, same `notifications-send` enqueue.
- Fire-and-forget hook in `reviews.service.completeAnswer` after `awardXp`. Gated on `xpAwarded > 0 && this.dispatcher && this.friendshipsRepo`. Errors go through structured `FastifyBaseLogger` (passed in via constructor).

## Wiring (caught in review)
The initial implementation hardcoded `dispatcher = undefined` in `reviews.route.ts` — the reviewer flagged the feature as dead-on-arrival. Fixed by moving all repo/service construction inside the `FastifyPluginAsyncZod` async function (matching `sessions.route.ts` precedent), conditionally building `Dispatcher` when `fastify.queues.notificationsSend` is available, and threading `fastify.log` as the service's logger. See commit `60564c0`.

## Per-task review discipline
- Task 1 — Repository methods → APPROVED (Opus reviewer verified half-open interval, friends-only scoping, direction-agnostic CASE WHEN, cross-driver result normalization)
- Task 2 — Template + dispatcher → APPROVED
- Task 3 — Reviews hook → BLOCKER found (dead-on-arrival dispatcher); fixed in `60564c0`, re-verified

## Test plan
- [x] 154 unit tests pass (6 new in reviews.service.test.ts, 3 in dispatcher.test.ts, 1 in templates.test.ts)
- [x] 78 integration tests pass (6 new in friendships.repository.integration.test.ts for `findOvertakenFriendIds` + `getWeeklyXp`)
- [x] `pnpm verify:migration` clean (no migration in this phase)
- [x] `pnpm --filter server check-types` clean for production code (pre-existing test-file strict-null noise unchanged)
- [x] Worker boots clean

## Prefs gating
Uses the existing `user.achievement_notifications_enabled` column — no new pref column for MVP. Spec §4.1 labels the notification "Essencial", so default-on is correct. A separate `overtaken_notifications_enabled` column can land later if user research demands.

## Known follow-ups (not in this PR)
- Per-week notification rate-limit (rapid back-and-forth would fire multiple pushes — acceptable for MVP since per-answer XP is bounded 3-12).
- Display-name fallback to "Alguém" if `user.name` is null (already implemented, but worth revisiting once auth UX is finalized).

## Spec & plan
- `docs/superpowers/specs/2026-05-12-phase-2d1-overtaken-notification-design.md`
- `docs/superpowers/plans/2026-05-12-phase-2d1-overtaken-notification.md`