### PR TITLE
feat: phase 2e.1 — ultra entitlement scaffolding + unlimited lives

### DIFF
--- a/apps/server/src/features/lives/lives.repository.integration.test.ts
+++ b/apps/server/src/features/lives/lives.repository.integration.test.ts
@@ -36,6 +36,7 @@ describe("LivesRepository (integration)", () => {
       expect(r.ok).toBe(true);
       if (!r.ok) throw new Error("unreachable");
       expect(r.livesAfter).toBe(4);
+      expect(r.isUltra).toBe(false);
       // The pg driver serializes JS Dates using local timezone when writing, and reads
       // timestamp columns as local time, so the round-trip shifts by the local TZ offset.
       // Verify the anchor was set (not null) and matches what the DB actually persisted.
@@ -55,6 +56,7 @@ describe("LivesRepository (integration)", () => {
       expect(r.ok).toBe(true);
       if (!r.ok) throw new Error("unreachable");
       expect(r.livesAfter).toBe(3);
+      expect(r.isUltra).toBe(false);
       // COALESCE kept the previously-persisted anchor: returned value matches DB round-trip, not `now`.
       const persisted = await repo.getUserLives(userId);
       expect(r.lastRegenAt!.getTime()).toBe(persisted!.livesLastRegenAt!.getTime());
@@ -71,12 +73,33 @@ describe("LivesRepository (integration)", () => {
       const after = (await repo.getUserLives(userId))!;
       expect(after.lives).toBe(0);
     });
+
+    it("Ultra user with active subscription: returns ok:true, livesAfter=MAX, isUltra=true without DB write", async () => {
+      const expiresAt = new Date("2099-01-01T00:00:00Z");
+      await db
+        .update(user)
+        .set({ lives: 3, isUltra: true, ultraExpiresAt: expiresAt })
+        .where(eq(user.id, userId));
+
+      const now = new Date("2026-05-11T10:00:00Z");
+      const r = await repo.tryDecrement(userId, now);
+
+      expect(r.ok).toBe(true);
+      if (!r.ok) throw new Error("unreachable");
+      expect(r.livesAfter).toBe(MAX_LIVES);
+      expect(r.lastRegenAt).toBeNull();
+      expect(r.isUltra).toBe(true);
+
+      // DB lives column must be unchanged
+      const after = (await repo.getUserLives(userId))!;
+      expect(after.lives).toBe(3);
+    });
   });
 
   describe("materializeRegen", () => {
     it("no-op when lives at MAX (anchor null)", async () => {
       const r = await repo.materializeRegen(userId, new Date());
-      expect(r).toEqual({ lives: MAX_LIVES, lastRegenAt: null });
+      expect(r).toEqual({ lives: MAX_LIVES, lastRegenAt: null, isUltra: false });
     });
 
     it("regens +2 after 8h elapsed from anchor", async () => {
@@ -89,6 +112,7 @@ describe("LivesRepository (integration)", () => {
       const r = await repo.materializeRegen(userId, now);
       expect(r.lives).toBe(4);
       expect(r.lastRegenAt).toEqual(new Date(anchor.getTime() + 2 * LIVES_REGEN_INTERVAL_MS));
+      expect(r.isUltra).toBe(false);
     });
 
     it("caps at MAX and nulls anchor", async () => {
@@ -99,7 +123,38 @@ describe("LivesRepository (integration)", () => {
         .where(eq(user.id, userId));
       const now = new Date("2026-05-11T10:00:00Z"); // > 24h, enough to fill to MAX
       const r = await repo.materializeRegen(userId, now);
-      expect(r).toEqual({ lives: MAX_LIVES, lastRegenAt: null });
+      expect(r).toEqual({ lives: MAX_LIVES, lastRegenAt: null, isUltra: false });
+    });
+
+    it("Ultra user with active subscription: returns MAX_LIVES, lastRegenAt null, isUltra true regardless of stored lives", async () => {
+      const expiresAt = new Date("2099-01-01T00:00:00Z");
+      await db
+        .update(user)
+        .set({ lives: 2, isUltra: true, ultraExpiresAt: expiresAt })
+        .where(eq(user.id, userId));
+
+      const now = new Date("2026-05-11T10:00:00Z");
+      const r = await repo.materializeRegen(userId, now);
+
+      expect(r.lives).toBe(MAX_LIVES);
+      expect(r.lastRegenAt).toBeNull();
+      expect(r.isUltra).toBe(true);
+    });
+
+    it("expired Ultra user: applies normal regen logic (Ultra short-circuit does not fire)", async () => {
+      const expiredAt = new Date("2025-01-01T00:00:00Z"); // in the past
+      const anchor = new Date("2026-05-11T02:00:00Z");
+      await db
+        .update(user)
+        .set({ lives: 2, livesLastRegenAt: anchor, isUltra: true, ultraExpiresAt: expiredAt })
+        .where(eq(user.id, userId));
+
+      const now = new Date("2026-05-11T10:00:00Z"); // +8h = 2 ticks
+      const r = await repo.materializeRegen(userId, now);
+
+      // Normal regen applies: 2 + 2 = 4
+      expect(r.lives).toBe(4);
+      expect(r.isUltra).toBe(false);
     });
   });
 });

--- a/apps/server/src/features/lives/lives.repository.ts
+++ b/apps/server/src/features/lives/lives.repository.ts
@@ -5,6 +5,10 @@ import { MAX_LIVES, computeRegenSnapshot } from "@pruvi/shared";
 
 type DbClient = typeof db;
 
+function isUltraActive(row: { isUltra: boolean; ultraExpiresAt: Date | null }, now: Date): boolean {
+  return row.isUltra && (!row.ultraExpiresAt || row.ultraExpiresAt > now);
+}
+
 export class LivesRepository {
   constructor(private db: DbClient) {}
 
@@ -13,6 +17,8 @@ export class LivesRepository {
       .select({
         lives: user.lives,
         livesLastRegenAt: user.livesLastRegenAt,
+        isUltra: user.isUltra,
+        ultraExpiresAt: user.ultraExpiresAt,
       })
       .from(user)
       .where(eq(user.id, userId))
@@ -23,11 +29,17 @@ export class LivesRepository {
   async materializeRegen(
     userId: string,
     now: Date,
-  ): Promise<{ lives: number; lastRegenAt: Date | null }> {
+  ): Promise<{ lives: number; lastRegenAt: Date | null; isUltra: boolean }> {
     const current = await this.getUserLives(userId);
     if (!current) {
-      return { lives: MAX_LIVES, lastRegenAt: null };
+      return { lives: MAX_LIVES, lastRegenAt: null, isUltra: false };
     }
+
+    // Ultra bypass: skip regen logic entirely
+    if (isUltraActive(current, now)) {
+      return { lives: MAX_LIVES, lastRegenAt: null, isUltra: true };
+    }
+
     const snap = computeRegenSnapshot(current.lives, current.livesLastRegenAt, now);
     if (snap.regenerated > 0) {
       await this.db
@@ -35,16 +47,23 @@ export class LivesRepository {
         .set({ lives: snap.lives, livesLastRegenAt: snap.lastRegenAt })
         .where(eq(user.id, userId));
     }
-    return { lives: snap.lives, lastRegenAt: snap.lastRegenAt };
+    return { lives: snap.lives, lastRegenAt: snap.lastRegenAt, isUltra: false };
   }
 
   async tryDecrement(
     userId: string,
     now: Date,
   ): Promise<
-    | { ok: true; livesAfter: number; lastRegenAt: Date | null }
+    | { ok: true; livesAfter: number; lastRegenAt: Date | null; isUltra: boolean }
     | { ok: false }
   > {
+    // Ultra bypass: skip atomic UPDATE entirely
+    const current = await this.getUserLives(userId);
+    if (current && isUltraActive(current, now)) {
+      return { ok: true, livesAfter: MAX_LIVES, lastRegenAt: null, isUltra: true };
+    }
+
+    // Existing race-free atomic UPDATE for non-Ultra users
     const result = await this.db
       .update(user)
       .set({
@@ -59,6 +78,6 @@ export class LivesRepository {
 
     const row = result[0];
     if (!row) return { ok: false };
-    return { ok: true, livesAfter: row.lives, lastRegenAt: row.livesLastRegenAt };
+    return { ok: true, livesAfter: row.lives, lastRegenAt: row.livesLastRegenAt, isUltra: false };
   }
 }

--- a/apps/server/src/features/lives/lives.service.test.ts
+++ b/apps/server/src/features/lives/lives.service.test.ts
@@ -19,7 +19,7 @@ describe("LivesService", () => {
   });
 
   it("returns MAX_LIVES with resetsAt null when user not found (materializeRegen fallback)", async () => {
-    repo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null });
+    repo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null, isUltra: false });
 
     const result = await service.getLives("user-1");
 
@@ -28,10 +28,11 @@ describe("LivesService", () => {
     expect(value.lives).toBe(5);
     expect(value.maxLives).toBe(5);
     expect(value.resetsAt).toBeNull();
+    expect(value.unlimited).toBe(false);
   });
 
   it("returns full lives with resetsAt null when lives at MAX and anchor is null", async () => {
-    repo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null });
+    repo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null, isUltra: false });
 
     const result = await service.getLives("user-1");
 
@@ -39,11 +40,12 @@ describe("LivesService", () => {
     const value = result._unsafeUnwrap();
     expect(value.lives).toBe(5);
     expect(value.resetsAt).toBeNull();
+    expect(value.unlimited).toBe(false);
   });
 
   it("returns partial lives with resetsAt = anchor + 4h", async () => {
     const anchor = new Date("2026-05-11T08:00:00Z");
-    repo.materializeRegen.mockResolvedValue({ lives: 3, lastRegenAt: anchor });
+    repo.materializeRegen.mockResolvedValue({ lives: 3, lastRegenAt: anchor, isUltra: false });
 
     const result = await service.getLives("user-1");
 
@@ -51,11 +53,12 @@ describe("LivesService", () => {
     const value = result._unsafeUnwrap();
     expect(value.lives).toBe(3);
     expect(value.resetsAt).toEqual(new Date(anchor.getTime() + LIVES_REGEN_INTERVAL_MS));
+    expect(value.unlimited).toBe(false);
   });
 
   it("returns 0 lives with resetsAt = anchor + 4h (not null)", async () => {
     const anchor = new Date("2026-05-11T06:00:00Z");
-    repo.materializeRegen.mockResolvedValue({ lives: 0, lastRegenAt: anchor });
+    repo.materializeRegen.mockResolvedValue({ lives: 0, lastRegenAt: anchor, isUltra: false });
 
     const result = await service.getLives("user-1");
 
@@ -63,5 +66,33 @@ describe("LivesService", () => {
     const value = result._unsafeUnwrap();
     expect(value.lives).toBe(0);
     expect(value.resetsAt).toEqual(new Date(anchor.getTime() + LIVES_REGEN_INTERVAL_MS));
+    expect(value.unlimited).toBe(false);
+  });
+
+  it("Ultra user with active subscription: returns unlimited=true, MAX_LIVES, resetsAt null", async () => {
+    repo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null, isUltra: true });
+
+    const result = await service.getLives("ultra-user");
+
+    expect(result.isOk()).toBe(true);
+    const value = result._unsafeUnwrap();
+    expect(value.lives).toBe(5);
+    expect(value.maxLives).toBe(5);
+    expect(value.resetsAt).toBeNull();
+    expect(value.unlimited).toBe(true);
+  });
+
+  it("Ultra user with expired subscription: falls through to non-Ultra behavior", async () => {
+    const anchor = new Date("2026-05-11T06:00:00Z");
+    // materializeRegen returns isUltra: false when subscription is expired
+    repo.materializeRegen.mockResolvedValue({ lives: 2, lastRegenAt: anchor, isUltra: false });
+
+    const result = await service.getLives("expired-ultra-user");
+
+    expect(result.isOk()).toBe(true);
+    const value = result._unsafeUnwrap();
+    expect(value.lives).toBe(2);
+    expect(value.resetsAt).toEqual(new Date(anchor.getTime() + LIVES_REGEN_INTERVAL_MS));
+    expect(value.unlimited).toBe(false);
   });
 });

--- a/apps/server/src/features/lives/lives.service.ts
+++ b/apps/server/src/features/lives/lives.service.ts
@@ -10,7 +10,7 @@ export class LivesService {
     userId: string,
   ): Promise<
     Result<
-      { lives: number; maxLives: number; resetsAt: Date | null },
+      { lives: number; maxLives: number; resetsAt: Date | null; unlimited: boolean },
       AppError
     >
   > {
@@ -18,7 +18,8 @@ export class LivesService {
     return ok({
       lives: state.lives,
       maxLives: MAX_LIVES,
-      resetsAt: nextRegenAt(state.lives, state.lastRegenAt),
+      resetsAt: state.isUltra ? null : nextRegenAt(state.lives, state.lastRegenAt),
+      unlimited: state.isUltra,
     });
   }
 }

--- a/apps/server/src/features/reviews/reviews.service.test.ts
+++ b/apps/server/src/features/reviews/reviews.service.test.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
   mockRepo.findLatestReview.mockResolvedValue(null);
   mockRepo.insertReview.mockResolvedValue(undefined);
   mockRepo.awardXp.mockResolvedValue(undefined);
-  mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null });
+  mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null, isUltra: false });
   mockLivesRepo.tryDecrement.mockResolvedValue({ ok: true, livesAfter: 4, lastRegenAt: null });
 });
 
@@ -68,7 +68,7 @@ describe("ReviewsService.answerQuestion", () => {
   });
 
   it("wrong answer: returns correct=false, quality=1, xpAwarded=0, lives decremented by 1", async () => {
-    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null });
+    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null, isUltra: false });
     mockLivesRepo.tryDecrement.mockResolvedValue({ ok: true, livesAfter: 4, lastRegenAt: null });
 
     const result = await service.answerQuestion(USER_ID, QUESTION_ID, 0);
@@ -88,7 +88,7 @@ describe("ReviewsService.answerQuestion", () => {
   });
 
   it("wrong answer with 0 lives: tryDecrement returns ok:false → ValidationError", async () => {
-    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 0, lastRegenAt: new Date() });
+    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 0, lastRegenAt: new Date(), isUltra: false });
     mockLivesRepo.tryDecrement.mockResolvedValue({ ok: false });
 
     const result = await service.answerQuestion(USER_ID, QUESTION_ID, 0);
@@ -100,7 +100,7 @@ describe("ReviewsService.answerQuestion", () => {
   });
 
   it("correct answer: tryDecrement never called; livesRemaining reflects materialized value", async () => {
-    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 3, lastRegenAt: new Date() });
+    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 3, lastRegenAt: new Date(), isUltra: false });
 
     const result = await service.answerQuestion(USER_ID, QUESTION_ID, 2);
 
@@ -131,7 +131,7 @@ describe("ReviewsService.answerQuestion", () => {
 
     vi.clearAllMocks();
     mockRepo.findQuestionById.mockResolvedValue(makeQuestion());
-    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null });
+    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null, isUltra: false });
     mockRepo.insertReview.mockResolvedValue(undefined);
     mockRepo.awardXp.mockResolvedValue(undefined);
 
@@ -209,7 +209,7 @@ describe("completeAnswer — overtaken notification hook", () => {
     mockRepo.insertReview.mockResolvedValue(undefined);
     mockRepo.awardXp.mockResolvedValue(undefined);
     mockRepo.findUserName = vi.fn().mockResolvedValue({ name: "Ana" });
-    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null });
+    mockLivesRepo.materializeRegen.mockResolvedValue({ lives: 5, lastRegenAt: null, isUltra: false });
     mockLivesRepo.tryDecrement.mockResolvedValue({ ok: true, livesAfter: 4, lastRegenAt: null });
 
     mockFriendshipsRepo.getWeeklyXp.mockResolvedValue(50);

--- a/apps/server/src/features/social/ranking/ranking.repository.integration.test.ts
+++ b/apps/server/src/features/social/ranking/ranking.repository.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
 import {
   setupTestDb,
   cleanupTestDb,
@@ -29,13 +30,14 @@ describe("RankingRepository (integration)", () => {
     await teardownTestDb();
   });
 
-  async function insertUser(id: string, opts?: { username?: string }) {
+  async function insertUser(id: string, opts?: { username?: string; isUltra?: boolean }) {
     await db.insert(user).values({
       id,
       name: `User ${id}`,
       email: `${id}@example.com`,
       emailVerified: false,
       username: opts?.username ?? null,
+      isUltra: opts?.isUltra ?? false,
       updatedAt: new Date(),
     });
   }
@@ -193,6 +195,38 @@ describe("RankingRepository (integration)", () => {
       expect(rows).toHaveLength(1);
       expect(rows[0]!.user_id).toBe("solo-me");
       expect(rows[0]!.weekly_xp).toBe(25);
+    });
+
+    it("returns is_ultra per-row reflecting the user column value", async () => {
+      const weekStart = new Date("2026-05-11T03:00:00.000Z");
+      const futureDate = new Date("2099-01-01T00:00:00.000Z");
+
+      // me: not Ultra; friend-ultra: Ultra with expiry; friend-regular: not Ultra
+      await insertUser("me-ultra-test");
+      await insertUser("friend-ultra", { isUltra: true });
+      await insertUser("friend-regular");
+
+      // Set ultraExpiresAt on the ultra friend via update
+      await db
+        .update(user)
+        .set({ ultraExpiresAt: futureDate })
+        .where(eq(user.id, "friend-ultra"));
+
+      await makeFriendship("me-ultra-test", "friend-ultra");
+      await makeFriendship("me-ultra-test", "friend-regular");
+
+      const rows = await repo.getFriendsRanking("me-ultra-test", weekStart);
+
+      expect(rows).toHaveLength(3);
+
+      const meRow = rows.find((r) => r.user_id === "me-ultra-test")!;
+      expect(meRow.is_ultra).toBe(false);
+
+      const ultraRow = rows.find((r) => r.user_id === "friend-ultra")!;
+      expect(ultraRow.is_ultra).toBe(true);
+
+      const regularRow = rows.find((r) => r.user_id === "friend-regular")!;
+      expect(regularRow.is_ultra).toBe(false);
     });
   });
 });

--- a/apps/server/src/features/social/ranking/ranking.repository.ts
+++ b/apps/server/src/features/social/ranking/ranking.repository.ts
@@ -9,6 +9,7 @@ export interface RawRankingRow extends Record<string, unknown> {
   username: string | null;
   image: string | null;
   weekly_xp: number;
+  is_ultra: boolean;
 }
 
 export class RankingRepository {
@@ -22,13 +23,13 @@ export class RankingRepository {
         WHERE (requester_id = ${userId} OR recipient_id = ${userId}) AND status = 'accepted'
       )
       SELECT
-        u.id AS user_id, u.name, u.username, u.image,
+        u.id AS user_id, u.name, u.username, u.image, u.is_ultra,
         COALESCE(SUM(rl.xp_earned), 0)::int AS weekly_xp
       FROM "user" u
       LEFT JOIN review_log rl
         ON rl.user_id = u.id AND rl.reviewed_at >= ${weekStart}
       WHERE u.id = ${userId} OR u.id IN (SELECT friend_id FROM friends)
-      GROUP BY u.id, u.name, u.username, u.image
+      GROUP BY u.id, u.name, u.username, u.image, u.is_ultra
       ORDER BY weekly_xp DESC, u.id ASC
     `);
     // Drizzle's execute() returns shape per driver: { rows: [...] } on pg, Array on PGlite.

--- a/apps/server/src/features/social/ranking/ranking.service.test.ts
+++ b/apps/server/src/features/social/ranking/ranking.service.test.ts
@@ -10,7 +10,7 @@ function makeRepo(rows: RawRankingRow[]): RankingRepository {
 }
 
 /** Build a sorted list of N rows: the row at index `meIndex` has userId "me". */
-function buildRows(count: number, meIndex: number): RawRankingRow[] {
+function buildRows(count: number, meIndex: number, ultraIndices: number[] = []): RawRankingRow[] {
   return Array.from({ length: count }, (_, i) => ({
     user_id: i === meIndex ? "me" : `user-${i}`,
     name: i === meIndex ? "Me" : `User ${i}`,
@@ -18,6 +18,7 @@ function buildRows(count: number, meIndex: number): RawRankingRow[] {
     image: null,
     // XP decreasing so index order = rank order
     weekly_xp: (count - i) * 10,
+    is_ultra: ultraIndices.includes(i),
   }));
 }
 
@@ -124,6 +125,65 @@ describe("RankingService", () => {
       const meEntries = result.entries.filter((e) => e.isMe);
       expect(meEntries).toHaveLength(1);
       expect(meEntries[0]?.userId).toBe("me");
+    });
+  });
+
+  describe("isUltra flag", () => {
+    it("passes isUltra=false for all entries when no Ultra users", async () => {
+      const rows = buildRows(4, 1); // no ultraIndices → all false
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      expect(result.entries.every((e) => e.isUltra === false)).toBe(true);
+    });
+
+    it("passes isUltra=true for all entries when all are Ultra", async () => {
+      const rows = buildRows(4, 1, [0, 1, 2, 3]);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      expect(result.entries.every((e) => e.isUltra === true)).toBe(true);
+    });
+
+    it("passes isUltra per-entry correctly when some are Ultra and some are not", async () => {
+      // 5 entries; indices 0, 2 are Ultra; indices 1, 3, 4 are not
+      const rows = buildRows(5, 4, [0, 2]);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      expect(result.entries).toHaveLength(5);
+
+      // index 0 → ultra
+      expect(result.entries[0]?.isUltra).toBe(true);
+      // index 1 → not ultra
+      expect(result.entries[1]?.isUltra).toBe(false);
+      // index 2 → ultra
+      expect(result.entries[2]?.isUltra).toBe(true);
+      // index 3 → not ultra
+      expect(result.entries[3]?.isUltra).toBe(false);
+      // index 4 (me) → not ultra
+      expect(result.entries[4]?.isUltra).toBe(false);
+    });
+
+    it("isUltra flag is preserved after trim window is applied", async () => {
+      // 13 entries; me at index 6, only index 3 is Ultra
+      const rows = buildRows(13, 6, [3]);
+      const service = new RankingService(makeRepo(rows));
+
+      const result = await service.getRanking("me", NOW);
+
+      // trim window: start = max(0, min(3,1)) = 1, slice [1,11)
+      // index 3 in original = index 2 in the window (1-based offset of 1)
+      expect(result.entries).toHaveLength(10);
+
+      // Find the ultra entry in results
+      const ultraEntries = result.entries.filter((e) => e.isUltra);
+      expect(ultraEntries).toHaveLength(1);
+      // The ultra user is user-3 (index 3 in original rows)
+      expect(ultraEntries[0]?.userId).toBe("user-3");
     });
   });
 });

--- a/apps/server/src/features/social/ranking/ranking.service.ts
+++ b/apps/server/src/features/social/ranking/ranking.service.ts
@@ -16,6 +16,7 @@ export class RankingService {
       weeklyXp: r.weekly_xp,
       rank: i + 1,
       isMe: r.user_id === userId,
+      isUltra: r.is_ultra,
     }));
 
     let entries = ranked;

--- a/apps/server/src/features/ultra/ultra.repository.integration.test.ts
+++ b/apps/server/src/features/ultra/ultra.repository.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import {
+  setupTestDb,
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { UltraRepository } from "./ultra.repository";
+
+describe("UltraRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new UltraRepository(db);
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  async function insertUser(id: string) {
+    await db.insert(user).values({
+      id,
+      name: `User ${id}`,
+      email: `${id}@example.com`,
+      emailVerified: false,
+      inviteCode: `code${id.replace(/-/g, "").slice(0, 8)}`,
+      username: null,
+      updatedAt: new Date(),
+    });
+  }
+
+  describe("get", () => {
+    it("returns null for missing user", async () => {
+      const result = await repo.get("nonexistent-user");
+      expect(result).toBeNull();
+    });
+
+    it("returns shape with defaults for existing user", async () => {
+      await insertUser("user-get-1");
+      const result = await repo.get("user-get-1");
+      expect(result).not.toBeNull();
+      expect(result?.isUltra).toBe(false);
+      expect(result?.ultraExpiresAt).toBeNull();
+    });
+  });
+
+  describe("grant", () => {
+    it("sets isUltra=true and ultraExpiresAt for a user", async () => {
+      await insertUser("user-grant-1");
+      const expiresAt = new Date("2027-01-01T00:00:00.000Z");
+      await repo.grant("user-grant-1", expiresAt);
+
+      const result = await repo.get("user-grant-1");
+      expect(result?.isUltra).toBe(true);
+      expect(result?.ultraExpiresAt).toBeInstanceOf(Date);
+      expect(result?.ultraExpiresAt?.toISOString()).toBe(expiresAt.toISOString());
+    });
+  });
+
+  describe("revoke", () => {
+    it("clears isUltra and ultraExpiresAt for an Ultra user", async () => {
+      await insertUser("user-revoke-1");
+      const expiresAt = new Date("2027-01-01T00:00:00.000Z");
+      await repo.grant("user-revoke-1", expiresAt);
+
+      // Confirm it's set
+      const before = await repo.get("user-revoke-1");
+      expect(before?.isUltra).toBe(true);
+
+      // Revoke
+      await repo.revoke("user-revoke-1");
+
+      const after = await repo.get("user-revoke-1");
+      expect(after?.isUltra).toBe(false);
+      expect(after?.ultraExpiresAt).toBeNull();
+    });
+  });
+
+  describe("CHECK constraint: ultra_expires_at requires is_ultra=true", () => {
+    it("throws when setting ultra_expires_at non-null while is_ultra=false", async () => {
+      await insertUser("user-chk-1");
+
+      // Attempt to set ultra_expires_at without setting is_ultra=true
+      await expect(
+        db.execute(
+          // Use raw SQL to bypass Drizzle's type system — simulates a bad direct DB write
+          // @ts-ignore
+          `UPDATE "user" SET ultra_expires_at = '2027-01-01T00:00:00.000Z' WHERE id = 'user-chk-1'`,
+        ),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/apps/server/src/features/ultra/ultra.repository.integration.test.ts
+++ b/apps/server/src/features/ultra/ultra.repository.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { sql } from "drizzle-orm";
 import {
   setupTestDb,
   cleanupTestDb,
@@ -62,6 +63,16 @@ describe("UltraRepository (integration)", () => {
       expect(result?.ultraExpiresAt).toBeInstanceOf(Date);
       expect(result?.ultraExpiresAt?.toISOString()).toBe(expiresAt.toISOString());
     });
+
+    it("re-granting overwrites the expiry (idempotent)", async () => {
+      await insertUser("user-grant-2");
+      const t1 = new Date("2027-01-01T00:00:00.000Z");
+      const t2 = new Date("2028-06-01T00:00:00.000Z");
+      await repo.grant("user-grant-2", t1);
+      await repo.grant("user-grant-2", t2);
+      const result = await repo.get("user-grant-2");
+      expect(result?.ultraExpiresAt?.toISOString()).toBe(t2.toISOString());
+    });
   });
 
   describe("revoke", () => {
@@ -91,8 +102,7 @@ describe("UltraRepository (integration)", () => {
       await expect(
         db.execute(
           // Use raw SQL to bypass Drizzle's type system — simulates a bad direct DB write
-          // @ts-ignore
-          `UPDATE "user" SET ultra_expires_at = '2027-01-01T00:00:00.000Z' WHERE id = 'user-chk-1'`,
+          sql`UPDATE "user" SET ultra_expires_at = '2027-01-01T00:00:00.000Z' WHERE id = 'user-chk-1'`,
         ),
       ).rejects.toThrow();
     });

--- a/apps/server/src/features/ultra/ultra.repository.ts
+++ b/apps/server/src/features/ultra/ultra.repository.ts
@@ -1,0 +1,32 @@
+import { eq } from "drizzle-orm";
+import { user } from "@pruvi/db/schema/auth";
+import type { db as DbClient } from "@pruvi/db";
+
+type Db = typeof DbClient;
+
+export class UltraRepository {
+  constructor(private db: Db) {}
+
+  async get(userId: string): Promise<{ isUltra: boolean; ultraExpiresAt: Date | null } | null> {
+    const rows = await this.db
+      .select({ isUltra: user.isUltra, ultraExpiresAt: user.ultraExpiresAt })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async grant(userId: string, expiresAt: Date): Promise<void> {
+    await this.db
+      .update(user)
+      .set({ isUltra: true, ultraExpiresAt: expiresAt })
+      .where(eq(user.id, userId));
+  }
+
+  async revoke(userId: string): Promise<void> {
+    await this.db
+      .update(user)
+      .set({ isUltra: false, ultraExpiresAt: null })
+      .where(eq(user.id, userId));
+  }
+}

--- a/apps/server/src/features/ultra/ultra.route.ts
+++ b/apps/server/src/features/ultra/ultra.route.ts
@@ -45,7 +45,7 @@ export const ultraRoutes: FastifyPluginAsyncZod = async (fastify) => {
     async (request) => {
       const { userId } = request.params as { userId: string };
       const { expiresAt } = request.body as { expiresAt: string };
-      return successResponse(unwrapResult(await service.grant(userId, new Date(expiresAt))));
+      return unwrapResult(await service.grant(userId, new Date(expiresAt)));
     },
   );
 

--- a/apps/server/src/features/ultra/ultra.route.ts
+++ b/apps/server/src/features/ultra/ultra.route.ts
@@ -1,0 +1,65 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import type { FastifyRequest } from "fastify";
+import { z } from "zod";
+import { GrantUltraBodySchema, UltraStatusSchema } from "@pruvi/shared";
+import { env } from "@pruvi/env/server";
+import { db } from "@pruvi/db";
+import { unwrapResult, successResponse } from "../../types";
+import { AppError, UnauthorizedError } from "../../utils/errors";
+import { UltraRepository } from "./ultra.repository";
+import { UltraService } from "./ultra.service";
+
+const repo = new UltraRepository(db);
+const service = new UltraService(repo);
+
+const adminGuard = async (request: FastifyRequest) => {
+  if (!env.ADMIN_API_TOKEN) {
+    throw new AppError("Admin API disabled", 503, "ADMIN_DISABLED");
+  }
+  const token = request.headers["x-admin-token"];
+  if (token !== env.ADMIN_API_TOKEN) {
+    throw new UnauthorizedError("Admin token required");
+  }
+};
+
+export const ultraRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  // GET /users/me/ultra
+  fastify.get(
+    "/users/me/ultra",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: UltraStatusSchema }) } },
+    },
+    async (request) => {
+      return successResponse(unwrapResult(await service.getStatus(request.userId)).data);
+    },
+  );
+
+  // POST /admin/users/:userId/ultra — grant Ultra
+  fastify.post(
+    "/admin/users/:userId/ultra",
+    {
+      preHandler: [adminGuard],
+      schema: { params: z.object({ userId: z.string() }), body: GrantUltraBodySchema },
+    },
+    async (request) => {
+      const { userId } = request.params as { userId: string };
+      const { expiresAt } = request.body as { expiresAt: string };
+      return successResponse(unwrapResult(await service.grant(userId, new Date(expiresAt))));
+    },
+  );
+
+  // DELETE /admin/users/:userId/ultra — revoke Ultra
+  fastify.delete(
+    "/admin/users/:userId/ultra",
+    {
+      preHandler: [adminGuard],
+      schema: { params: z.object({ userId: z.string() }) },
+    },
+    async (request, reply) => {
+      const { userId } = request.params as { userId: string };
+      unwrapResult(await service.revoke(userId));
+      return reply.code(204).send();
+    },
+  );
+};

--- a/apps/server/src/features/ultra/ultra.service.test.ts
+++ b/apps/server/src/features/ultra/ultra.service.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UltraService } from "./ultra.service";
+
+const FUTURE = new Date(Date.now() + 86400_000);
+const PAST = new Date(Date.now() - 86400_000);
+
+describe("UltraService", () => {
+  let repo: {
+    get: ReturnType<typeof vi.fn>;
+    grant: ReturnType<typeof vi.fn>;
+    revoke: ReturnType<typeof vi.fn>;
+  };
+  let service: UltraService;
+
+  beforeEach(() => {
+    repo = { get: vi.fn(), grant: vi.fn(), revoke: vi.fn() };
+    service = new UltraService(repo as any);
+  });
+
+  describe("isUltra", () => {
+    it("returns false when user is null", async () => {
+      repo.get.mockResolvedValue(null);
+      expect(await service.isUltra("u")).toBe(false);
+    });
+
+    it("returns false when is_ultra=false", async () => {
+      repo.get.mockResolvedValue({ isUltra: false, ultraExpiresAt: null });
+      expect(await service.isUltra("u")).toBe(false);
+    });
+
+    it("returns true when is_ultra=true and no expiry", async () => {
+      repo.get.mockResolvedValue({ isUltra: true, ultraExpiresAt: null });
+      expect(await service.isUltra("u")).toBe(true);
+    });
+
+    it("returns true when is_ultra=true and expiry in future", async () => {
+      repo.get.mockResolvedValue({ isUltra: true, ultraExpiresAt: FUTURE });
+      expect(await service.isUltra("u")).toBe(true);
+    });
+
+    it("returns false when is_ultra=true but expiry in past (defensive)", async () => {
+      repo.get.mockResolvedValue({ isUltra: true, ultraExpiresAt: PAST });
+      expect(await service.isUltra("u")).toBe(false);
+    });
+  });
+
+  describe("getStatus", () => {
+    it("returns NotFoundError when user does not exist", async () => {
+      repo.get.mockResolvedValue(null);
+      const r = await service.getStatus("u");
+      expect(r.isErr()).toBe(true);
+    });
+
+    it("returns isUltra:false + expiresAt:null for non-Ultra user", async () => {
+      repo.get.mockResolvedValue({ isUltra: false, ultraExpiresAt: null });
+      const r = await service.getStatus("u");
+      expect(r._unsafeUnwrap()).toEqual({ isUltra: false, expiresAt: null });
+    });
+
+    it("returns isUltra:true + ISO expiresAt for Ultra user", async () => {
+      repo.get.mockResolvedValue({ isUltra: true, ultraExpiresAt: FUTURE });
+      const r = await service.getStatus("u");
+      expect(r._unsafeUnwrap().isUltra).toBe(true);
+      expect(r._unsafeUnwrap().expiresAt).toBe(FUTURE.toISOString());
+    });
+  });
+
+  it("grant calls repo.grant with correct args", async () => {
+    repo.grant.mockResolvedValue(undefined);
+    await service.grant("u", FUTURE);
+    expect(repo.grant).toHaveBeenCalledWith("u", FUTURE);
+  });
+
+  it("revoke calls repo.revoke with correct userId", async () => {
+    repo.revoke.mockResolvedValue(undefined);
+    await service.revoke("u");
+    expect(repo.revoke).toHaveBeenCalledWith("u");
+  });
+});

--- a/apps/server/src/features/ultra/ultra.service.test.ts
+++ b/apps/server/src/features/ultra/ultra.service.test.ts
@@ -63,6 +63,12 @@ describe("UltraService", () => {
       expect(r._unsafeUnwrap().isUltra).toBe(true);
       expect(r._unsafeUnwrap().expiresAt).toBe(FUTURE.toISOString());
     });
+
+    it("returns isUltra:false when is_ultra=true but expiry is past (defensive)", async () => {
+      repo.get.mockResolvedValue({ isUltra: true, ultraExpiresAt: PAST });
+      const r = await service.getStatus("u");
+      expect(r._unsafeUnwrap()).toEqual({ isUltra: false, expiresAt: PAST.toISOString() });
+    });
   });
 
   it("grant calls repo.grant with correct args", async () => {

--- a/apps/server/src/features/ultra/ultra.service.ts
+++ b/apps/server/src/features/ultra/ultra.service.ts
@@ -1,0 +1,31 @@
+import { ok, err, type Result } from "neverthrow";
+import { AppError, NotFoundError } from "../../utils/errors";
+import type { UltraRepository } from "./ultra.repository";
+
+export class UltraService {
+  constructor(private repo: UltraRepository) {}
+
+  async isUltra(userId: string): Promise<boolean> {
+    const row = await this.repo.get(userId);
+    if (!row?.isUltra) return false;
+    if (row.ultraExpiresAt && row.ultraExpiresAt < new Date()) return false;
+    return true;
+  }
+
+  async getStatus(userId: string): Promise<Result<{ isUltra: boolean; expiresAt: string | null }, AppError>> {
+    const row = await this.repo.get(userId);
+    if (!row) return err(new NotFoundError("User not found"));
+    const effective = row.isUltra && (!row.ultraExpiresAt || row.ultraExpiresAt > new Date());
+    return ok({ isUltra: effective, expiresAt: row.ultraExpiresAt?.toISOString() ?? null });
+  }
+
+  async grant(userId: string, expiresAt: Date): Promise<Result<void, AppError>> {
+    await this.repo.grant(userId, expiresAt);
+    return ok(undefined);
+  }
+
+  async revoke(userId: string): Promise<Result<void, AppError>> {
+    await this.repo.revoke(userId);
+    return ok(undefined);
+  }
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -11,6 +11,7 @@ import {
 import { gamificationRoutes } from "./features/gamification";
 import { tokensRoutes, preferencesRoutes } from "./features/notifications";
 import { invitationsRoutes, friendshipsRoutes, rankingRoutes } from "./features/social";
+import { ultraRoutes } from "./features/ultra/ultra.route";
 import { livesRoutes } from "./features/lives";
 import { onboardingRoutes } from "./features/onboarding";
 import { progressRoutes } from "./features/progress";
@@ -84,6 +85,7 @@ export async function buildApp() {
   await app.register(invitationsRoutes);
   await app.register(friendshipsRoutes);
   await app.register(rankingRoutes);
+  await app.register(ultraRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -37,7 +37,7 @@ export async function buildApp() {
   await app.register(fastifyCors, {
     origin: env.CORS_ORIGIN,
     methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
+    allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With", "X-Admin-Token"],
     credentials: true,
     maxAge: 86400,
   });

--- a/docs/superpowers/plans/2026-05-12-phase-2e1-ultra-entitlement.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e1-ultra-entitlement.md
@@ -1,0 +1,632 @@
+# Phase 2E.1 — Ultra Entitlement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Ship the `is_ultra` entitlement column + helper service + unlimited-lives perk + ranking `isUltra` flag + admin grant/revoke endpoints. Defer billing webhooks to 2E.4.
+
+**Architecture:** Single new schema migration (`0007`). New `UltraRepository` + `UltraService` + `ultra.route.ts`. `LivesRepository` reads `is_ultra` alongside lives in one SELECT; both `materializeRegen` and `tryDecrement` short-circuit for Ultra. `LivesResponseSchema` and `RankingEntrySchema` gain `unlimited` and `isUltra` fields respectively.
+
+**Source spec:** `docs/superpowers/specs/2026-05-12-phase-2e1-ultra-entitlement-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `packages/shared/src/ultra.ts` — Zod schemas (`UltraStatusSchema`, `GrantUltraBodySchema`)
+- `packages/shared/src/ultra.test.ts`
+- `packages/db/src/migrations/0007_<generated>.sql`
+- `apps/server/src/features/ultra/ultra.repository.ts`
+- `apps/server/src/features/ultra/ultra.service.ts`
+- `apps/server/src/features/ultra/ultra.route.ts`
+- `apps/server/src/features/ultra/ultra.service.test.ts`
+- `apps/server/src/features/ultra/ultra.repository.integration.test.ts`
+
+**Modify:**
+- `packages/db/src/schema/auth.ts` — add `isUltra`, `ultraExpiresAt`
+- `packages/db/src/test-client.ts` — mirror DDL + CHECK + index
+- `packages/shared/src/index.ts` — re-export ultra
+- `packages/shared/src/lives.ts` — extend `LivesResponseSchema` with `unlimited`
+- `packages/shared/src/social.ts` — extend `RankingEntrySchema` with `isUltra`
+- `packages/env/src/server.ts` — add `ADMIN_API_TOKEN`
+- `apps/server/src/features/lives/lives.repository.ts` — `getUserLives` selects `is_ultra`+`ultra_expires_at`; `materializeRegen` + `tryDecrement` short-circuit
+- `apps/server/src/features/lives/lives.service.ts` — return `unlimited` flag
+- `apps/server/src/features/lives/lives.service.test.ts` — Ultra cases
+- `apps/server/src/features/lives/lives.repository.integration.test.ts` — Ultra cases
+- `apps/server/src/features/social/ranking/ranking.repository.ts` — include `u.is_ultra` in SQL
+- `apps/server/src/features/social/ranking/ranking.service.ts` — pass through to response
+- `apps/server/src/features/social/ranking/ranking.service.test.ts` — assert `isUltra` per entry
+- `apps/server/src/features/social/ranking/ranking.repository.integration.test.ts` — assert flag
+- `apps/server/src/index.ts` (or `app.ts`) — register ultra routes
+
+---
+
+## Tasks
+
+### Task 1: Shared schemas + helper types
+
+**Files:**
+- Create: `packages/shared/src/ultra.ts`, `packages/shared/src/ultra.test.ts`
+- Modify: `packages/shared/src/index.ts`, `packages/shared/src/lives.ts`, `packages/shared/src/social.ts`
+
+- [ ] **Step 1: Create `packages/shared/src/ultra.ts`**
+
+```typescript
+import { z } from "zod";
+
+export const UltraStatusSchema = z.object({
+  isUltra: z.boolean(),
+  expiresAt: z.string().datetime().nullable(),
+});
+export type UltraStatus = z.infer<typeof UltraStatusSchema>;
+
+export const GrantUltraBodySchema = z.object({
+  expiresAt: z.string().datetime(),
+});
+export type GrantUltraBody = z.infer<typeof GrantUltraBodySchema>;
+```
+
+- [ ] **Step 2: Tests for ultra.ts**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { UltraStatusSchema, GrantUltraBodySchema } from "./ultra";
+
+describe("UltraStatusSchema", () => {
+  it("accepts isUltra=true with ISO expiry", () => {
+    expect(UltraStatusSchema.safeParse({ isUltra: true, expiresAt: "2026-06-12T00:00:00.000Z" }).success).toBe(true);
+  });
+  it("accepts isUltra=false with null expiry", () => {
+    expect(UltraStatusSchema.safeParse({ isUltra: false, expiresAt: null }).success).toBe(true);
+  });
+  it("rejects non-ISO expiry", () => {
+    expect(UltraStatusSchema.safeParse({ isUltra: true, expiresAt: "tomorrow" }).success).toBe(false);
+  });
+});
+
+describe("GrantUltraBodySchema", () => {
+  it("requires expiresAt", () => {
+    expect(GrantUltraBodySchema.safeParse({}).success).toBe(false);
+  });
+  it("accepts ISO datetime", () => {
+    expect(GrantUltraBodySchema.safeParse({ expiresAt: "2026-06-12T00:00:00.000Z" }).success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Extend `LivesResponseSchema` in `packages/shared/src/lives.ts`**
+
+Find `LivesResponseSchema` and add `unlimited: z.boolean()`. Backward-compatible additive change.
+
+- [ ] **Step 4: Extend `RankingEntrySchema` in `packages/shared/src/social.ts`**
+
+Add `isUltra: z.boolean()` to the schema (after `image`).
+
+- [ ] **Step 5: Re-export from `packages/shared/src/index.ts`**
+
+Append: `export * from "./ultra";`
+
+- [ ] **Step 6: Run tests + commit**
+
+```bash
+pnpm --filter @pruvi/shared test
+git add packages/shared/src
+git commit -m "feat(shared): ultra status schemas + lives unlimited + ranking isUltra fields"
+```
+
+---
+
+### Task 2: DB schema + migration
+
+**Files:**
+- Modify: `packages/db/src/schema/auth.ts`
+- Create: `packages/db/src/migrations/0007_<name>.sql`
+- Modify: `packages/db/src/test-client.ts`
+
+- [ ] **Step 1: Add columns to `auth.ts`**
+
+```typescript
+// inside the user pgTable, after onboardingCompleted (or any location matching the file's grouping):
+isUltra: boolean("is_ultra").notNull().default(false),
+ultraExpiresAt: timestamp("ultra_expires_at"),
+```
+
+- [ ] **Step 2: Generate migration**
+
+Run: `pnpm --filter @pruvi/db db:generate`. Note the generated filename.
+
+- [ ] **Step 3: Edit the generated migration**
+
+Replace the generated SQL with the idempotent version (paste verbatim, keep `--> statement-breakpoint` markers):
+
+```sql
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "is_ultra" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "ultra_expires_at" timestamp;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_ultra_expiry_chk') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_ultra_expiry_chk"
+      CHECK ("ultra_expires_at" IS NULL OR "is_ultra" = true);
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "user_ultra_expiry_idx" ON "user" ("ultra_expires_at") WHERE "is_ultra" = true;
+```
+
+- [ ] **Step 4: Update `packages/db/src/migrations/meta/0007_snapshot.json` if needed**
+
+Drizzle-kit may not capture the partial index or CHECK constraint (per Phase 2C/2D precedent). If you observe drift on a subsequent `db:generate`, manually patch the snapshot. For this task, accept the drift if it occurs and document it in the commit message.
+
+- [ ] **Step 5: Mirror in PGlite test-client**
+
+In `packages/db/src/test-client.ts`, add to the user table DDL:
+- `is_ultra BOOLEAN NOT NULL DEFAULT false`
+- `ultra_expires_at TIMESTAMP`
+- `CONSTRAINT user_ultra_expiry_chk CHECK (ultra_expires_at IS NULL OR is_ultra = true)` (inline, matching the existing inline-CHECK style)
+- `CREATE INDEX IF NOT EXISTS user_ultra_expiry_idx ON "user" (ultra_expires_at) WHERE is_ultra = true;` (after the CREATE TABLE)
+
+- [ ] **Step 6: verify:migration + existing tests**
+
+```bash
+pnpm verify:migration
+pnpm --filter server test
+pnpm --filter server test:integration
+```
+
+All must pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/db
+git commit -m "feat(db): user.is_ultra + ultra_expires_at columns (migration 0007)"
+```
+
+---
+
+### Task 3: Ultra repository + service + admin route
+
+**Files:**
+- Create: `apps/server/src/features/ultra/ultra.repository.ts`
+- Create: `apps/server/src/features/ultra/ultra.service.ts`
+- Create: `apps/server/src/features/ultra/ultra.route.ts`
+- Create: `apps/server/src/features/ultra/ultra.service.test.ts`
+- Create: `apps/server/src/features/ultra/ultra.repository.integration.test.ts`
+- Modify: `packages/env/src/server.ts`
+- Modify: `apps/server/src/index.ts` (or wherever routes register)
+
+- [ ] **Step 1: Add `ADMIN_API_TOKEN` to env**
+
+In `packages/env/src/server.ts`:
+```typescript
+ADMIN_API_TOKEN: z.string().min(16).optional(),
+```
+
+- [ ] **Step 2: Repository**
+
+```typescript
+import { eq } from "drizzle-orm";
+import { user } from "@pruvi/db/schema/auth";
+import type { db as DbClient } from "@pruvi/db";
+
+type Db = typeof DbClient;
+
+export class UltraRepository {
+  constructor(private db: Db) {}
+
+  async get(userId: string): Promise<{ isUltra: boolean; ultraExpiresAt: Date | null } | null> {
+    const rows = await this.db
+      .select({ isUltra: user.isUltra, ultraExpiresAt: user.ultraExpiresAt })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async grant(userId: string, expiresAt: Date): Promise<void> {
+    await this.db
+      .update(user)
+      .set({ isUltra: true, ultraExpiresAt: expiresAt })
+      .where(eq(user.id, userId));
+  }
+
+  async revoke(userId: string): Promise<void> {
+    await this.db
+      .update(user)
+      .set({ isUltra: false, ultraExpiresAt: null })
+      .where(eq(user.id, userId));
+  }
+}
+```
+
+- [ ] **Step 3: Service**
+
+```typescript
+import { ok, err, type Result } from "neverthrow";
+import { AppError, NotFoundError } from "../../utils/errors";
+import type { UltraRepository } from "./ultra.repository";
+
+export class UltraService {
+  constructor(private repo: UltraRepository) {}
+
+  async isUltra(userId: string): Promise<boolean> {
+    const row = await this.repo.get(userId);
+    if (!row?.isUltra) return false;
+    if (row.ultraExpiresAt && row.ultraExpiresAt < new Date()) return false;
+    return true;
+  }
+
+  async getStatus(userId: string): Promise<Result<{ isUltra: boolean; expiresAt: string | null }, AppError>> {
+    const row = await this.repo.get(userId);
+    if (!row) return err(new NotFoundError("User not found"));
+    const effective = row.isUltra && (!row.ultraExpiresAt || row.ultraExpiresAt > new Date());
+    return ok({ isUltra: effective, expiresAt: row.ultraExpiresAt?.toISOString() ?? null });
+  }
+
+  async grant(userId: string, expiresAt: Date): Promise<Result<void, AppError>> {
+    await this.repo.grant(userId, expiresAt);
+    return ok(undefined);
+  }
+
+  async revoke(userId: string): Promise<Result<void, AppError>> {
+    await this.repo.revoke(userId);
+    return ok(undefined);
+  }
+}
+```
+
+- [ ] **Step 4: Route**
+
+```typescript
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { GrantUltraBodySchema, UltraStatusSchema } from "@pruvi/shared";
+import { env } from "@pruvi/env/server";
+import { db } from "@pruvi/db";
+import { unwrapResult, successResponse } from "../../types";
+import { UnauthorizedError } from "../../utils/errors";  // or appropriate
+import { UltraRepository } from "./ultra.repository";
+import { UltraService } from "./ultra.service";
+
+export const ultraRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const repo = new UltraRepository(db);
+  const service = new UltraService(repo);
+
+  // GET /users/me/ultra
+  fastify.get(
+    "/users/me/ultra",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: UltraStatusSchema }) } },
+    },
+    async (request) => {
+      return successResponse(unwrapResult(await service.getStatus(request.userId)).data);
+    },
+  );
+
+  // Admin endpoints — gated by ADMIN_API_TOKEN env
+  const adminGuard = async (request: any) => {
+    if (!env.ADMIN_API_TOKEN) {
+      throw new AppError("Admin API disabled", 503, "ADMIN_DISABLED");
+    }
+    const token = request.headers["x-admin-token"];
+    if (token !== env.ADMIN_API_TOKEN) {
+      throw new UnauthorizedError("Admin token required");
+    }
+  };
+
+  fastify.post(
+    "/admin/users/:userId/ultra",
+    {
+      preHandler: [adminGuard],
+      schema: { params: z.object({ userId: z.string() }), body: GrantUltraBodySchema },
+    },
+    async (request) => {
+      const { userId } = request.params as { userId: string };
+      const { expiresAt } = request.body as { expiresAt: string };
+      return successResponse(unwrapResult(await service.grant(userId, new Date(expiresAt))));
+    },
+  );
+
+  fastify.delete(
+    "/admin/users/:userId/ultra",
+    {
+      preHandler: [adminGuard],
+      schema: { params: z.object({ userId: z.string() }) },
+    },
+    async (request, reply) => {
+      const { userId } = request.params as { userId: string };
+      unwrapResult(await service.revoke(userId));
+      return reply.code(204).send();
+    },
+  );
+};
+```
+
+**Look up the canonical error class names** (`UnauthorizedError`, `AppError`) in `apps/server/src/utils/errors.ts` — if they have different names (e.g. `AuthError`), use those. The plan above uses placeholder names; verify before coding.
+
+- [ ] **Step 5: Service unit tests**
+
+```typescript
+// ultra.service.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UltraService } from "./ultra.service";
+
+const FUTURE = new Date(Date.now() + 86400_000);
+const PAST = new Date(Date.now() - 86400_000);
+
+describe("UltraService", () => {
+  let repo: any;
+  let service: UltraService;
+  beforeEach(() => {
+    repo = { get: vi.fn(), grant: vi.fn(), revoke: vi.fn() };
+    service = new UltraService(repo);
+  });
+
+  describe("isUltra", () => {
+    it("returns false when user is null", async () => {
+      repo.get.mockResolvedValue(null);
+      expect(await service.isUltra("u")).toBe(false);
+    });
+    it("returns false when is_ultra=false", async () => {
+      repo.get.mockResolvedValue({ isUltra: false, ultraExpiresAt: null });
+      expect(await service.isUltra("u")).toBe(false);
+    });
+    it("returns true when is_ultra=true and no expiry", async () => {
+      repo.get.mockResolvedValue({ isUltra: true, ultraExpiresAt: null });
+      expect(await service.isUltra("u")).toBe(true);
+    });
+    it("returns true when is_ultra=true and expiry in future", async () => {
+      repo.get.mockResolvedValue({ isUltra: true, ultraExpiresAt: FUTURE });
+      expect(await service.isUltra("u")).toBe(true);
+    });
+    it("returns false when is_ultra=true but expiry in past (defensive)", async () => {
+      repo.get.mockResolvedValue({ isUltra: true, ultraExpiresAt: PAST });
+      expect(await service.isUltra("u")).toBe(false);
+    });
+  });
+
+  describe("getStatus", () => {
+    it("NotFoundError when user does not exist", async () => {
+      repo.get.mockResolvedValue(null);
+      const r = await service.getStatus("u");
+      expect(r.isErr()).toBe(true);
+    });
+    it("returns isUltra:false + expiresAt:null for non-Ultra user", async () => {
+      repo.get.mockResolvedValue({ isUltra: false, ultraExpiresAt: null });
+      const r = await service.getStatus("u");
+      expect(r._unsafeUnwrap()).toEqual({ isUltra: false, expiresAt: null });
+    });
+    it("returns isUltra:true + ISO expiresAt for Ultra user", async () => {
+      repo.get.mockResolvedValue({ isUltra: true, ultraExpiresAt: FUTURE });
+      const r = await service.getStatus("u");
+      expect(r._unsafeUnwrap().isUltra).toBe(true);
+      expect(r._unsafeUnwrap().expiresAt).toBe(FUTURE.toISOString());
+    });
+  });
+
+  it("grant calls repo.grant", async () => {
+    await service.grant("u", FUTURE);
+    expect(repo.grant).toHaveBeenCalledWith("u", FUTURE);
+  });
+  it("revoke calls repo.revoke", async () => {
+    await service.revoke("u");
+    expect(repo.revoke).toHaveBeenCalledWith("u");
+  });
+});
+```
+
+- [ ] **Step 6: Repository integration tests**
+
+```typescript
+// ultra.repository.integration.test.ts
+// Standard pattern matching other integration tests in this codebase.
+// Cases: get returns row, grant sets columns, revoke clears, CHECK constraint
+//   rejects ultra_expires_at without is_ultra=true.
+```
+
+- [ ] **Step 7: Wire route**
+
+Register `ultraRoutes` in the server entry. Match the existing pattern (probably alongside `invitationsRoutes` and `friendshipsRoutes`).
+
+- [ ] **Step 8: Run + commit**
+
+```bash
+pnpm --filter server test && pnpm --filter server test:integration
+git add apps/server/src/features/ultra apps/server/src/index.ts packages/env
+git commit -m "feat(ultra): repository + service + admin grant/revoke endpoints"
+```
+
+---
+
+### Task 4: Lives bypass for Ultra
+
+**Files:**
+- Modify: `apps/server/src/features/lives/lives.repository.ts`
+- Modify: `apps/server/src/features/lives/lives.service.ts`
+- Modify: `apps/server/src/features/lives/lives.service.test.ts`
+- Modify: `apps/server/src/features/lives/lives.repository.integration.test.ts`
+
+- [ ] **Step 1: `getUserLives` selects Ultra columns**
+
+```typescript
+async getUserLives(userId: string) {
+  const rows = await this.db
+    .select({
+      lives: user.lives,
+      livesLastRegenAt: user.livesLastRegenAt,
+      isUltra: user.isUltra,
+      ultraExpiresAt: user.ultraExpiresAt,
+    })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+```
+
+- [ ] **Step 2: `materializeRegen` short-circuit**
+
+```typescript
+async materializeRegen(userId: string, now: Date): Promise<{ lives: number; lastRegenAt: Date | null; isUltra: boolean }> {
+  const current = await this.getUserLives(userId);
+  if (!current) {
+    return { lives: MAX_LIVES, lastRegenAt: null, isUltra: false };
+  }
+  const ultraActive = current.isUltra && (!current.ultraExpiresAt || current.ultraExpiresAt > now);
+  if (ultraActive) {
+    return { lives: MAX_LIVES, lastRegenAt: null, isUltra: true };
+  }
+  const snap = computeRegenSnapshot(current.lives, current.livesLastRegenAt, now);
+  if (snap.regenerated > 0) {
+    await this.db
+      .update(user)
+      .set({ lives: snap.lives, livesLastRegenAt: snap.lastRegenAt })
+      .where(eq(user.id, userId));
+  }
+  return { lives: snap.lives, lastRegenAt: snap.lastRegenAt, isUltra: false };
+}
+```
+
+- [ ] **Step 3: `tryDecrement` short-circuit**
+
+Return type extended:
+```typescript
+| { ok: true; livesAfter: number; lastRegenAt: Date | null; isUltra: boolean }
+| { ok: false }
+```
+
+Implementation: read `getUserLives` first; if Ultra, return `{ ok: true, livesAfter: MAX_LIVES, lastRegenAt: null, isUltra: true }` without UPDATE. Otherwise proceed with the existing atomic UPDATE (add `isUltra: false` to the success-return shape).
+
+- [ ] **Step 4: `lives.service.ts` returns `unlimited`**
+
+```typescript
+async getLives(userId: string): Promise<Result<{ lives: number; maxLives: number; resetsAt: Date | null; unlimited: boolean }, AppError>> {
+  const state = await this.repo.materializeRegen(userId, new Date());
+  return ok({
+    lives: state.lives,
+    maxLives: MAX_LIVES,
+    resetsAt: state.isUltra ? null : nextRegenAt(state.lives, state.lastRegenAt),
+    unlimited: state.isUltra,
+  });
+}
+```
+
+- [ ] **Step 5: Update tests**
+
+`lives.service.test.ts`:
+- Existing tests: add `unlimited: false` to expected shapes.
+- New tests: Ultra user → `unlimited: true, resetsAt: null`.
+
+`lives.repository.integration.test.ts`:
+- Existing tests: add `isUltra: false` to expected shapes from `materializeRegen` + `tryDecrement`.
+- New tests:
+  - `materializeRegen` for Ultra user → returns `{ lives: 5, lastRegenAt: null, isUltra: true }` regardless of stored lives value.
+  - `tryDecrement` for Ultra user → returns `{ ok: true, livesAfter: 5, lastRegenAt: null, isUltra: true }`; the DB `lives` column is NOT decremented.
+
+- [ ] **Step 6: Reviews-service compatibility check**
+
+In `apps/server/src/features/reviews/reviews.service.ts`, the call site of `tryDecrement` will still work (Ultra branch returns `ok` shape). But verify: are there any tests that destructure the return shape and would now fail with the new `isUltra` field? Grep for `tryDecrement(` usages and `.livesAfter`. If tests use exact-shape matchers, update them.
+
+- [ ] **Step 7: Run + commit**
+
+```bash
+pnpm --filter server test && pnpm --filter server test:integration
+git add apps/server/src/features/lives
+git commit -m "feat(lives): unlimited lives bypass for Ultra users"
+```
+
+---
+
+### Task 5: Ranking `isUltra` flag
+
+**Files:**
+- Modify: `apps/server/src/features/social/ranking/ranking.repository.ts`
+- Modify: `apps/server/src/features/social/ranking/ranking.service.ts`
+- Modify: `apps/server/src/features/social/ranking/ranking.service.test.ts`
+- Modify: `apps/server/src/features/social/ranking/ranking.repository.integration.test.ts`
+
+- [ ] **Step 1: Repository SQL**
+
+Add `u.is_ultra` to SELECT + GROUP BY. Add `is_ultra: boolean` to `RawRankingRow`.
+
+- [ ] **Step 2: Service mapping**
+
+```typescript
+const ranked = rows.map((r, i) => ({
+  userId: r.user_id,
+  name: r.name,
+  username: r.username,
+  image: r.image,
+  weeklyXp: r.weekly_xp,
+  isUltra: r.is_ultra,
+  rank: i + 1,
+  isMe: r.user_id === userId,
+}));
+```
+
+- [ ] **Step 3: Tests**
+
+Unit test: extend mocks to include `is_ultra: true/false` and assert it's reflected in each entry.
+
+Integration test: seed users with mixed `is_ultra` values; assert `isUltra` per row matches.
+
+- [ ] **Step 4: Run + commit**
+
+```bash
+pnpm --filter server test && pnpm --filter server test:integration
+git add apps/server/src/features/social/ranking
+git commit -m "feat(ranking): include isUltra flag per entry"
+```
+
+---
+
+### Task 6: Final verification + push
+
+- [ ] **Step 1: Full sweep**
+
+```bash
+pnpm --filter server test
+pnpm --filter server test:integration
+pnpm --filter @pruvi/shared test
+pnpm verify:migration
+pnpm --filter server check-types
+```
+
+All must pass. Pre-existing test-file strict-null noise OK.
+
+- [ ] **Step 2: Smoke**
+
+```bash
+pnpm dev:worker  # Ctrl-C after ready
+```
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feature/phase-2e1-ultra-entitlement
+gh pr create --base main --title "feat: phase 2e.1 — ultra entitlement scaffolding + unlimited lives" --body "..."
+```
+
+PR body: summarize schema, hot-path bypass, admin endpoints, ranking flag, list deferred items (2E.2 shield, 2E.3 simulado, 2E.4 billing webhooks), reference spec + plan.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- ✅ Schema (is_ultra + ultra_expires_at + CHECK + index) → Task 2
+- ✅ UltraRepository + UltraService → Task 3
+- ✅ Admin grant/revoke routes (token-gated) → Task 3
+- ✅ `GET /users/me/ultra` → Task 3
+- ✅ Lives bypass for Ultra → Task 4
+- ✅ `unlimited` field in LivesResponse → Tasks 1 + 4
+- ✅ `isUltra` field in RankingEntry → Tasks 1 + 5
+
+**Placeholder scan:** None — each step contains explicit code or a precise lookup instruction.
+
+**Type consistency:**
+- `materializeRegen` and `tryDecrement` return shapes both include `isUltra: boolean` — service uses it for `unlimited` flag.
+- `RankingEntry.isUltra` set from `RawRankingRow.is_ultra` (snake-case → camelCase mapping in service layer).
+- `UltraStatus.expiresAt` is `string | null` (ISO datetime), not `Date` — repo returns Date, service converts via `.toISOString()`.

--- a/docs/superpowers/specs/2026-05-12-phase-2e1-ultra-entitlement-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e1-ultra-entitlement-design.md
@@ -1,0 +1,250 @@
+# Phase 2E.1 — Ultra Entitlement Scaffolding (Design Spec)
+
+**Date:** 2026-05-12
+**Phase:** 2E.1 (first slice of the Ultra/monetization phase)
+**Source spec:** `pruvi-freatures.md` §5.1 (Pruvi Ultra: vidas ilimitadas, badge Ultra, billing via Google Play / App Store)
+
+## Goal
+
+Ship the server-side scaffolding for "is this user Ultra?": the column, the entitlement helper, the unlimited-lives perk, and the `isUltra` flag in the ranking response so the frontend can render the badge. Make it easy to grant/revoke Ultra in QA without a billing platform wired up.
+
+## Non-goals (deferred to 2E.2 / 2E.3 / 2E.4)
+
+- **Streak shield mechanics** (2E.2): monthly refill cron, auto-use on streak break.
+- **Simulado semanal** (2E.3): new question-selection path, simulado table, performance comparison.
+- **Google Play RTDN / App Store Server Notifications V2 webhooks** (2E.4): real billing integration. Out of scope here because Apple Developer credentials aren't available yet (open product item) and Google credentials need their own setup.
+- **Ad-removal logic** — there are no ads in the codebase yet.
+- **Receipt validation / cryptographic verification of billing platform tokens.**
+- **Rate-limited grant/revoke UI** for admin operations.
+- **Ultra-tier price changes** — the column doesn't track plan or price; just `is_ultra` + `ultra_expires_at`.
+
+## Data Model
+
+### `user` extensions
+
+```sql
++ is_ultra            boolean NOT NULL DEFAULT false
++ ultra_expires_at    timestamp                              -- NULL = lifetime, but in practice always set when is_ultra=true
++ CHECK (ultra_expires_at IS NULL OR is_ultra = true)        -- can't have an expiry without being Ultra
+```
+
+**Why two fields:** `is_ultra` is the read-fast boolean for hot-path gating (every answer / every ranking entry). `ultra_expires_at` lets us schedule expiry without a cron — the entitlement helper compares `now() < ultra_expires_at` and treats expired-but-flagged users as non-Ultra (defensive). The DB also gets a daily cleanup job in 2E.4 to flip `is_ultra=false` once `ultra_expires_at < now()`, but reads don't depend on that cleanup running on time.
+
+**Why not a separate `subscription` table:** for MVP, Ultra is binary (you have it or you don't). When we add tier variants (e.g. annual vs monthly, family plan), a `subscription` table makes sense. Premature now.
+
+## Architecture
+
+### Feature module
+
+```
+apps/server/src/features/ultra/
+  ultra.repository.ts        # get(userId), grant(userId, expiresAt), revoke(userId)
+  ultra.service.ts           # isUltra(userId), grantUltra(...), revokeUltra(...)
+  ultra.route.ts             # admin grant/revoke endpoints (token-gated for QA)
+  ultra.service.test.ts
+  ultra.repository.integration.test.ts
+```
+
+### `UltraService.isUltra(userId)` semantics
+
+```typescript
+async isUltra(userId: string): Promise<boolean> {
+  const row = await this.repo.get(userId);
+  if (!row?.isUltra) return false;
+  if (row.ultraExpiresAt && row.ultraExpiresAt < new Date()) return false;
+  return true;
+}
+```
+
+The expiry check is defensive — even if `is_ultra=true` lingers after expiry, reads treat the user as non-Ultra. This decouples correctness from the daily cleanup job.
+
+## Hot-path integration
+
+### Lives bypass
+
+Ultra users have unlimited lives — wrong answers do not decrement.
+
+`LivesService.getLives` and `reviews.service.completeAnswer` both need to short-circuit for Ultra.
+
+**Approach: read `is_ultra` alongside lives** in `LivesRepository.materializeRegen` and `getUserLives`. Single SELECT, no extra round-trip.
+
+```typescript
+// LivesRepository
+async getUserLives(userId: string) {
+  const rows = await this.db
+    .select({
+      lives: user.lives,
+      livesLastRegenAt: user.livesLastRegenAt,
+      isUltra: user.isUltra,
+      ultraExpiresAt: user.ultraExpiresAt,
+    })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+```
+
+`materializeRegen` becomes:
+
+```typescript
+async materializeRegen(userId, now) {
+  const row = await this.getUserLives(userId);
+  if (!row) return { lives: MAX_LIVES, lastRegenAt: null, isUltra: false };
+  const ultra = row.isUltra && (!row.ultraExpiresAt || row.ultraExpiresAt > now);
+  if (ultra) return { lives: MAX_LIVES, lastRegenAt: null, isUltra: true };
+  // ... existing regen logic ...
+  return { lives: snap.lives, lastRegenAt: snap.lastRegenAt, isUltra: false };
+}
+```
+
+`tryDecrement` likewise:
+
+```typescript
+async tryDecrement(userId, now): Promise<{ ok: true; livesAfter: number; lastRegenAt: Date | null; isUltra: boolean } | { ok: false }> {
+  // Check Ultra status first; if Ultra, return ok with sentinel lives = MAX
+  const row = await this.getUserLives(userId);
+  if (row?.isUltra && (!row.ultraExpiresAt || row.ultraExpiresAt > now)) {
+    return { ok: true, livesAfter: MAX_LIVES, lastRegenAt: null, isUltra: true };
+  }
+  // ... existing atomic UPDATE ...
+}
+```
+
+**Why not gate at service layer:** keeping the gate in the repository ensures every caller of `tryDecrement` is consistent. A future call site won't accidentally bypass the gate.
+
+**Race window:** there's a microsecond window where `is_ultra` flips false between the read and the atomic UPDATE. Worst case: Ultra-user loses a life right after their subscription ends. Acceptable.
+
+### `LivesService.getLives` response
+
+Add `unlimited: boolean` to the response shape:
+
+```typescript
+{ lives: number, maxLives: number, resetsAt: Date | null, unlimited: boolean }
+```
+
+Ultra users get `unlimited: true, lives: 5 (sentinel), maxLives: 5, resetsAt: null`. Frontend renders ∞ when `unlimited` is true.
+
+### Ranking response
+
+`RankingEntrySchema` gets `isUltra: z.boolean()`. The ranking SQL already groups by user fields — add `u.is_ultra` to the select + group-by clauses. Service maps the SQL field to the response.
+
+```typescript
+// In ranking.repository.ts SQL:
+SELECT u.id AS user_id, u.name, u.username, u.image, u.is_ultra,
+       COALESCE(SUM(rl.xp_earned), 0)::int AS weekly_xp
+...
+GROUP BY u.id, u.name, u.username, u.image, u.is_ultra
+```
+
+`RankingEntry.isUltra` reflects the column as-is (no expiry check) — the daily cleanup keeps it accurate. The ranking is cached 60s so a recently-expired Ultra would briefly show the badge; acceptable.
+
+## API surface
+
+### Admin grant / revoke (QA-only for MVP)
+
+Gated by env-based admin token (`X-Admin-Token` header matches `ADMIN_API_TOKEN` env var). Returns 401 if missing or mismatched.
+
+**`POST /admin/users/:userId/ultra`** body `{ expiresAt: ISO-string }`
+
+Grants Ultra. Sets `is_ultra=true, ultra_expires_at=...`. Idempotent: re-granting extends/replaces the expiry.
+
+**`DELETE /admin/users/:userId/ultra`**
+
+Revokes Ultra. Sets `is_ultra=false, ultra_expires_at=NULL`.
+
+These let QA flip users without a billing platform. The real billing-webhook endpoint (Phase 2E.4) will call the same service methods internally.
+
+### User-facing entitlement check
+
+**`GET /users/me/ultra`**
+
+```json
+{ "isUltra": true, "expiresAt": "2026-06-12T00:00:00Z" }
+```
+
+Cached `ultra:{userId}` 60s. Invalidated on grant/revoke. Frontend uses this for the profile-screen Ultra badge / "subscribe" CTA.
+
+## Migration `0007_<name>.sql`
+
+```sql
+-- Idempotent ADD COLUMN
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "is_ultra" boolean NOT NULL DEFAULT false;
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "ultra_expires_at" timestamp;
+
+-- Defensive CHECK: can't have an expiry without being Ultra
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_ultra_expiry_chk') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_ultra_expiry_chk"
+      CHECK ("ultra_expires_at" IS NULL OR "is_ultra" = true);
+  END IF;
+END $$;
+
+-- Index for the future daily-cleanup query (Phase 2E.4): WHERE is_ultra = true AND ultra_expires_at < now()
+CREATE INDEX IF NOT EXISTS "user_ultra_expiry_idx" ON "user" ("ultra_expires_at") WHERE "is_ultra" = true;
+```
+
+Mirror DDL in `packages/db/src/test-client.ts`.
+
+## Shared schemas (`packages/shared/src/ultra.ts`)
+
+```typescript
+export const UltraStatusSchema = z.object({
+  isUltra: z.boolean(),
+  expiresAt: z.string().datetime().nullable(),
+});
+
+export const GrantUltraBodySchema = z.object({
+  expiresAt: z.string().datetime(),
+});
+```
+
+Extend `LivesResponseSchema` to add `unlimited: z.boolean()`.
+Extend `RankingEntrySchema` to add `isUltra: z.boolean()`.
+
+## Env
+
+`packages/env/src/server.ts` adds:
+- `ADMIN_API_TOKEN: z.string().min(16).optional()` — when present, admin endpoints are enabled. When absent (e.g. prod with no admin tooling yet), the routes return 503 to avoid an accidental open backdoor.
+
+## Testing strategy
+
+### Unit (Vitest)
+
+- `ultra.service.test.ts` — `isUltra` returns true for non-expired Ultra, false for expired-but-flagged, false for never-Ultra, false for null user; grant/revoke delegate to repo.
+- `lives.service.test.ts` — extend: Ultra user receives `{ lives: MAX, unlimited: true, resetsAt: null }`.
+- `reviews.service.test.ts` — extend: Ultra user gets `tryDecrement` success path even on wrong answer (no decrement actually happens but service treats result as ok).
+- `ranking.service.test.ts` — extend: assert `isUltra` on each entry reflects the seeded value.
+
+### Integration (PGlite)
+
+- `ultra.repository.integration.test.ts` — grant sets columns, revoke clears, get returns expected shape.
+- `lives.repository.integration.test.ts` — extend: Ultra user `tryDecrement` returns ok without UPDATE actually decrementing `lives` column.
+- `ranking.repository.integration.test.ts` — extend: ranking includes Ultra flag.
+- `user CHECK constraint`: setting `ultra_expires_at` without `is_ultra=true` throws.
+
+## Acceptance criteria
+
+- Migration `0007` applies cleanly + `verify:migration` passes
+- `is_ultra` + `ultra_expires_at` columns on user with CHECK constraint
+- `UltraService.isUltra(userId)` ships, tested with expiry edge cases
+- `LivesService.getLives` returns `unlimited: true` for Ultra
+- `LivesRepository.tryDecrement` no-ops for Ultra users (no actual decrement)
+- Ranking response includes `isUltra` per entry
+- Admin grant/revoke endpoints work when `ADMIN_API_TOKEN` is set; return 503 when not
+- `GET /users/me/ultra` returns current entitlement
+- All existing tests + new tests pass
+- Worker boots clean
+
+## Deferred (followed up in subsequent phases)
+
+- **Streak shield (§5.3)** → Phase 2E.2: monthly refill, auto-use logic.
+- **Simulado semanal (§5.2)** → Phase 2E.3: question-selection variant, simulado table, performance comparison.
+- **Real billing webhooks (Google Play RTDN, App Store SS Notifications V2)** → Phase 2E.4: depends on Apple/Google credentials.
+- **Ultra-badge UI in profile screen** → frontend rebuild owns.
+- **Plan tier variants (annual, family)** → out of scope, requires `subscription` table.
+- **Receipt re-verification cron** → 2E.4.
+
+---
+
+*End of spec.*

--- a/packages/db/src/migrations/0007_open_valeria_richards.sql
+++ b/packages/db/src/migrations/0007_open_valeria_richards.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "is_ultra" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "ultra_expires_at" timestamp;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_ultra_expiry_chk') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_ultra_expiry_chk"
+      CHECK ("ultra_expires_at" IS NULL OR "is_ultra" = true);
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "user_ultra_expiry_idx" ON "user" ("ultra_expires_at") WHERE "is_ultra" = true;

--- a/packages/db/src/migrations/meta/0007_snapshot.json
+++ b/packages/db/src/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1419 @@
+{
+  "id": "a160ebfe-fc30-4a12-8e91-1bb147d9178d",
+  "prevId": "9083516d-d449-452b-9ac6-c515e8466f22",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives": {
+          "name": "lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lives_last_regen_at": {
+          "name": "lives_last_regen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "selected_exam": {
+          "name": "selected_exam",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulties": {
+          "name": "difficulties",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "daily_study_time_minutes": {
+          "name": "daily_study_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ultra": {
+          "name": "is_ultra",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ultra_expires_at": {
+          "name": "ultra_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)"
+        },
+        "notification_hour": {
+          "name": "notification_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 19
+        },
+        "streak_reminders_enabled": {
+          "name": "streak_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "achievement_notifications_enabled": {
+          "name": "achievement_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_session": {
+      "name": "daily_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_correct": {
+          "name": "questions_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastery_snapshot": {
+          "name": "mastery_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_session_user_created_idx": {
+          "name": "daily_session_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_session_user_id_user_id_fk": {
+          "name": "daily_session_user_id_user_id_fk",
+          "tableFrom": "daily_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "friendship_requester_idx": {
+          "name": "friendship_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendship_recipient_idx": {
+          "name": "friendship_recipient_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendship_requester_id_user_id_fk": {
+          "name": "friendship_requester_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_recipient_id_user_id_fk": {
+          "name": "friendship_recipient_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subject_name_unique": {
+          "name": "subject_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "subject_slug_unique": {
+          "name": "subject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopic": {
+      "name": "subtopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtopic_topic_order_idx": {
+          "name": "subtopic_topic_order_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopic_topic_id_topic_id_fk": {
+          "name": "subtopic_topic_id_topic_id_fk",
+          "tableFrom": "subtopic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtopic_topic_slug_uniq": {
+          "name": "subtopic_topic_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topic_subject_order_idx": {
+          "name": "topic_subject_order_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_subject_id_subject_id_fk": {
+          "name": "topic_subject_id_subject_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_subject_slug_uniq": {
+          "name": "topic_subject_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_option_index": {
+          "name": "correct_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_calculation": {
+          "name": "requires_calculation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtopic_id": {
+          "name": "subtopic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_subject_difficulty_idx": {
+          "name": "question_subject_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_subtopic_difficulty_idx": {
+          "name": "question_subtopic_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_subject_id_subject_id_fk": {
+          "name": "question_subject_id_subject_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_subtopic_id_subtopic_id_fk": {
+          "name": "question_subtopic_id_subtopic_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subtopic",
+          "columnsFrom": [
+            "subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_log": {
+      "name": "review_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "easiness_factor": {
+          "name": "easiness_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_log_user_next_review_idx": {
+          "name": "review_log_user_next_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_log_user_question_idx": {
+          "name": "review_log_user_question_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_log_user_id_user_id_fk": {
+          "name": "review_log_user_id_user_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_log_question_id_question_id_fk": {
+          "name": "review_log_question_id_question_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_token": {
+      "name": "push_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_token_user_idx": {
+          "name": "push_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_token_user_id_user_id_fk": {
+          "name": "push_token_user_id_user_id_fk",
+          "tableFrom": "push_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_token_token_unique": {
+          "name": "push_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_acceptance": {
+      "name": "invitation_acceptance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_acceptance_inviter_idx": {
+          "name": "invitation_acceptance_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_acceptance_inviter_id_user_id_fk": {
+          "name": "invitation_acceptance_inviter_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_acceptance_invitee_id_user_id_fk": {
+          "name": "invitation_acceptance_invitee_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invitee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_acceptance_invitee_id_unique": {
+          "name": "invitation_acceptance_invitee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1778540820492,
       "tag": "0006_special_tusk",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1778545868777,
+      "tag": "0007_open_valeria_richards",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -21,6 +21,8 @@ export const user = pgTable("user", {
     .default(sql`'{}'::text[]`),
   dailyStudyTimeMinutes: integer("daily_study_time_minutes"),
   onboardingCompleted: boolean("onboarding_completed").notNull().default(false),
+  isUltra: boolean("is_ultra").notNull().default(false),
+  ultraExpiresAt: timestamp("ultra_expires_at"),
   username: text("username"),
   inviteCode: text("invite_code")
     .notNull()

--- a/packages/db/src/test-client.ts
+++ b/packages/db/src/test-client.ts
@@ -28,9 +28,14 @@ export async function createTestDb() {
       notification_hour INTEGER NOT NULL DEFAULT 19,
       streak_reminders_enabled BOOLEAN NOT NULL DEFAULT TRUE,
       achievement_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+      is_ultra BOOLEAN NOT NULL DEFAULT false,
+      ultra_expires_at TIMESTAMP,
+      CONSTRAINT user_ultra_expiry_chk CHECK (ultra_expires_at IS NULL OR is_ultra = true),
       created_at TIMESTAMP NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMP NOT NULL DEFAULT NOW()
     );
+
+    CREATE INDEX IF NOT EXISTS "user_ultra_expiry_idx" ON "user" (ultra_expires_at) WHERE is_ultra = true;
 
     CREATE TABLE IF NOT EXISTS "session" (
       id TEXT PRIMARY KEY,

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -19,6 +19,7 @@ export const env = createEnv({
     APPLE_CLIENT_SECRET: z.string().optional(),
     APPLE_BUNDLE_ID: z.string().optional(),
     EXPO_ACCESS_TOKEN: z.string().optional(),
+    ADMIN_API_TOKEN: z.string().min(16).optional(),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,3 +14,4 @@ export * from "./topics";
 export * from "./notifications";
 export * from "./social";
 export * from "./weekly";
+export * from "./ultra";

--- a/packages/shared/src/lives.ts
+++ b/packages/shared/src/lives.ts
@@ -8,6 +8,7 @@ export const LivesResponseSchema = z.object({
   lives: z.number().int().min(0).max(MAX_LIVES),
   maxLives: z.literal(MAX_LIVES),
   resetsAt: z.coerce.date().nullable(),
+  unlimited: z.boolean(),
 });
 
 export type LivesResponse = z.infer<typeof LivesResponseSchema>;

--- a/packages/shared/src/social.ts
+++ b/packages/shared/src/social.ts
@@ -42,6 +42,7 @@ export const RankingEntrySchema = z.object({
   name: z.string(),
   username: z.string().nullable(),
   image: z.string().nullable(),
+  isUltra: z.boolean(),
   weeklyXp: z.number().int().nonnegative(),
   rank: z.number().int().positive(),
   isMe: z.boolean(),

--- a/packages/shared/src/ultra.test.ts
+++ b/packages/shared/src/ultra.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { UltraStatusSchema, GrantUltraBodySchema } from "./ultra";
+
+describe("UltraStatusSchema", () => {
+  it("accepts isUltra=true with ISO expiry", () => {
+    expect(UltraStatusSchema.safeParse({ isUltra: true, expiresAt: "2026-06-12T00:00:00.000Z" }).success).toBe(true);
+  });
+  it("accepts isUltra=false with null expiry", () => {
+    expect(UltraStatusSchema.safeParse({ isUltra: false, expiresAt: null }).success).toBe(true);
+  });
+  it("rejects non-ISO expiry", () => {
+    expect(UltraStatusSchema.safeParse({ isUltra: true, expiresAt: "tomorrow" }).success).toBe(false);
+  });
+});
+
+describe("GrantUltraBodySchema", () => {
+  it("requires expiresAt", () => {
+    expect(GrantUltraBodySchema.safeParse({}).success).toBe(false);
+  });
+  it("accepts ISO datetime", () => {
+    expect(GrantUltraBodySchema.safeParse({ expiresAt: "2026-06-12T00:00:00.000Z" }).success).toBe(true);
+  });
+});

--- a/packages/shared/src/ultra.ts
+++ b/packages/shared/src/ultra.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const UltraStatusSchema = z.object({
+  isUltra: z.boolean(),
+  expiresAt: z.string().datetime().nullable(),
+});
+export type UltraStatus = z.infer<typeof UltraStatusSchema>;
+
+export const GrantUltraBodySchema = z.object({
+  expiresAt: z.string().datetime(),
+});
+export type GrantUltraBody = z.infer<typeof GrantUltraBodySchema>;


### PR DESCRIPTION
## Summary
First slice of Phase 2E (Ultra / monetization). Ships the server-side entitlement scaffolding for "is this user Ultra?": the schema, the entitlement service, the unlimited-lives perk, and the `isUltra` flag on ranking entries.

**Deferred to subsequent phases:**
- 2E.2 — Streak shield (monthly refill cron, auto-use on streak break)
- 2E.3 — Simulado semanal (new question-selection variant, simulado table, performance comparison)
- 2E.4 — Google Play RTDN + App Store Server Notifications V2 webhooks (depends on Apple Developer credentials)

## Data model — migration `0007_open_valeria_richards.sql`
- `user.is_ultra boolean NOT NULL DEFAULT false`
- `user.ultra_expires_at timestamp`
- CHECK constraint `user_ultra_expiry_chk`: \`ultra_expires_at IS NULL OR is_ultra = true\` (defense-in-depth — can't have an expiry without being Ultra)
- Partial index `user_ultra_expiry_idx ON (ultra_expires_at) WHERE is_ultra = true` (for the future 2E.4 daily cleanup query)

All idempotent (DO-block guards on the CHECK; `IF NOT EXISTS` on column/index DDL). PGlite mirror in `test-client.ts` matches.

## API surface
- `GET /users/me/ultra` → `{ isUltra, expiresAt }` — user-authenticated. Cache-friendly.
- `POST /admin/users/:userId/ultra` body `{ expiresAt }` — token-gated via `X-Admin-Token` header.
- `DELETE /admin/users/:userId/ultra` — token-gated, returns 204.

Admin endpoints return **503 when `ADMIN_API_TOKEN` env is undefined** (no accidental open backdoor) and **401 when set but the header is wrong/missing**. The real billing-webhook endpoints (2E.4) will call the same service methods internally.

## Hot-path integration
**Lives bypass for Ultra:**
- `LivesRepository.getUserLives` now SELECTs `is_ultra` + `ultra_expires_at` alongside lives in one statement — no extra round-trip.
- `materializeRegen` short-circuits for active Ultra users, returning `{ lives: 5, lastRegenAt: null, isUltra: true }` without UPDATE.
- `tryDecrement` pre-checks Ultra status; if Ultra-active, returns `{ ok: true, livesAfter: MAX_LIVES, lastRegenAt: null, isUltra: true }` without touching the DB. The existing race-free atomic `UPDATE … WHERE lives > 0 RETURNING` is preserved unchanged for non-Ultra users.
- `LivesService.getLives` response now includes `unlimited: boolean` — frontend renders ∞ when true.

**Ranking `isUltra` flag:**
- `RankingEntry.isUltra` reflects the column-as-is (no expiry check). The 60s ranking cache + future daily cleanup keep it fresh. Frontend uses this to render the Ultra badge per row.

## Entitlement semantics
`UltraService.isUltra(userId)` is defensive: even if `is_ultra=true` lingers after expiry, reads treat the user as non-Ultra. This decouples correctness from the daily cleanup job (which lands in 2E.4).

```typescript
async isUltra(userId): Promise<boolean> {
  const row = await this.repo.get(userId);
  if (!row?.isUltra) return false;
  if (row.ultraExpiresAt && row.ultraExpiresAt < new Date()) return false;
  return true;
}
```

## Per-task review discipline
Every task ran implementer + Opus reviewer (no haiku, per saved feedback memory). Notable findings:
- **Task 3:** Opus flagged 5 real issues — critically, a double-wrapped response envelope on `POST /admin/...` and a CHECK-constraint integration test that was silently a no-op due to passing a raw string to Drizzle's `db.execute()`. Fixed in commit `4d89b01`.
- **Task 4:** Opus flagged a test-hygiene gap — stale `materializeRegen` mocks in `reviews.service.test.ts` missing the new `isUltra` field. Fixed in commit `48ff3c1`.

## Test plan
- [x] 171 unit tests pass (includes new ultra.service + lives unlimited cases + ranking isUltra cases)
- [x] 88 integration tests pass (includes ultra.repository CHECK + grant idempotency + lives Ultra bypass + ranking mixed-Ultra)
- [x] `pnpm verify:migration` clean
- [x] `pnpm --filter server check-types` clean for production code
- [x] CORS `allowedHeaders` includes `X-Admin-Token` for future browser-based admin tooling

## Env
- `ADMIN_API_TOKEN: z.string().min(16).optional()` — admin endpoints enabled only when set.

## Spec & plan
- `docs/superpowers/specs/2026-05-12-phase-2e1-ultra-entitlement-design.md`
- `docs/superpowers/plans/2026-05-12-phase-2e1-ultra-entitlement.md`