### PR TITLE
feat: phase 2e.2 — streak shield (Ultra perk, single-grant, auto-protect)

### DIFF
--- a/apps/server/src/features/sessions/sessions.route.ts
+++ b/apps/server/src/features/sessions/sessions.route.ts
@@ -150,10 +150,13 @@ export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
       );
       const { session, transitions } = unwrapResult(result).data;
 
-      // Invalidate caches that depend on session completion
+      // Invalidate caches that depend on session completion.
+      // `shields:` is invalidated unconditionally: if the auto-use hook fires (fire-and-forget),
+      // the shield balance changed; if it doesn't fire, the del is a cheap no-op.
       await Promise.all([
         fastify.cache.del(`session-today:${request.userId}`),
         fastify.cache.del(`streaks:${request.userId}`),
+        fastify.cache.del(`shields:${request.userId}`),
       ]);
 
       // Enqueue next session pre-generation

--- a/apps/server/src/features/sessions/sessions.route.ts
+++ b/apps/server/src/features/sessions/sessions.route.ts
@@ -14,6 +14,8 @@ import { SweepRepository } from "../notifications/sweep.repository";
 import { Dispatcher } from "../notifications/dispatcher";
 import { StreaksRepository } from "../streaks/streaks.repository";
 import { StreaksService } from "../streaks/streaks.service";
+import { ShieldsRepository } from "../shields/shields.repository";
+import { ShieldsService } from "../shields/shields.service";
 import { db } from "@pruvi/db";
 import { successResponse, unwrapResult } from "../../types";
 
@@ -31,6 +33,8 @@ export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
   const sweepRepo = new SweepRepository(db);
   const streaksRepo = new StreaksRepository(db);
   const streaksService = new StreaksService(streaksRepo);
+  const shieldsRepo = new ShieldsRepository(db);
+  const shieldsService = new ShieldsService(shieldsRepo);
   const dispatcher = fastify.queues.notificationsSend
     ? new Dispatcher({
         tokensService,
@@ -45,6 +49,8 @@ export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
     topicsService,
     streaksService,
     dispatcher,
+    shieldsService,
+    fastify.log,
   );
   // POST /sessions/start
   fastify.post(

--- a/apps/server/src/features/sessions/sessions.service.test.ts
+++ b/apps/server/src/features/sessions/sessions.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ok } from "neverthrow";
+import { todayInBrt } from "@pruvi/shared";
 import { SessionsService } from "./sessions.service";
 import { ValidationError, NotFoundError } from "../../utils/errors";
 
@@ -286,5 +287,151 @@ describe("SessionsService.completeSession returns mastery transitions", () => {
     const result = await service.completeSession("u1", 9, 0, 0);
     const { transitions } = result._unsafeUnwrap();
     expect(transitions).toEqual([]);
+  });
+});
+
+describe("SessionsService.completeSession shield auto-use hook", () => {
+  const now = new Date();
+  const todayStr = todayInBrt(now);
+  const yesterdayStr = todayInBrt(new Date(now.getTime() - 86_400_000));
+  const twoDaysAgoStr = todayInBrt(new Date(now.getTime() - 2 * 86_400_000));
+  const threeDaysAgoStr = todayInBrt(new Date(now.getTime() - 3 * 86_400_000));
+
+  function makeSessionRepo(userId = "u1") {
+    return {
+      findSessionById: vi.fn().mockResolvedValue({ id: 1, userId, status: "active" }),
+      completeSession: vi.fn().mockResolvedValue({ id: 1, status: "completed" }),
+      readMasterySnapshot: vi.fn().mockResolvedValue(null),
+    } as any;
+  }
+
+  function makeTopicsService() {
+    return {
+      computeTransitions: vi.fn().mockReturnValue([]),
+      getCurrentMasteryAndNames: vi.fn().mockResolvedValue({ currentMap: new Map(), namesMap: new Map() }),
+      snapshotMastery: vi.fn(),
+    } as any;
+  }
+
+  it("calls tryUseShield with yesterday's BRT date when prev-completed is 2 days ago", async () => {
+    const tryUseShield = vi.fn().mockResolvedValue({ used: true, balanceAfter: 0 });
+    const shieldsService = { tryUseShield } as any;
+    const streaksService = {
+      getStreaks: vi.fn().mockResolvedValue(ok({ currentStreak: 1, longestStreak: 1, totalSessions: 1 })),
+      getRecentCompletedDates: vi.fn().mockResolvedValue([todayStr, twoDaysAgoStr]),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      streaksService,
+      null,
+      shieldsService,
+    );
+
+    const result = await service.completeSession("u1", 1, 5, 4);
+    expect(result.isOk()).toBe(true);
+
+    // Flush microtasks so fire-and-forget resolves
+    await new Promise((r) => setImmediate(r));
+
+    expect(tryUseShield).toHaveBeenCalledWith("u1", yesterdayStr);
+  });
+
+  it("does NOT call tryUseShield when gap is 1 day", async () => {
+    const tryUseShield = vi.fn().mockResolvedValue({ used: false, balanceAfter: null });
+    const shieldsService = { tryUseShield } as any;
+    const streaksService = {
+      getStreaks: vi.fn().mockResolvedValue(ok({ currentStreak: 2, longestStreak: 2, totalSessions: 2 })),
+      getRecentCompletedDates: vi.fn().mockResolvedValue([todayStr, yesterdayStr]),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      streaksService,
+      null,
+      shieldsService,
+    );
+
+    await service.completeSession("u1", 1, 5, 4);
+    await new Promise((r) => setImmediate(r));
+
+    expect(tryUseShield).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call tryUseShield when gap is 3+ days", async () => {
+    const tryUseShield = vi.fn().mockResolvedValue({ used: false, balanceAfter: null });
+    const shieldsService = { tryUseShield } as any;
+    const streaksService = {
+      getStreaks: vi.fn().mockResolvedValue(ok({ currentStreak: 1, longestStreak: 1, totalSessions: 1 })),
+      getRecentCompletedDates: vi.fn().mockResolvedValue([todayStr, threeDaysAgoStr]),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      streaksService,
+      null,
+      shieldsService,
+    );
+
+    await service.completeSession("u1", 1, 5, 4);
+    await new Promise((r) => setImmediate(r));
+
+    expect(tryUseShield).not.toHaveBeenCalled();
+  });
+
+  it("does NOT throw when shieldsService is not injected", async () => {
+    const streaksService = {
+      getStreaks: vi.fn().mockResolvedValue(ok({ currentStreak: 1, longestStreak: 1, totalSessions: 1 })),
+      getRecentCompletedDates: vi.fn().mockResolvedValue([todayStr, twoDaysAgoStr]),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      streaksService,
+      null,
+      // no shieldsService
+    );
+
+    const result = await service.completeSession("u1", 1, 5, 4);
+    await new Promise((r) => setImmediate(r));
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("fire-and-forget: completeSession returns ok even when tryUseShield rejects", async () => {
+    const tryUseShield = vi.fn().mockRejectedValue(new Error("shield DB error"));
+    const shieldsService = { tryUseShield } as any;
+    const streaksService = {
+      getStreaks: vi.fn().mockResolvedValue(ok({ currentStreak: 1, longestStreak: 1, totalSessions: 1 })),
+      getRecentCompletedDates: vi.fn().mockResolvedValue([todayStr, twoDaysAgoStr]),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      streaksService,
+      null,
+      shieldsService,
+    );
+
+    const result = await service.completeSession("u1", 1, 5, 4);
+    expect(result.isOk()).toBe(true);
+
+    // Flush microtasks — tryUseShield rejects but is swallowed by the .catch
+    await new Promise((r) => setImmediate(r));
+
+    // completeSession already returned ok before shield hook ran
+    expect(result._unsafeUnwrap()).toEqual(
+      expect.objectContaining({ session: expect.objectContaining({ status: "completed" }) }),
+    );
   });
 });

--- a/apps/server/src/features/sessions/sessions.service.ts
+++ b/apps/server/src/features/sessions/sessions.service.ts
@@ -170,16 +170,16 @@ export class SessionsService {
               const kind = `${r.value.currentStreak}-day-streak` as "7-day-streak" | "30-day-streak";
               this.dispatcher!
                 .sendAchievementNotification(userId, kind)
-                .catch((e) => console.error("streak achievement push failed", e));
+                .catch((e) => this.logger?.error?.({ err: e, userId, kind }, "streak achievement push failed"));
             }
           })
-          .catch((e) => console.error("streak read failed in achievement hook", e));
+          .catch((e) => this.logger?.error?.({ err: e, userId }, "streak read failed in achievement hook"));
       }
       for (const t of transitions) {
         if (t.to === "quase_mestre") {
           this.dispatcher
             .sendAchievementNotification(userId, "quase-mestre", { subtopicName: t.name })
-            .catch((e) => console.error("mastery achievement push failed", e));
+            .catch((e) => this.logger?.error?.({ err: e, userId, subtopicName: t.name }, "mastery achievement push failed"));
         }
       }
     }

--- a/apps/server/src/features/sessions/sessions.service.ts
+++ b/apps/server/src/features/sessions/sessions.service.ts
@@ -1,4 +1,6 @@
 import { err, ok, type Result } from "neverthrow";
+import type { FastifyBaseLogger } from "fastify";
+import { todayInBrt } from "@pruvi/shared";
 import type { AppError } from "../../utils/errors";
 import { NotFoundError, ValidationError } from "../../utils/errors";
 import type { SessionsRepository } from "./sessions.repository";
@@ -6,6 +8,7 @@ import type { QuestionsService } from "../questions/questions.service";
 import type { TopicsService } from "../topics/topics.service";
 import type { Dispatcher } from "../notifications/dispatcher";
 import type { StreaksService } from "../streaks/streaks.service";
+import type { ShieldsService } from "../shields/shields.service";
 
 type SessionRow = NonNullable<Awaited<ReturnType<SessionsRepository["findTodaySession"]>>>;
 type QuestionItem = { id: number; subtopicId: number; [key: string]: unknown };
@@ -17,6 +20,8 @@ export class SessionsService {
     private topicsService: TopicsService,
     private streaksService: StreaksService | null = null,
     private dispatcher: Dispatcher | null = null,
+    private shieldsService?: ShieldsService,
+    private logger?: FastifyBaseLogger,
   ) {}
 
   /** Start or resume today's session */
@@ -179,6 +184,28 @@ export class SessionsService {
       }
     }
 
+    // Fire-and-forget shield auto-use hook
+    if (this.shieldsService && this.streaksService) {
+      void this.maybeProtectMissedDay(userId).catch((e) => {
+        this.logger?.error?.({ err: e, userId }, "shield auto-use failed");
+      });
+    }
+
     return ok({ session: completed, transitions });
+  }
+
+  private async maybeProtectMissedDay(userId: string): Promise<void> {
+    const now = new Date();
+    const todayStr = todayInBrt(now);
+    const yesterdayStr = todayInBrt(new Date(now.getTime() - 86_400_000));
+    const dates = await this.streaksService!.getRecentCompletedDates(userId, 2);
+    if (dates.length < 2) return;
+    if (dates[0] !== todayStr) return;
+    // Both dates are YYYY-MM-DD BRT strings — convert to date-aware Date at midnight BRT (UTC 03:00).
+    const todayDate = new Date(todayStr + "T03:00:00Z");
+    const prevDate = new Date(dates[1] + "T03:00:00Z");
+    const diffDays = Math.round((todayDate.getTime() - prevDate.getTime()) / 86_400_000);
+    if (diffDays !== 2) return;
+    await this.shieldsService!.tryUseShield(userId, yesterdayStr);
   }
 }

--- a/apps/server/src/features/shields/shields.repository.integration.test.ts
+++ b/apps/server/src/features/shields/shields.repository.integration.test.ts
@@ -231,24 +231,21 @@ describe("ShieldsRepository (integration)", () => {
   });
 
   describe("listProtectedDates", () => {
-    it("returns ISO date strings for the user's protected dates", async () => {
+    it("returns ISO date strings for the user's protected dates, ascending", async () => {
       await insertUser("u-list-1", { streakShieldsAvailable: 1 });
 
-      // Insert a protection row directly
-      await db.insert(streakShieldUsage).values({
-        userId: "u-list-1",
-        protectedDate: "2026-05-09",
-      });
+      // Insert out-of-order to verify the ORDER BY in the query
       await db.insert(streakShieldUsage).values({
         userId: "u-list-1",
         protectedDate: "2026-05-10",
       });
+      await db.insert(streakShieldUsage).values({
+        userId: "u-list-1",
+        protectedDate: "2026-05-09",
+      });
 
       const dates = await repo.listProtectedDates("u-list-1");
-      expect(dates).toHaveLength(2);
-      // Should be ISO YYYY-MM-DD strings
-      expect(dates).toContain("2026-05-09");
-      expect(dates).toContain("2026-05-10");
+      expect(dates).toEqual(["2026-05-09", "2026-05-10"]);
     });
 
     it("returns empty array when no protected dates", async () => {

--- a/apps/server/src/features/shields/shields.repository.integration.test.ts
+++ b/apps/server/src/features/shields/shields.repository.integration.test.ts
@@ -113,11 +113,11 @@ describe("ShieldsRepository (integration)", () => {
       ).rejects.toThrow();
     });
 
-    it("rejects direct UPDATE attempting streak_shields_available above max (e.g. 10)", async () => {
+    it("rejects direct UPDATE attempting streak_shields_available = 2 (one above MAX = 1)", async () => {
       await insertUser("u-chk-2", { streakShieldsAvailable: 0 });
       await expect(
         db.execute(
-          sql`UPDATE "user" SET streak_shields_available = 10 WHERE id = 'u-chk-2'`,
+          sql`UPDATE "user" SET streak_shields_available = 2 WHERE id = 'u-chk-2'`,
         ),
       ).rejects.toThrow();
     });

--- a/apps/server/src/features/shields/shields.repository.integration.test.ts
+++ b/apps/server/src/features/shields/shields.repository.integration.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import {
+  setupTestDb,
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { streakShieldUsage } from "@pruvi/db/schema/streak-shield-usage";
+import { ShieldsRepository } from "./shields.repository";
+
+describe("ShieldsRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new ShieldsRepository(db);
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  async function insertUser(
+    id: string,
+    overrides: {
+      isUltra?: boolean;
+      ultraExpiresAt?: Date | null;
+      streakShieldsAvailable?: number;
+      lastShieldGrantAt?: Date | null;
+    } = {},
+  ) {
+    await db.insert(user).values({
+      id,
+      name: `User ${id}`,
+      email: `${id}@example.com`,
+      emailVerified: false,
+      inviteCode: `code${id.replace(/-/g, "").slice(0, 8)}`,
+      username: null,
+      updatedAt: new Date(),
+      isUltra: overrides.isUltra ?? false,
+      ultraExpiresAt: overrides.ultraExpiresAt ?? null,
+      streakShieldsAvailable: overrides.streakShieldsAvailable ?? 0,
+      lastShieldGrantAt: overrides.lastShieldGrantAt ?? null,
+    });
+  }
+
+  describe("tryUseShield", () => {
+    it("with shields=1: decrement to 0, insert usage row, return { used: true, balanceAfter: 0 }", async () => {
+      await insertUser("u-try-1", { streakShieldsAvailable: 1 });
+      const result = await repo.tryUseShield("u-try-1", "2026-05-10");
+      expect(result).toEqual({ used: true, balanceAfter: 0 });
+
+      // Verify usage row inserted
+      const rows = await db
+        .select()
+        .from(streakShieldUsage)
+        .where(eq(streakShieldUsage.userId, "u-try-1"));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.protectedDate).toBe("2026-05-10");
+
+      // Verify shield balance decremented
+      const userRow = await repo.getUserShieldState("u-try-1");
+      expect(userRow?.streakShieldsAvailable).toBe(0);
+    });
+
+    it("with shields=0: returns { used: false, balanceAfter: null }. No usage row inserted", async () => {
+      await insertUser("u-try-2", { streakShieldsAvailable: 0 });
+      const result = await repo.tryUseShield("u-try-2", "2026-05-10");
+      expect(result).toEqual({ used: false, balanceAfter: null });
+
+      const rows = await db
+        .select()
+        .from(streakShieldUsage)
+        .where(eq(streakShieldUsage.userId, "u-try-2"));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("for already-protected date: returns { used: false, balanceAfter: null }. Shields count NOT decremented (transaction rolled back)", async () => {
+      await insertUser("u-try-3", { streakShieldsAvailable: 1 });
+      // First use: succeed
+      await repo.tryUseShield("u-try-3", "2026-05-10");
+
+      // Second use on same date: should return used: false, roll back decrement
+      const result = await repo.tryUseShield("u-try-3", "2026-05-10");
+      expect(result).toEqual({ used: false, balanceAfter: null });
+
+      // Shield was rolled back — balance should still be 0 (not -1 or anything else)
+      const userRow = await repo.getUserShieldState("u-try-3");
+      expect(userRow?.streakShieldsAvailable).toBe(0);
+
+      // Only one usage row should exist
+      const rows = await db
+        .select()
+        .from(streakShieldUsage)
+        .where(eq(streakShieldUsage.userId, "u-try-3"));
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  describe("CHECK constraint", () => {
+    it("rejects direct UPDATE attempting streak_shields_available = -1", async () => {
+      await insertUser("u-chk-1", { streakShieldsAvailable: 0 });
+      await expect(
+        db.execute(
+          sql`UPDATE "user" SET streak_shields_available = -1 WHERE id = 'u-chk-1'`,
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("rejects direct UPDATE attempting streak_shields_available above max (e.g. 10)", async () => {
+      await insertUser("u-chk-2", { streakShieldsAvailable: 0 });
+      await expect(
+        db.execute(
+          sql`UPDATE "user" SET streak_shields_available = 10 WHERE id = 'u-chk-2'`,
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("materializeRefill", () => {
+    it("for Ultra user with NULL last_grant: grants 1 shield, sets last_grant_at = now", async () => {
+      await insertUser("u-refill-1", {
+        isUltra: true,
+        ultraExpiresAt: null,
+        streakShieldsAvailable: 0,
+        lastShieldGrantAt: null,
+      });
+      const now = new Date();
+      const result = await repo.materializeRefill("u-refill-1", now);
+      expect(result.available).toBe(1);
+      expect(result.isUltraActive).toBe(true);
+      expect(result.lastGrantAt).toBeInstanceOf(Date);
+
+      // Verify DB updated
+      const userRow = await repo.getUserShieldState("u-refill-1");
+      expect(userRow?.streakShieldsAvailable).toBe(1);
+      expect(userRow?.lastShieldGrantAt).toBeInstanceOf(Date);
+    });
+
+    it("for Ultra user with stale (40 days ago) last_grant and 0 shields: grants 1 shield, sets last_grant_at = now", async () => {
+      const staleGrant = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+      await insertUser("u-refill-2", {
+        isUltra: true,
+        ultraExpiresAt: null,
+        streakShieldsAvailable: 0,
+        lastShieldGrantAt: staleGrant,
+      });
+      const now = new Date();
+      const result = await repo.materializeRefill("u-refill-2", now);
+      expect(result.available).toBe(1);
+      expect(result.isUltraActive).toBe(true);
+
+      const userRow = await repo.getUserShieldState("u-refill-2");
+      expect(userRow?.streakShieldsAvailable).toBe(1);
+    });
+
+    it("for Ultra user with 1 shield already (regardless of stale grant): NO-op", async () => {
+      const staleGrant = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+      await insertUser("u-refill-3", {
+        isUltra: true,
+        ultraExpiresAt: null,
+        streakShieldsAvailable: 1,
+        lastShieldGrantAt: staleGrant,
+      });
+      const now = new Date();
+      const result = await repo.materializeRefill("u-refill-3", now);
+      expect(result.available).toBe(1);
+
+      // lastGrantAt should remain unchanged (staleGrant)
+      const userRow = await repo.getUserShieldState("u-refill-3");
+      expect(userRow?.streakShieldsAvailable).toBe(1);
+    });
+
+    it("for non-Ultra user: NO-op", async () => {
+      await insertUser("u-refill-4", {
+        isUltra: false,
+        streakShieldsAvailable: 0,
+        lastShieldGrantAt: null,
+      });
+      const now = new Date();
+      const result = await repo.materializeRefill("u-refill-4", now);
+      expect(result.available).toBe(0);
+      expect(result.isUltraActive).toBe(false);
+
+      const userRow = await repo.getUserShieldState("u-refill-4");
+      expect(userRow?.streakShieldsAvailable).toBe(0);
+    });
+
+    it("for Ultra user with 5d-old grant and 0 shields: NO-op (interval not elapsed)", async () => {
+      const recentGrant = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+      await insertUser("u-refill-5", {
+        isUltra: true,
+        ultraExpiresAt: null,
+        streakShieldsAvailable: 0,
+        lastShieldGrantAt: recentGrant,
+      });
+      const now = new Date();
+      const result = await repo.materializeRefill("u-refill-5", now);
+      expect(result.available).toBe(0);
+      expect(result.isUltraActive).toBe(true);
+
+      const userRow = await repo.getUserShieldState("u-refill-5");
+      expect(userRow?.streakShieldsAvailable).toBe(0);
+    });
+
+    it("race safety: two sequential calls — second observes freshly-granted state, no double-grant", async () => {
+      await insertUser("u-refill-race", {
+        isUltra: true,
+        ultraExpiresAt: null,
+        streakShieldsAvailable: 0,
+        lastShieldGrantAt: null,
+      });
+      const now = new Date();
+      // First call grants
+      const r1 = await repo.materializeRefill("u-refill-race", now);
+      expect(r1.available).toBe(1);
+
+      // Second call — now shields = 1, which is at MAX_STREAK_SHIELDS (1), so no second grant
+      const r2 = await repo.materializeRefill("u-refill-race", now);
+      expect(r2.available).toBe(1);
+
+      const userRow = await repo.getUserShieldState("u-refill-race");
+      expect(userRow?.streakShieldsAvailable).toBe(1);
+    });
+  });
+
+  describe("listProtectedDates", () => {
+    it("returns ISO date strings for the user's protected dates", async () => {
+      await insertUser("u-list-1", { streakShieldsAvailable: 1 });
+
+      // Insert a protection row directly
+      await db.insert(streakShieldUsage).values({
+        userId: "u-list-1",
+        protectedDate: "2026-05-09",
+      });
+      await db.insert(streakShieldUsage).values({
+        userId: "u-list-1",
+        protectedDate: "2026-05-10",
+      });
+
+      const dates = await repo.listProtectedDates("u-list-1");
+      expect(dates).toHaveLength(2);
+      // Should be ISO YYYY-MM-DD strings
+      expect(dates).toContain("2026-05-09");
+      expect(dates).toContain("2026-05-10");
+    });
+
+    it("returns empty array when no protected dates", async () => {
+      await insertUser("u-list-2");
+      const dates = await repo.listProtectedDates("u-list-2");
+      expect(dates).toEqual([]);
+    });
+  });
+});

--- a/apps/server/src/features/shields/shields.repository.ts
+++ b/apps/server/src/features/shields/shields.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, isNull, lt, sql } from "drizzle-orm";
+import { and, asc, eq, gt, isNull, lt, sql } from "drizzle-orm";
 import type { db as DbClient } from "@pruvi/db";
 import { user } from "@pruvi/db/schema/auth";
 import { streakShieldUsage } from "@pruvi/db/schema/streak-shield-usage";
@@ -105,7 +105,8 @@ export class ShieldsRepository {
     const rows = await this.db
       .select({ protectedDate: streakShieldUsage.protectedDate })
       .from(streakShieldUsage)
-      .where(eq(streakShieldUsage.userId, userId));
+      .where(eq(streakShieldUsage.userId, userId))
+      .orderBy(asc(streakShieldUsage.protectedDate));
     return rows.map((r) =>
       typeof r.protectedDate === "string" ? r.protectedDate : new Date(r.protectedDate).toISOString().slice(0, 10),
     );

--- a/apps/server/src/features/shields/shields.repository.ts
+++ b/apps/server/src/features/shields/shields.repository.ts
@@ -1,0 +1,113 @@
+import { and, eq, gt, isNull, lt, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { user } from "@pruvi/db/schema/auth";
+import { streakShieldUsage } from "@pruvi/db/schema/streak-shield-usage";
+import { MAX_STREAK_SHIELDS, SHIELD_REFILL_INTERVAL_MS, type ShieldUseResult } from "@pruvi/shared";
+
+type Db = typeof DbClient;
+
+export class ShieldsRepository {
+  constructor(private db: Db) {}
+
+  async getUserShieldState(userId: string) {
+    const rows = await this.db
+      .select({
+        streakShieldsAvailable: user.streakShieldsAvailable,
+        lastShieldGrantAt: user.lastShieldGrantAt,
+        isUltra: user.isUltra,
+        ultraExpiresAt: user.ultraExpiresAt,
+      })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Apply lazy refill if eligible. Single-grant model (MAX=1, per spec v2): an
+   * Ultra-active user with 0 shields and either a NULL anchor or anchor >= 30d
+   * old gets exactly 1 shield. Race-safe via conditional UPDATE.
+   */
+  async materializeRefill(
+    userId: string,
+    now: Date,
+  ): Promise<{ available: number; lastGrantAt: Date | null; isUltraActive: boolean }> {
+    const current = await this.getUserShieldState(userId);
+    if (!current) return { available: 0, lastGrantAt: null, isUltraActive: false };
+    const ultraActive = current.isUltra && (!current.ultraExpiresAt || current.ultraExpiresAt > now);
+    if (!ultraActive) {
+      return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: false };
+    }
+    if (current.streakShieldsAvailable >= MAX_STREAK_SHIELDS) {
+      return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: true };
+    }
+    const eligible =
+      current.lastShieldGrantAt === null ||
+      now.getTime() - current.lastShieldGrantAt.getTime() >= SHIELD_REFILL_INTERVAL_MS;
+    if (!eligible) {
+      return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: true };
+    }
+    // Race-safe conditional UPDATE: WHERE predicate re-evaluates inside row-level lock.
+    const whereConditions =
+      current.lastShieldGrantAt === null
+        ? and(eq(user.id, userId), eq(user.streakShieldsAvailable, 0), isNull(user.lastShieldGrantAt))
+        : and(
+            eq(user.id, userId),
+            eq(user.streakShieldsAvailable, 0),
+            lt(user.lastShieldGrantAt, new Date(now.getTime() - SHIELD_REFILL_INTERVAL_MS)),
+          );
+    const updated = await this.db
+      .update(user)
+      .set({ streakShieldsAvailable: 1, lastShieldGrantAt: now })
+      .where(whereConditions)
+      .returning({ available: user.streakShieldsAvailable, lastGrantAt: user.lastShieldGrantAt });
+    if (updated.length === 0) {
+      // Concurrent grant won. Re-read.
+      const fresh = await this.getUserShieldState(userId);
+      return { available: fresh?.streakShieldsAvailable ?? 0, lastGrantAt: fresh?.lastShieldGrantAt ?? null, isUltraActive: true };
+    }
+    return { available: updated[0]!.available, lastGrantAt: updated[0]!.lastGrantAt, isUltraActive: true };
+  }
+
+  /**
+   * Atomic decrement + protection insert. Returns `{ used: true }` only when
+   * both succeed; UNIQUE conflict on (user_id, protected_date) rolls back
+   * the decrement via thrown error.
+   */
+  async tryUseShield(userId: string, protectedDate: string): Promise<ShieldUseResult> {
+    try {
+      return await this.db.transaction(async (tx) => {
+        // 1. Conditional decrement — only succeeds when shields > 0 (predicate inside row lock).
+        const dec = await tx
+          .update(user)
+          .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} - 1` })
+          .where(and(eq(user.id, userId), gt(user.streakShieldsAvailable, 0)))
+          .returning({ available: user.streakShieldsAvailable });
+        if (dec.length === 0) return { used: false, balanceAfter: null };
+
+        // 2. Insert protection row. UNIQUE conflict → throw to roll back the decrement.
+        try {
+          await tx.insert(streakShieldUsage).values({ userId, protectedDate });
+        } catch (_e) {
+          throw new Error("ALREADY_PROTECTED");
+        }
+        return { used: true, balanceAfter: dec[0]!.available };
+      });
+    } catch (e) {
+      if (e instanceof Error && e.message === "ALREADY_PROTECTED") {
+        return { used: false, balanceAfter: null };
+      }
+      throw e;
+    }
+  }
+
+  async listProtectedDates(userId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ protectedDate: streakShieldUsage.protectedDate })
+      .from(streakShieldUsage)
+      .where(eq(streakShieldUsage.userId, userId));
+    return rows.map((r) =>
+      typeof r.protectedDate === "string" ? r.protectedDate : new Date(r.protectedDate).toISOString().slice(0, 10),
+    );
+  }
+}

--- a/apps/server/src/features/shields/shields.route.ts
+++ b/apps/server/src/features/shields/shields.route.ts
@@ -1,0 +1,21 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { ShieldBalanceResponseSchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { unwrapResult } from "../../types";
+import { ShieldsRepository } from "./shields.repository";
+import { ShieldsService } from "./shields.service";
+
+export const shieldsRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const repo = new ShieldsRepository(db);
+  const service = new ShieldsService(repo);
+
+  fastify.get(
+    "/users/me/shields",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: ShieldBalanceResponseSchema }) } },
+    },
+    async (request) => unwrapResult(await service.getBalance(request.userId)),
+  );
+};

--- a/apps/server/src/features/shields/shields.route.ts
+++ b/apps/server/src/features/shields/shields.route.ts
@@ -1,10 +1,12 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
-import { ShieldBalanceResponseSchema } from "@pruvi/shared";
+import { ShieldBalanceResponseSchema, type ShieldBalanceResponse } from "@pruvi/shared";
 import { db } from "@pruvi/db";
-import { unwrapResult } from "../../types";
+import { successResponse, unwrapResult } from "../../types";
 import { ShieldsRepository } from "./shields.repository";
 import { ShieldsService } from "./shields.service";
+
+const SHIELDS_CACHE_TTL = 60;
 
 export const shieldsRoutes: FastifyPluginAsyncZod = async (fastify) => {
   const repo = new ShieldsRepository(db);
@@ -16,6 +18,15 @@ export const shieldsRoutes: FastifyPluginAsyncZod = async (fastify) => {
       preHandler: [fastify.authenticate],
       schema: { response: { 200: z.object({ success: z.literal(true), data: ShieldBalanceResponseSchema }) } },
     },
-    async (request) => unwrapResult(await service.getBalance(request.userId)),
+    async (request) => {
+      const cacheKey = `shields:${request.userId}`;
+      const cached = await fastify.cache.get<ShieldBalanceResponse>(cacheKey);
+      if (cached) {
+        return successResponse(cached);
+      }
+      const response = unwrapResult(await service.getBalance(request.userId));
+      await fastify.cache.set(cacheKey, response.data, SHIELDS_CACHE_TTL);
+      return response;
+    },
   );
 };

--- a/apps/server/src/features/shields/shields.service.test.ts
+++ b/apps/server/src/features/shields/shields.service.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ShieldsService } from "./shields.service";
+import { SHIELD_REFILL_INTERVAL_MS } from "@pruvi/shared";
+
+const NOW = new Date("2026-05-11T12:00:00.000Z");
+
+describe("ShieldsService", () => {
+  let repo: {
+    materializeRefill: ReturnType<typeof vi.fn>;
+    tryUseShield: ReturnType<typeof vi.fn>;
+  };
+  let service: ShieldsService;
+
+  beforeEach(() => {
+    repo = {
+      materializeRefill: vi.fn(),
+      tryUseShield: vi.fn(),
+    };
+    service = new ShieldsService(repo as any);
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("getBalance", () => {
+    it("non-Ultra user: available=0, nextRefillAt=null", async () => {
+      repo.materializeRefill.mockResolvedValue({
+        available: 0,
+        lastGrantAt: null,
+        isUltraActive: false,
+      });
+      const result = await service.getBalance("user-1");
+      const data = result._unsafeUnwrap();
+      expect(data.available).toBe(0);
+      expect(data.maxAvailable).toBe(1);
+      expect(data.nextRefillAt).toBeNull();
+    });
+
+    it("Ultra user, NULL lastShieldGrantAt: refill grants 1; available=1, nextRefillAt=null (at cap)", async () => {
+      repo.materializeRefill.mockResolvedValue({
+        available: 1,
+        lastGrantAt: NOW,
+        isUltraActive: true,
+      });
+      const result = await service.getBalance("user-2");
+      const data = result._unsafeUnwrap();
+      expect(data.available).toBe(1);
+      expect(data.maxAvailable).toBe(1);
+      // at cap → nextRefillAt null
+      expect(data.nextRefillAt).toBeNull();
+    });
+
+    it("Ultra user with 0 shields, last grant 31d ago: refill grants 1; available=1, nextRefillAt=null (at cap)", async () => {
+      const lastGrantAt = new Date(NOW.getTime() - 31 * 24 * 60 * 60 * 1000);
+      repo.materializeRefill.mockResolvedValue({
+        available: 1,
+        lastGrantAt,
+        isUltraActive: true,
+      });
+      const result = await service.getBalance("user-3");
+      const data = result._unsafeUnwrap();
+      expect(data.available).toBe(1);
+      expect(data.nextRefillAt).toBeNull();
+    });
+
+    it("Ultra user with 0 shields, last grant 5d ago: no refill; nextRefillAt = lastGrant + 30d", async () => {
+      const lastGrantAt = new Date(NOW.getTime() - 5 * 24 * 60 * 60 * 1000);
+      repo.materializeRefill.mockResolvedValue({
+        available: 0,
+        lastGrantAt,
+        isUltraActive: true,
+      });
+      const result = await service.getBalance("user-4");
+      const data = result._unsafeUnwrap();
+      expect(data.available).toBe(0);
+      const expectedNextRefill = new Date(lastGrantAt.getTime() + SHIELD_REFILL_INTERVAL_MS);
+      expect(data.nextRefillAt).toBe(expectedNextRefill.toISOString());
+    });
+
+    it("Ultra user already at 1 shield: no refill; available=1, nextRefillAt=null", async () => {
+      const lastGrantAt = new Date(NOW.getTime() - 2 * 24 * 60 * 60 * 1000);
+      repo.materializeRefill.mockResolvedValue({
+        available: 1,
+        lastGrantAt,
+        isUltraActive: true,
+      });
+      const result = await service.getBalance("user-5");
+      const data = result._unsafeUnwrap();
+      expect(data.available).toBe(1);
+      expect(data.nextRefillAt).toBeNull();
+    });
+  });
+
+  describe("tryUseShield", () => {
+    it("happy path: returns { used: true, balanceAfter: 0 }", async () => {
+      repo.materializeRefill.mockResolvedValue({
+        available: 1,
+        lastGrantAt: NOW,
+        isUltraActive: true,
+      });
+      repo.tryUseShield.mockResolvedValue({ used: true, balanceAfter: 0 });
+      const result = await service.tryUseShield("user-6", "2026-05-10");
+      expect(result).toEqual({ used: true, balanceAfter: 0 });
+      expect(repo.tryUseShield).toHaveBeenCalledWith("user-6", "2026-05-10");
+    });
+
+    it("no shields: returns { used: false, balanceAfter: null }", async () => {
+      repo.materializeRefill.mockResolvedValue({
+        available: 0,
+        lastGrantAt: null,
+        isUltraActive: true,
+      });
+      repo.tryUseShield.mockResolvedValue({ used: false, balanceAfter: null });
+      const result = await service.tryUseShield("user-7", "2026-05-10");
+      expect(result).toEqual({ used: false, balanceAfter: null });
+    });
+
+    it("already-protected: returns { used: false, balanceAfter: null }", async () => {
+      repo.materializeRefill.mockResolvedValue({
+        available: 1,
+        lastGrantAt: NOW,
+        isUltraActive: true,
+      });
+      repo.tryUseShield.mockResolvedValue({ used: false, balanceAfter: null });
+      const result = await service.tryUseShield("user-8", "2026-05-10");
+      expect(result).toEqual({ used: false, balanceAfter: null });
+    });
+  });
+});

--- a/apps/server/src/features/shields/shields.service.ts
+++ b/apps/server/src/features/shields/shields.service.ts
@@ -1,0 +1,34 @@
+import { ok, type Result } from "neverthrow";
+import { type AppError } from "../../utils/errors";
+import { MAX_STREAK_SHIELDS, SHIELD_REFILL_INTERVAL_MS, type ShieldUseResult } from "@pruvi/shared";
+import type { ShieldsRepository } from "./shields.repository";
+
+export class ShieldsService {
+  constructor(private repo: ShieldsRepository) {}
+
+  async getBalance(
+    userId: string,
+  ): Promise<Result<{ available: number; maxAvailable: typeof MAX_STREAK_SHIELDS; nextRefillAt: string | null }, AppError>> {
+    const now = new Date();
+    const state = await this.repo.materializeRefill(userId, now);
+    let nextRefillAt: Date | null = null;
+    if (state.isUltraActive && state.available < MAX_STREAK_SHIELDS && state.lastGrantAt) {
+      nextRefillAt = new Date(state.lastGrantAt.getTime() + SHIELD_REFILL_INTERVAL_MS);
+    } else if (state.isUltraActive && state.available < MAX_STREAK_SHIELDS && !state.lastGrantAt) {
+      // Edge: Ultra user with NULL last_shield_grant_at but materializeRefill didn't grant
+      // (concurrent grant lost the race). nextRefillAt = now is the truthful answer.
+      nextRefillAt = now;
+    }
+    return ok({
+      available: state.available,
+      maxAvailable: MAX_STREAK_SHIELDS as typeof MAX_STREAK_SHIELDS,
+      nextRefillAt: nextRefillAt?.toISOString() ?? null,
+    });
+  }
+
+  async tryUseShield(userId: string, protectedDate: string): Promise<ShieldUseResult> {
+    // Materialize refill first so eligible Ultra users have access to a freshly-granted shield.
+    await this.repo.materializeRefill(userId, new Date());
+    return this.repo.tryUseShield(userId, protectedDate);
+  }
+}

--- a/apps/server/src/features/streaks/streaks.repository.ts
+++ b/apps/server/src/features/streaks/streaks.repository.ts
@@ -7,11 +7,13 @@ type DbClient = typeof db;
 export class StreaksRepository {
   constructor(private db: DbClient) {}
 
-  /** Get all completed session dates for a user, ordered newest first */
+  /** Get all completed session dates for a user, ordered newest first.
+   *  Returns DISTINCT BRT-local calendar dates (one row per day) as YYYY-MM-DD strings.
+   */
   async getCompletedSessionDates(userId: string) {
     const rows = await this.db
       .selectDistinct({
-        date: sql<string>`${dailySession.createdAt}::date`.as("date"),
+        date: sql<string>`(${dailySession.createdAt} AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo')::date`.as("date"),
       })
       .from(dailySession)
       .where(
@@ -20,7 +22,7 @@ export class StreaksRepository {
           eq(dailySession.status, "completed")
         )
       )
-      .orderBy(desc(sql`${dailySession.createdAt}::date`));
+      .orderBy(desc(sql`(${dailySession.createdAt} AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo')::date`));
 
     return rows.map((r) => r.date);
   }

--- a/apps/server/src/features/streaks/streaks.route.ts
+++ b/apps/server/src/features/streaks/streaks.route.ts
@@ -1,13 +1,14 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { StreaksService } from "./streaks.service";
 import { StreaksRepository } from "./streaks.repository";
+import { ShieldsRepository } from "../shields/shields.repository";
 import { db } from "@pruvi/db";
 import { successResponse, unwrapResult } from "../../types";
 
-const repo = new StreaksRepository(db);
-const service = new StreaksService(repo);
-
 export const streaksRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const repo = new StreaksRepository(db);
+  const shieldsRepo = new ShieldsRepository(db);
+  const service = new StreaksService(repo, shieldsRepo);
   // GET /streaks
   fastify.get(
     "/streaks",

--- a/apps/server/src/features/streaks/streaks.service.test.ts
+++ b/apps/server/src/features/streaks/streaks.service.test.ts
@@ -14,13 +14,16 @@ function daysAgo(n: number) {
   return d.toISOString().slice(0, 10);
 }
 
-function createMocks() {
+function createMocks(shieldsProtectedDates: string[] = []) {
   const repo = {
     getCompletedSessionDates: vi.fn(),
     countCompletedSessions: vi.fn(),
   };
-  const service = new StreaksService(repo as any);
-  return { repo, service };
+  const shieldsRepo = {
+    listProtectedDates: vi.fn().mockResolvedValue(shieldsProtectedDates),
+  };
+  const service = new StreaksService(repo as any, shieldsRepo as any);
+  return { repo, shieldsRepo, service };
 }
 
 describe("StreaksService", () => {
@@ -84,5 +87,37 @@ describe("StreaksService", () => {
     const value = result._unsafeUnwrap();
     expect(value.currentStreak).toBe(2);
     expect(value.longestStreak).toBe(2);
+  });
+
+  describe("shield protected dates merge", () => {
+    it("protected yesterday fills gap: today + day-before-yesterday + protected yesterday = streak 3", async () => {
+      // completed: today, 2 days ago (gap at yesterday)
+      // protected: yesterday → merged → today, yesterday, 2daysAgo → streak = 3
+      const { repo: r, service: s } = createMocks([daysAgo(1)]);
+      r.getCompletedSessionDates.mockResolvedValue([todayStr(), daysAgo(2)]);
+      r.countCompletedSessions.mockResolvedValue(2);
+
+      const result = await s.getStreaks("user-1");
+
+      expect(result.isOk()).toBe(true);
+      const value = result._unsafeUnwrap();
+      expect(value.currentStreak).toBe(3);
+      expect(value.longestStreak).toBe(3);
+      // totalSessions still uses countCompletedSessions — protected dates don't count
+      expect(value.totalSessions).toBe(2);
+    });
+
+    it("without protected dates, today + day-before-yesterday = streak 1 (gap breaks it)", async () => {
+      // No shield — gap at yesterday breaks streak, only today counts
+      const { repo: r, service: s } = createMocks([]);
+      r.getCompletedSessionDates.mockResolvedValue([todayStr(), daysAgo(2)]);
+      r.countCompletedSessions.mockResolvedValue(2);
+
+      const result = await s.getStreaks("user-1");
+
+      expect(result.isOk()).toBe(true);
+      const value = result._unsafeUnwrap();
+      expect(value.currentStreak).toBe(1);
+    });
   });
 });

--- a/apps/server/src/features/streaks/streaks.service.test.ts
+++ b/apps/server/src/features/streaks/streaks.service.test.ts
@@ -1,17 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { todayInBrt } from "@pruvi/shared";
 import { StreaksService } from "./streaks.service";
 
+// BRT-local "today" — matches what the repo returns and what computeStreaks compares against.
 function todayStr() {
-  const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  return d.toISOString().slice(0, 10);
+  return todayInBrt(new Date());
 }
 
 function daysAgo(n: number) {
-  const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 10);
+  return todayInBrt(new Date(Date.now() - n * 86_400_000));
 }
 
 function createMocks(shieldsProtectedDates: string[] = []) {

--- a/apps/server/src/features/streaks/streaks.service.ts
+++ b/apps/server/src/features/streaks/streaks.service.ts
@@ -1,4 +1,5 @@
 import { ok, type Result } from "neverthrow";
+import { todayInBrt } from "@pruvi/shared";
 import type { AppError } from "../../utils/errors";
 import type { StreaksRepository } from "./streaks.repository";
 import type { ShieldsRepository } from "../shields/shields.repository";
@@ -47,14 +48,12 @@ export class StreaksService {
  * sorted newest-first (e.g., ["2026-03-15", "2026-03-14", "2026-03-12"]).
  */
 function computeStreaks(dates: string[]) {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const todayStr = today.toISOString().slice(0, 10);
-
-  // Check if today or yesterday is in the dates (to count current streak)
-  const yesterday = new Date(today);
-  yesterday.setDate(yesterday.getDate() - 1);
-  const yesterdayStr = yesterday.toISOString().slice(0, 10);
+  // "Today" must be BRT-local to match the date strings the repo returns. UTC midnight
+  // would skip the user's evening between 21:00 BRT and 23:59 BRT for users in late-night
+  // sessions (00:00–03:00 UTC).
+  const now = new Date();
+  const todayStr = todayInBrt(now);
+  const yesterdayStr = todayInBrt(new Date(now.getTime() - 86_400_000));
 
   let currentStreak = 0;
   let longestStreak = 0;

--- a/apps/server/src/features/streaks/streaks.service.ts
+++ b/apps/server/src/features/streaks/streaks.service.ts
@@ -1,9 +1,13 @@
 import { ok, type Result } from "neverthrow";
 import type { AppError } from "../../utils/errors";
 import type { StreaksRepository } from "./streaks.repository";
+import type { ShieldsRepository } from "../shields/shields.repository";
 
 export class StreaksService {
-  constructor(private repo: StreaksRepository) {}
+  constructor(
+    private repo: StreaksRepository,
+    private shieldsRepo?: ShieldsRepository,
+  ) {}
 
   async getStreaks(
     userId: string
@@ -13,18 +17,28 @@ export class StreaksService {
       AppError
     >
   > {
-    const [dates, totalSessions] = await Promise.all([
+    const [completedDates, protectedDates, totalSessions] = await Promise.all([
       this.repo.getCompletedSessionDates(userId),
+      this.shieldsRepo?.listProtectedDates(userId) ?? Promise.resolve([] as string[]),
       this.repo.countCompletedSessions(userId),
     ]);
 
-    if (dates.length === 0) {
+    // Both arrays contain `YYYY-MM-DD` BRT-local strings — Set dedup is safe.
+    const allDates = Array.from(new Set([...completedDates, ...protectedDates])).sort().reverse();
+
+    if (allDates.length === 0) {
       return ok({ currentStreak: 0, longestStreak: 0, totalSessions: 0 });
     }
 
-    const { currentStreak, longestStreak } = computeStreaks(dates);
+    const { currentStreak, longestStreak } = computeStreaks(allDates);
 
     return ok({ currentStreak, longestStreak, totalSessions });
+  }
+
+  /** Returns up to `limit` most-recent completed session dates (BRT YYYY-MM-DD, newest first). */
+  async getRecentCompletedDates(userId: string, limit: number): Promise<string[]> {
+    const dates = await this.repo.getCompletedSessionDates(userId);
+    return dates.slice(0, limit);
   }
 }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -12,6 +12,7 @@ import { gamificationRoutes } from "./features/gamification";
 import { tokensRoutes, preferencesRoutes } from "./features/notifications";
 import { invitationsRoutes, friendshipsRoutes, rankingRoutes } from "./features/social";
 import { ultraRoutes } from "./features/ultra/ultra.route";
+import { shieldsRoutes } from "./features/shields/shields.route";
 import { livesRoutes } from "./features/lives";
 import { onboardingRoutes } from "./features/onboarding";
 import { progressRoutes } from "./features/progress";
@@ -86,6 +87,7 @@ export async function buildApp() {
   await app.register(friendshipsRoutes);
   await app.register(rankingRoutes);
   await app.register(ultraRoutes);
+  await app.register(shieldsRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/docs/superpowers/plans/2026-05-12-phase-2e2-streak-shield.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e2-streak-shield.md
@@ -2,7 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** Ship streak shields: Ultra users accumulate up to 3 (one per 30 days, lazy refill). Auto-protect a 1-day gap on session-complete. New endpoint to view balance.
+**Goal:** Ship streak shields: Ultra users have at most 1 shield in stock (binary, no accumulation per spec v2 §5.3). Lazy single-grant refill 30 days after last grant. Auto-protect a 1-day gap on session-complete. New endpoint to view balance.
+
+> **Status note:** Tasks 1-2 already shipped (commits `2a24dba`, `82191c7`, `66adaed`, `7f7486c`). Shared constants (MAX_STREAK_SHIELDS = 1, ShieldUseResultSchema, todayInBrt) + migration `0008_known_lockjaw.sql` (with CHECK `<= 1`) + PGlite mirror are all in place. Implement Tasks 3-5 below.
 
 **Architecture:** New `shields/` feature module (repo + service + route). Atomic CTE in `tryUseShield` for race-free decrement + protection-row insert. Lazy refill computed in `materializeRefill`. `StreaksService` merges protected dates from `streak_shield_usage` into the completed-dates set. Fire-and-forget hook in `sessions.completeSession`.
 
@@ -295,40 +297,36 @@ export class ShieldsRepository {
     return { available: updated[0]!.available, lastGrantAt: updated[0]!.lastGrantAt, isUltraActive: true };
   }
 
-  /** Atomic decrement + insert. Returns success if both occurred. */
-  async tryUseShield(
-    userId: string,
-    protectedDate: string,
-  ): Promise<{ used: boolean; balanceAfter: number | null }> {
-    // Single CTE: decrement only if shields>0, insert only if no conflict.
-    const result = await this.db.execute<{ new_balance: number | null; usage_id: number | null }>(sql`
-      WITH decrement AS (
-        UPDATE "user"
-        SET streak_shields_available = streak_shields_available - 1
-        WHERE id = ${userId} AND streak_shields_available > 0
-        RETURNING streak_shields_available
-      ),
-      insertion AS (
-        INSERT INTO streak_shield_usage (user_id, protected_date)
-        VALUES (${userId}, ${protectedDate}::date)
-        ON CONFLICT (user_id, protected_date) DO NOTHING
-        RETURNING id
-      )
-      SELECT
-        (SELECT streak_shields_available FROM decrement) AS new_balance,
-        (SELECT id FROM insertion) AS usage_id
-    `);
-    const rows = Array.isArray(result) ? result : (result as { rows: Array<{ new_balance: number | null; usage_id: number | null }> }).rows;
-    const row = rows[0];
-    if (!row || row.new_balance === null || row.usage_id === null) {
-      // Either no shields OR already protected — rollback effect by reverting any successful side.
-      // But because both ran in a single statement, if usage_id is null and decrement happened, we must reverse it.
-      // PG executes CTE branches in arbitrary order; need to guard against partial application.
-      // SAFER APPROACH: explicit transaction with row-level locking.
-      // (See Task 3 step 1.5 below for an alternative if this edge surfaces.)
-      return { used: false, balanceAfter: null };
+  /**
+   * Atomic decrement + protection insert. Returns `{ used: true }` only when
+   * both succeed; UNIQUE conflict on (user_id, protected_date) rolls back
+   * the decrement via thrown error.
+   */
+  async tryUseShield(userId: string, protectedDate: string): Promise<ShieldUseResult> {
+    try {
+      return await this.db.transaction(async (tx) => {
+        // 1. Conditional decrement — only succeeds when shields > 0 (predicate inside row lock).
+        const dec = await tx
+          .update(user)
+          .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} - 1` })
+          .where(and(eq(user.id, userId), gt(user.streakShieldsAvailable, 0)))
+          .returning({ available: user.streakShieldsAvailable });
+        if (dec.length === 0) return { used: false, balanceAfter: null };
+
+        // 2. Insert protection row. UNIQUE conflict → throw to roll back the decrement.
+        try {
+          await tx.insert(streakShieldUsage).values({ userId, protectedDate });
+        } catch (e) {
+          throw new Error("ALREADY_PROTECTED");
+        }
+        return { used: true, balanceAfter: dec[0]!.available };
+      });
+    } catch (e) {
+      if (e instanceof Error && e.message === "ALREADY_PROTECTED") {
+        return { used: false, balanceAfter: null };
+      }
+      throw e;
     }
-    return { used: true, balanceAfter: row.new_balance };
   }
 
   async listProtectedDates(userId: string): Promise<string[]> {
@@ -341,43 +339,14 @@ export class ShieldsRepository {
 }
 ```
 
-**Important caveat on `tryUseShield`:** in standard SQL, the two CTE branches (`decrement`, `insertion`) run independently and may both succeed or both fail. Postgres specifically defines that data modifications in CTEs use the same snapshot, but they execute in parallel; you cannot make one conditional on the other within a single CTE without manual transaction wrapping.
-
-**Use a transaction instead** for guaranteed correctness:
-
-```typescript
-async tryUseShield(userId: string, protectedDate: string): Promise<{ used: boolean; balanceAfter: number | null }> {
-  return this.db.transaction(async (tx) => {
-    // Try to decrement first. If 0 rows, no shields.
-    const dec = await tx
-      .update(user)
-      .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} - 1` })
-      .where(and(eq(user.id, userId), gt(user.streakShieldsAvailable, 0)))
-      .returning({ available: user.streakShieldsAvailable });
-    if (dec.length === 0) return { used: false, balanceAfter: null };
-    // Try to insert protection. UNIQUE conflict → rollback decrement.
-    try {
-      await tx.insert(streakShieldUsage).values({ userId, protectedDate });
-    } catch (e) {
-      // Rollback by throwing — transaction handler unwinds.
-      throw new Error("ALREADY_PROTECTED");
-    }
-    return { used: true, balanceAfter: dec[0]!.available };
-  }).catch((e) => {
-    if (e?.message === "ALREADY_PROTECTED") return { used: false, balanceAfter: null };
-    throw e;
-  });
-}
-```
-
-Use this transaction version, not the CTE. The CTE design was a planning exploration that doesn't actually provide atomicity-without-transactions.
+Note: import `ShieldUseResult` from `@pruvi/shared`. Imports needed at the top: `eq, sql, and, gt, isNull, lt` from `drizzle-orm`.
 
 - [ ] **Step 2: Service**
 
 ```typescript
 import { ok, type Result } from "neverthrow";
 import { AppError } from "../../utils/errors";
-import { MAX_STREAK_SHIELDS, SHIELD_REFILL_INTERVAL_MS } from "@pruvi/shared";
+import { MAX_STREAK_SHIELDS, SHIELD_REFILL_INTERVAL_MS, type ShieldUseResult } from "@pruvi/shared";
 import type { ShieldsRepository } from "./shields.repository";
 
 export class ShieldsService {
@@ -401,7 +370,7 @@ export class ShieldsService {
     });
   }
 
-  async tryUseShield(userId: string, protectedDate: string): Promise<{ used: boolean; balanceAfter: number | null }> {
+  async tryUseShield(userId: string, protectedDate: string): Promise<ShieldUseResult> {
     // Materialize refill first so eligible Ultra users have access to a freshly-granted shield.
     await this.repo.materializeRefill(userId, new Date());
     return this.repo.tryUseShield(userId, protectedDate);
@@ -496,6 +465,7 @@ const [completedDates, protectedDates] = await Promise.all([
   this.shieldsRepo?.listProtectedDates(userId) ?? Promise.resolve([] as string[]),
 ]);
 
+// Both arrays contain `YYYY-MM-DD` BRT-local strings — Set dedup is safe.
 const allDates = Array.from(new Set([...completedDates, ...protectedDates])).sort().reverse();
 if (allDates.length === 0) {
   return ok({ currentStreak: 0, longestStreak: 0, totalSessions: 0 });
@@ -553,30 +523,50 @@ if (this.shieldsService) {
 (Add `private logger?: FastifyBaseLogger` to constructor if it doesn't already exist — match the reviews.service pattern from 2D.1.)
 
 ```typescript
+import { todayInBrt } from "@pruvi/shared";
+
 private async maybeProtectMissedDay(userId: string): Promise<void> {
-  const dates = await this.repo.getRecentCompletedSessionDates(userId, 2);
+  // Use BRT-local date math — UTC would mis-fire near midnight for users.
+  const now = new Date();
+  const todayStr = todayInBrt(now);
+  const yesterdayStr = todayInBrt(new Date(now.getTime() - 86_400_000));
+  const dates = await this.streaksService!.getRecentCompletedDates(userId, 2);
   if (dates.length < 2) return;
-  const today = new Date();
-  today.setUTCHours(0, 0, 0, 0);
-  const todayStr = today.toISOString().slice(0, 10);
   if (dates[0] !== todayStr) return;
-  const prev = new Date(dates[1] + "T00:00:00Z");
-  const diffDays = Math.round((today.getTime() - prev.getTime()) / 86_400_000);
+  // Both dates are YYYY-MM-DD BRT strings — convert to date-aware Date at midnight BRT (UTC 03:00).
+  const todayDate = new Date(todayStr + "T03:00:00Z");
+  const prevDate = new Date(dates[1] + "T03:00:00Z");
+  const diffDays = Math.round((todayDate.getTime() - prevDate.getTime()) / 86_400_000);
   if (diffDays !== 2) return;
-  const yesterday = new Date(today.getTime() - 86_400_000);
-  await this.shieldsService!.tryUseShield(userId, yesterday.toISOString().slice(0, 10));
+  await this.shieldsService!.tryUseShield(userId, yesterdayStr);
 }
 ```
 
-**`SessionsRepository.getRecentCompletedSessionDates` helper** — add this method. It returns up to N most recent completed session dates (descending). It's a thin wrapper for the hook; existing `getCompletedSessionDates` on `StreaksRepository` returns the full list which is unnecessary here. (You may instead reuse the existing method and slice to 2 — verify the existing query is indexed efficiently.)
+**Sub-step (CRITICAL): verify `getCompletedSessionDates` returns DISTINCT BRT dates.**
 
-Decision: reuse the existing `streaks.repository.getCompletedSessionDates(userId)` and slice the first 2 in the service. This avoids a new repo method. The query is already indexed on `(user_id, created_at)`.
+Before wiring the hook, open `streaks.repository.ts` and inspect the SQL of `getCompletedSessionDates`. The query MUST return one row per distinct BRT calendar day (not per session). Without DISTINCT, two same-day sessions yield `dates = ['today', 'today']`, making `(today - dates[1]).days === 0` and breaking the gap math.
 
-To do this cleanly, the sessions service needs the streaks repo. Look at the existing constructor — streaks service is already injected. The streaks service exposes the data via `getStreaks`, but we want raw dates. Simplest: add a small `streaks.service.getCompletedDates(userId)` method that returns `string[]`, exposing the repo data.
+- If the current query uses `created_at::date` without a timezone conversion or without DISTINCT: fix it to use `(created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo')::date` AND wrap with `DISTINCT` or `GROUP BY`.
+- If already correct, leave it.
+
+**`StreaksService.getRecentCompletedDates(userId, limit)` helper** — add this method. It exposes the streaks repo's date list to the sessions hook without duplicating the query. Match the existing repo signature; slice to `limit` in the service.
+
+```typescript
+// streaks.service.ts
+async getRecentCompletedDates(userId: string, limit: number): Promise<string[]> {
+  const dates = await this.repo.getCompletedSessionDates(userId);
+  return dates.slice(0, limit);
+}
+```
+
+The sessions service already has `streaksService` injected, so no new wiring is needed beyond this method.
 
 - [ ] **Step 3: Wire in `sessions.route.ts`**
 
-Where `new SessionsService(...)` is constructed (likely in the route plugin function), pass `new ShieldsService(new ShieldsRepository(db))` as the new arg.
+Open `sessions.route.ts`. The `new SessionsService(...)` instantiation MUST be inside the `async (fastify) => { ... }` plugin function body — NOT at module level. This is the established pattern from the 2D.1 reviews-route fix (commit `60564c0`); module-level construction triggers DB connections at boot and can't access `fastify.*`.
+
+- If `new SessionsService(...)` is already inside the plugin function, just append `new ShieldsService(new ShieldsRepository(db))` as the new constructor arg.
+- If it's at module level, FIRST move all related construction inside the plugin function (match `reviews.route.ts` structure), THEN add the shields arg.
 
 - [ ] **Step 4: Tests**
 

--- a/docs/superpowers/plans/2026-05-12-phase-2e2-streak-shield.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e2-streak-shield.md
@@ -1,0 +1,647 @@
+# Phase 2E.2 — Streak Shield Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Ship streak shields: Ultra users accumulate up to 3 (one per 30 days, lazy refill). Auto-protect a 1-day gap on session-complete. New endpoint to view balance.
+
+**Architecture:** New `shields/` feature module (repo + service + route). Atomic CTE in `tryUseShield` for race-free decrement + protection-row insert. Lazy refill computed in `materializeRefill`. `StreaksService` merges protected dates from `streak_shield_usage` into the completed-dates set. Fire-and-forget hook in `sessions.completeSession`.
+
+**Source spec:** `docs/superpowers/specs/2026-05-12-phase-2e2-streak-shield-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `packages/shared/src/shields.ts` — `MAX_STREAK_SHIELDS`, `SHIELD_REFILL_INTERVAL_MS`, `ShieldBalanceResponseSchema`
+- `packages/shared/src/shields.test.ts`
+- `packages/db/src/schema/streak-shield-usage.ts`
+- `packages/db/src/migrations/0008_<generated>.sql`
+- `apps/server/src/features/shields/shields.repository.ts`
+- `apps/server/src/features/shields/shields.service.ts`
+- `apps/server/src/features/shields/shields.route.ts`
+- `apps/server/src/features/shields/shields.service.test.ts`
+- `apps/server/src/features/shields/shields.repository.integration.test.ts`
+
+**Modify:**
+- `packages/db/src/schema/auth.ts` — `streakShieldsAvailable`, `lastShieldGrantAt`
+- `packages/db/src/schema/index.ts` — re-export shield usage schema
+- `packages/db/src/test-client.ts` — mirror DDL
+- `packages/shared/src/index.ts` — re-export shields
+- `apps/server/src/features/streaks/streaks.service.ts` — merge protected dates
+- `apps/server/src/features/streaks/streaks.repository.ts` — add `getRecentCompletedSessionDates(userId, limit)` (helper used by sessions hook)
+- `apps/server/src/features/streaks/streaks.service.test.ts` — extend
+- `apps/server/src/features/sessions/sessions.service.ts` — inject `shieldsService`, fire-and-forget hook
+- `apps/server/src/features/sessions/sessions.service.test.ts` — hook cases
+- `apps/server/src/features/sessions/sessions.route.ts` — wire `shieldsService`
+- `apps/server/src/index.ts` — register `shieldsRoutes`
+
+---
+
+## Tasks
+
+### Task 1: Shared constants + schema
+
+**Files:**
+- Create: `packages/shared/src/shields.ts`, `packages/shared/src/shields.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] **Step 1: `packages/shared/src/shields.ts`**
+
+```typescript
+import { z } from "zod";
+
+export const MAX_STREAK_SHIELDS = 3;
+export const SHIELD_REFILL_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const ShieldBalanceResponseSchema = z.object({
+  available: z.number().int().min(0).max(MAX_STREAK_SHIELDS),
+  maxAvailable: z.literal(MAX_STREAK_SHIELDS),
+  nextRefillAt: z.string().datetime().nullable(),
+});
+export type ShieldBalanceResponse = z.infer<typeof ShieldBalanceResponseSchema>;
+```
+
+- [ ] **Step 2: `packages/shared/src/shields.test.ts`**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { ShieldBalanceResponseSchema, MAX_STREAK_SHIELDS } from "./shields";
+
+describe("ShieldBalanceResponseSchema", () => {
+  it("accepts a valid balance", () => {
+    expect(ShieldBalanceResponseSchema.safeParse({
+      available: 2, maxAvailable: 3, nextRefillAt: "2026-06-12T00:00:00.000Z",
+    }).success).toBe(true);
+  });
+  it("accepts null nextRefillAt", () => {
+    expect(ShieldBalanceResponseSchema.safeParse({
+      available: 0, maxAvailable: 3, nextRefillAt: null,
+    }).success).toBe(true);
+  });
+  it("rejects available > MAX_STREAK_SHIELDS", () => {
+    expect(ShieldBalanceResponseSchema.safeParse({
+      available: 4, maxAvailable: 3, nextRefillAt: null,
+    }).success).toBe(false);
+  });
+  it("rejects negative available", () => {
+    expect(ShieldBalanceResponseSchema.safeParse({
+      available: -1, maxAvailable: 3, nextRefillAt: null,
+    }).success).toBe(false);
+  });
+  it("MAX_STREAK_SHIELDS = 3", () => {
+    expect(MAX_STREAK_SHIELDS).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 3: Re-export**
+
+Append to `packages/shared/src/index.ts`:
+```typescript
+export * from "./shields";
+```
+
+- [ ] **Step 4: Run + commit**
+
+```bash
+pnpm --filter @pruvi/shared test shields
+git add packages/shared/src/shields.ts packages/shared/src/shields.test.ts packages/shared/src/index.ts
+git commit -m "feat(shared): streak shield constants + response schema"
+```
+
+---
+
+### Task 2: DB schema + migration
+
+**Files:**
+- Modify: `packages/db/src/schema/auth.ts`
+- Create: `packages/db/src/schema/streak-shield-usage.ts`
+- Modify: `packages/db/src/schema/index.ts`
+- Create: `packages/db/src/migrations/0008_<generated>.sql`
+- Modify: `packages/db/src/test-client.ts`
+
+- [ ] **Step 1: Add columns to `auth.ts`**
+
+```typescript
+streakShieldsAvailable: integer("streak_shields_available").notNull().default(0),
+lastShieldGrantAt: timestamp("last_shield_grant_at"),
+```
+
+- [ ] **Step 2: Create `streak-shield-usage.ts` schema**
+
+```typescript
+import { relations } from "drizzle-orm";
+import { date, index, pgTable, serial, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const streakShieldUsage = pgTable(
+  "streak_shield_usage",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    protectedDate: date("protected_date").notNull(),
+    usedAt: timestamp("used_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("streak_shield_usage_user_date_idx").on(table.userId, table.protectedDate),
+    index("streak_shield_usage_user_idx").on(table.userId),
+  ],
+);
+
+export const streakShieldUsageRelations = relations(streakShieldUsage, ({ one }) => ({
+  user: one(user, { fields: [streakShieldUsage.userId], references: [user.id] }),
+}));
+```
+
+- [ ] **Step 3: Re-export schema**
+
+Append to `packages/db/src/schema/index.ts`:
+```typescript
+export * from "./streak-shield-usage";
+```
+
+- [ ] **Step 4: Generate migration**
+
+Run: `pnpm --filter @pruvi/db db:generate`. Note the generated filename.
+
+- [ ] **Step 5: Replace migration SQL with idempotent version**
+
+```sql
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "streak_shields_available" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "last_shield_grant_at" timestamp;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_streak_shields_chk') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_streak_shields_chk"
+      CHECK ("streak_shields_available" >= 0 AND "streak_shields_available" <= 3);
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "streak_shield_usage" (
+  "id" serial PRIMARY KEY,
+  "user_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "protected_date" date NOT NULL,
+  "used_at" timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "streak_shield_usage_user_date_idx" ON "streak_shield_usage" ("user_id", "protected_date");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "streak_shield_usage_user_idx" ON "streak_shield_usage" ("user_id");
+```
+
+- [ ] **Step 6: Mirror in PGlite test-client**
+
+In `packages/db/src/test-client.ts`:
+- Add `streak_shields_available INTEGER NOT NULL DEFAULT 0` to user table.
+- Add `last_shield_grant_at TIMESTAMP`.
+- Add inline `CONSTRAINT user_streak_shields_chk CHECK (streak_shields_available >= 0 AND streak_shields_available <= 3)`.
+- After the user CREATE TABLE block, add the `streak_shield_usage` CREATE TABLE + UNIQUE/INDEX statements.
+
+- [ ] **Step 7: Run verify:migration + tests**
+
+```bash
+pnpm verify:migration
+pnpm --filter server test && pnpm --filter server test:integration
+```
+
+All must pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/db
+git commit -m "feat(db): streak_shields_available + streak_shield_usage (migration 0008)"
+```
+
+---
+
+### Task 3: Shields repository + service + route
+
+**Files:**
+- Create: `apps/server/src/features/shields/shields.repository.ts`
+- Create: `apps/server/src/features/shields/shields.service.ts`
+- Create: `apps/server/src/features/shields/shields.route.ts`
+- Create: `apps/server/src/features/shields/shields.service.test.ts`
+- Create: `apps/server/src/features/shields/shields.repository.integration.test.ts`
+- Modify: `apps/server/src/index.ts`
+
+- [ ] **Step 1: Repository**
+
+```typescript
+import { eq, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { user } from "@pruvi/db/schema/auth";
+import { streakShieldUsage } from "@pruvi/db/schema/streak-shield-usage";
+import { MAX_STREAK_SHIELDS } from "@pruvi/shared";
+
+type Db = typeof DbClient;
+
+export class ShieldsRepository {
+  constructor(private db: Db) {}
+
+  async getUserShieldState(userId: string) {
+    const rows = await this.db
+      .select({
+        streakShieldsAvailable: user.streakShieldsAvailable,
+        lastShieldGrantAt: user.lastShieldGrantAt,
+        isUltra: user.isUltra,
+        ultraExpiresAt: user.ultraExpiresAt,
+      })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  /** Apply lazy refill if eligible. Returns post-state. */
+  async materializeRefill(
+    userId: string,
+    now: Date,
+    intervalMs: number,
+  ): Promise<{ available: number; lastGrantAt: Date | null; isUltraActive: boolean }> {
+    const current = await this.getUserShieldState(userId);
+    if (!current) return { available: 0, lastGrantAt: null, isUltraActive: false };
+    const ultraActive = current.isUltra && (!current.ultraExpiresAt || current.ultraExpiresAt > now);
+    if (!ultraActive) {
+      return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: false };
+    }
+    let available = current.streakShieldsAvailable;
+    let lastGrant = current.lastShieldGrantAt;
+    if (available >= MAX_STREAK_SHIELDS) {
+      return { available, lastGrantAt: lastGrant, isUltraActive: true };
+    }
+    let ticks = 0;
+    if (lastGrant === null) {
+      ticks = 1;
+      lastGrant = now;
+    } else {
+      const elapsed = now.getTime() - lastGrant.getTime();
+      ticks = Math.max(0, Math.floor(elapsed / intervalMs));
+      if (ticks > 0) {
+        lastGrant = new Date(lastGrant.getTime() + ticks * intervalMs);
+      }
+    }
+    if (ticks === 0) {
+      return { available, lastGrantAt: current.lastShieldGrantAt, isUltraActive: true };
+    }
+    const newAvailable = Math.min(MAX_STREAK_SHIELDS, available + ticks);
+    await this.db
+      .update(user)
+      .set({ streakShieldsAvailable: newAvailable, lastShieldGrantAt: lastGrant })
+      .where(eq(user.id, userId));
+    return { available: newAvailable, lastGrantAt: lastGrant, isUltraActive: true };
+  }
+
+  /** Atomic decrement + insert. Returns success if both occurred. */
+  async tryUseShield(
+    userId: string,
+    protectedDate: string,
+  ): Promise<{ used: boolean; balanceAfter: number | null }> {
+    // Single CTE: decrement only if shields>0, insert only if no conflict.
+    const result = await this.db.execute<{ new_balance: number | null; usage_id: number | null }>(sql`
+      WITH decrement AS (
+        UPDATE "user"
+        SET streak_shields_available = streak_shields_available - 1
+        WHERE id = ${userId} AND streak_shields_available > 0
+        RETURNING streak_shields_available
+      ),
+      insertion AS (
+        INSERT INTO streak_shield_usage (user_id, protected_date)
+        VALUES (${userId}, ${protectedDate}::date)
+        ON CONFLICT (user_id, protected_date) DO NOTHING
+        RETURNING id
+      )
+      SELECT
+        (SELECT streak_shields_available FROM decrement) AS new_balance,
+        (SELECT id FROM insertion) AS usage_id
+    `);
+    const rows = Array.isArray(result) ? result : (result as { rows: Array<{ new_balance: number | null; usage_id: number | null }> }).rows;
+    const row = rows[0];
+    if (!row || row.new_balance === null || row.usage_id === null) {
+      // Either no shields OR already protected — rollback effect by reverting any successful side.
+      // But because both ran in a single statement, if usage_id is null and decrement happened, we must reverse it.
+      // PG executes CTE branches in arbitrary order; need to guard against partial application.
+      // SAFER APPROACH: explicit transaction with row-level locking.
+      // (See Task 3 step 1.5 below for an alternative if this edge surfaces.)
+      return { used: false, balanceAfter: null };
+    }
+    return { used: true, balanceAfter: row.new_balance };
+  }
+
+  async listProtectedDates(userId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ protectedDate: streakShieldUsage.protectedDate })
+      .from(streakShieldUsage)
+      .where(eq(streakShieldUsage.userId, userId));
+    return rows.map((r) => (typeof r.protectedDate === "string" ? r.protectedDate : new Date(r.protectedDate).toISOString().slice(0, 10)));
+  }
+}
+```
+
+**Important caveat on `tryUseShield`:** in standard SQL, the two CTE branches (`decrement`, `insertion`) run independently and may both succeed or both fail. Postgres specifically defines that data modifications in CTEs use the same snapshot, but they execute in parallel; you cannot make one conditional on the other within a single CTE without manual transaction wrapping.
+
+**Use a transaction instead** for guaranteed correctness:
+
+```typescript
+async tryUseShield(userId: string, protectedDate: string): Promise<{ used: boolean; balanceAfter: number | null }> {
+  return this.db.transaction(async (tx) => {
+    // Try to decrement first. If 0 rows, no shields.
+    const dec = await tx
+      .update(user)
+      .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} - 1` })
+      .where(and(eq(user.id, userId), gt(user.streakShieldsAvailable, 0)))
+      .returning({ available: user.streakShieldsAvailable });
+    if (dec.length === 0) return { used: false, balanceAfter: null };
+    // Try to insert protection. UNIQUE conflict → rollback decrement.
+    try {
+      await tx.insert(streakShieldUsage).values({ userId, protectedDate });
+    } catch (e) {
+      // Rollback by throwing — transaction handler unwinds.
+      throw new Error("ALREADY_PROTECTED");
+    }
+    return { used: true, balanceAfter: dec[0]!.available };
+  }).catch((e) => {
+    if (e?.message === "ALREADY_PROTECTED") return { used: false, balanceAfter: null };
+    throw e;
+  });
+}
+```
+
+Use this transaction version, not the CTE. The CTE design was a planning exploration that doesn't actually provide atomicity-without-transactions.
+
+- [ ] **Step 2: Service**
+
+```typescript
+import { ok, type Result } from "neverthrow";
+import { AppError } from "../../utils/errors";
+import { MAX_STREAK_SHIELDS, SHIELD_REFILL_INTERVAL_MS } from "@pruvi/shared";
+import type { ShieldsRepository } from "./shields.repository";
+
+export class ShieldsService {
+  constructor(private repo: ShieldsRepository) {}
+
+  async getBalance(userId: string): Promise<Result<{ available: number; maxAvailable: number; nextRefillAt: string | null }, AppError>> {
+    const now = new Date();
+    const state = await this.repo.materializeRefill(userId, now, SHIELD_REFILL_INTERVAL_MS);
+    let nextRefillAt: Date | null = null;
+    if (state.isUltraActive && state.available < MAX_STREAK_SHIELDS && state.lastGrantAt) {
+      nextRefillAt = new Date(state.lastGrantAt.getTime() + SHIELD_REFILL_INTERVAL_MS);
+    } else if (state.isUltraActive && state.available < MAX_STREAK_SHIELDS && !state.lastGrantAt) {
+      // Edge: Ultra user who somehow has no last_shield_grant_at — eligible immediately.
+      nextRefillAt = now;
+    }
+    return ok({
+      available: state.available,
+      maxAvailable: MAX_STREAK_SHIELDS,
+      nextRefillAt: nextRefillAt?.toISOString() ?? null,
+    });
+  }
+
+  async tryUseShield(userId: string, protectedDate: string): Promise<{ used: boolean; balanceAfter: number | null }> {
+    // Materialize refill first so eligible Ultra users have access to a freshly-granted shield.
+    await this.repo.materializeRefill(userId, new Date(), SHIELD_REFILL_INTERVAL_MS);
+    return this.repo.tryUseShield(userId, protectedDate);
+  }
+}
+```
+
+- [ ] **Step 3: Route**
+
+`shields.route.ts`:
+
+```typescript
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { ShieldBalanceResponseSchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { unwrapResult } from "../../types";
+import { ShieldsRepository } from "./shields.repository";
+import { ShieldsService } from "./shields.service";
+
+export const shieldsRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const repo = new ShieldsRepository(db);
+  const service = new ShieldsService(repo);
+
+  fastify.get(
+    "/users/me/shields",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: ShieldBalanceResponseSchema }) } },
+    },
+    async (request) => unwrapResult(await service.getBalance(request.userId)),
+  );
+};
+```
+
+- [ ] **Step 4: Wire in `apps/server/src/index.ts`**
+
+Register `shieldsRoutes` alongside `ultraRoutes`/`rankingRoutes`/etc.
+
+- [ ] **Step 5: Unit tests `shields.service.test.ts`**
+
+Cover:
+- Non-Ultra user: balance returns `{ available: 0, nextRefillAt: null }`.
+- Ultra user, no prior grant: refill applies; `available = 1`; `nextRefillAt = now + 30d`.
+- Ultra user, 60 days since last grant, 0 shields: refill applies 2 ticks; `available = 2`.
+- Ultra user, 100 days since last grant, 1 shield: cap at MAX (3), `available = 3`, `nextRefillAt = null` (at cap).
+- Ultra user, 5 days since last grant, 1 shield: no refill (interval not elapsed); `available = 1`.
+- `tryUseShield` happy path: returns `{ used: true, balanceAfter: 0 }`.
+- `tryUseShield` no shields: returns `{ used: false, balanceAfter: null }`.
+- `tryUseShield` already-protected: returns `{ used: false, balanceAfter: null }`.
+
+- [ ] **Step 6: Integration tests `shields.repository.integration.test.ts`**
+
+Cover:
+- `tryUseShield` with shields=1: decrement to 0, insert usage row, return `{ used: true, balanceAfter: 0 }`.
+- `tryUseShield` with shields=0: returns `{ used: false, balanceAfter: null }`. No usage row inserted.
+- `tryUseShield` for already-protected date: returns `{ used: false, balanceAfter: null }`. Shields count NOT decremented (transaction rolled back).
+- CHECK constraint: direct UPDATE attempting `streak_shields_available = -1` rejected. `streak_shields_available = 4` rejected.
+- `materializeRefill` for Ultra user with NULL last_grant: applies 1 tick, sets last_grant_at = now.
+- `materializeRefill` for Ultra user with stale (90 days ago) last_grant: applies 3 ticks (capped at MAX), advances last_grant_at by 3 * interval.
+- `listProtectedDates` returns sorted ISO date strings.
+
+- [ ] **Step 7: Run + commit**
+
+```bash
+pnpm --filter server test shields
+pnpm --filter server test:integration shields
+git add apps/server/src/features/shields apps/server/src/index.ts
+git commit -m "feat(shields): repository + service + GET /users/me/shields"
+```
+
+---
+
+### Task 4: Streaks integration
+
+**Files:**
+- Modify: `apps/server/src/features/streaks/streaks.service.ts`
+- Modify: `apps/server/src/features/streaks/streaks.service.test.ts`
+
+- [ ] **Step 1: Inject `ShieldsRepository`**
+
+Constructor signature: `constructor(private repo: StreaksRepository, private shieldsRepo?: ShieldsRepository)`. Optional for backward compat with existing test instantiations.
+
+- [ ] **Step 2: Merge protected dates in `getStreaks`**
+
+```typescript
+const [completedDates, protectedDates] = await Promise.all([
+  this.repo.getCompletedSessionDates(userId),
+  this.shieldsRepo?.listProtectedDates(userId) ?? Promise.resolve([] as string[]),
+]);
+
+const allDates = Array.from(new Set([...completedDates, ...protectedDates])).sort().reverse();
+if (allDates.length === 0) {
+  return ok({ currentStreak: 0, longestStreak: 0, totalSessions: 0 });
+}
+const { currentStreak, longestStreak } = computeStreaks(allDates);
+return ok({ currentStreak, longestStreak, totalSessions });
+```
+
+Note: `totalSessions` still uses `countCompletedSessions` — protected dates do NOT count as sessions, only as streak preservers.
+
+- [ ] **Step 3: Wire `shieldsRepo` in the route**
+
+`apps/server/src/features/streaks/streaks.route.ts` (or wherever `new StreaksService(...)` is called) — pass `new ShieldsRepository(db)` as 2nd arg.
+
+- [ ] **Step 4: Tests**
+
+`streaks.service.test.ts`:
+- Existing tests still pass (with `shieldsRepo` mocked to return empty array).
+- New test: with completed dates `[today, day-before-yesterday]` and protected date `[yesterday]`, current streak = 3.
+- New test: without protected date, the same scenario gives streak = 1 (only today, gap breaks it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm --filter server test streaks
+git add apps/server/src/features/streaks
+git commit -m "feat(streaks): merge protected dates from shield usage into streak compute"
+```
+
+---
+
+### Task 5: Sessions auto-use hook
+
+**Files:**
+- Modify: `apps/server/src/features/sessions/sessions.service.ts`
+- Modify: `apps/server/src/features/sessions/sessions.service.test.ts`
+- Modify: `apps/server/src/features/sessions/sessions.route.ts`
+
+- [ ] **Step 1: Inject `ShieldsService`**
+
+`SessionsService` constructor adds optional `shieldsService?: ShieldsService`. Place after the existing optional deps.
+
+- [ ] **Step 2: Hook in `completeSession`**
+
+After `repo.completeSession(...)` returns the row:
+
+```typescript
+if (this.shieldsService) {
+  void this.maybeProtectMissedDay(userId).catch((e) =>
+    this.logger?.error?.({ err: e, userId }, "shield auto-use failed"),
+  );
+}
+```
+
+(Add `private logger?: FastifyBaseLogger` to constructor if it doesn't already exist — match the reviews.service pattern from 2D.1.)
+
+```typescript
+private async maybeProtectMissedDay(userId: string): Promise<void> {
+  const dates = await this.repo.getRecentCompletedSessionDates(userId, 2);
+  if (dates.length < 2) return;
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const todayStr = today.toISOString().slice(0, 10);
+  if (dates[0] !== todayStr) return;
+  const prev = new Date(dates[1] + "T00:00:00Z");
+  const diffDays = Math.round((today.getTime() - prev.getTime()) / 86_400_000);
+  if (diffDays !== 2) return;
+  const yesterday = new Date(today.getTime() - 86_400_000);
+  await this.shieldsService!.tryUseShield(userId, yesterday.toISOString().slice(0, 10));
+}
+```
+
+**`SessionsRepository.getRecentCompletedSessionDates` helper** — add this method. It returns up to N most recent completed session dates (descending). It's a thin wrapper for the hook; existing `getCompletedSessionDates` on `StreaksRepository` returns the full list which is unnecessary here. (You may instead reuse the existing method and slice to 2 — verify the existing query is indexed efficiently.)
+
+Decision: reuse the existing `streaks.repository.getCompletedSessionDates(userId)` and slice the first 2 in the service. This avoids a new repo method. The query is already indexed on `(user_id, created_at)`.
+
+To do this cleanly, the sessions service needs the streaks repo. Look at the existing constructor — streaks service is already injected. The streaks service exposes the data via `getStreaks`, but we want raw dates. Simplest: add a small `streaks.service.getCompletedDates(userId)` method that returns `string[]`, exposing the repo data.
+
+- [ ] **Step 3: Wire in `sessions.route.ts`**
+
+Where `new SessionsService(...)` is constructed (likely in the route plugin function), pass `new ShieldsService(new ShieldsRepository(db))` as the new arg.
+
+- [ ] **Step 4: Tests**
+
+`sessions.service.test.ts`:
+- Cases:
+  - `completeSession` with prev-completed-date = 2 days ago AND `shieldsService` injected → `tryUseShield` called with yesterday's date.
+  - `completeSession` with prev-completed-date = 1 day ago → `tryUseShield` NOT called (no missed day).
+  - `completeSession` with prev-completed-date = 3 days ago → `tryUseShield` NOT called (gap too large).
+  - `completeSession` with no `shieldsService` → no error.
+  - Fire-and-forget: if `tryUseShield` rejects, `completeSession` still returns `ok`.
+
+Use `await new Promise((r) => setImmediate(r))` to flush microtasks before asserting.
+
+- [ ] **Step 5: Run + commit**
+
+```bash
+pnpm --filter server test sessions
+git add apps/server/src/features/sessions
+git commit -m "feat(sessions): auto-use shield on 1-day-gap completion"
+```
+
+---
+
+### Task 6: Final verification + push
+
+- [ ] **Step 1: Full sweep**
+
+```bash
+pnpm --filter server test
+pnpm --filter server test:integration
+pnpm --filter @pruvi/shared test
+pnpm verify:migration
+pnpm --filter server check-types
+```
+
+All must pass.
+
+- [ ] **Step 2: Worker boot smoke**
+
+```bash
+pnpm dev:worker  # Ctrl-C after ready
+```
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feature/phase-2e2-streak-shield
+gh pr create --base main --title "feat: phase 2e.2 — streak shield (Ultra perk + auto-protect)" --body "..."
+```
+
+PR body: summarize lazy refill, atomic tryUseShield via transaction, streak compute merging protected dates, sessions hook. Reference spec.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- ✅ Schema (columns + CHECK + table + indexes) → Task 2
+- ✅ `MAX_STREAK_SHIELDS = 3` constant + `SHIELD_REFILL_INTERVAL_MS` → Task 1
+- ✅ Lazy refill (`materializeRefill`) → Task 3
+- ✅ Atomic `tryUseShield` via transaction → Task 3
+- ✅ Streaks integration → Task 4
+- ✅ Auto-use hook → Task 5
+- ✅ `GET /users/me/shields` → Task 3
+
+**Type consistency:**
+- `tryUseShield` returns `{ used: boolean, balanceAfter: number | null }` consistently in repo + service.
+- `materializeRefill` returns `{ available, lastGrantAt, isUltraActive }` — service uses for `nextRefillAt` calc.
+- Protected dates are `YYYY-MM-DD` strings throughout (`listProtectedDates` returns strings, `tryUseShield` accepts string).
+
+**Placeholder scan:** None.
+
+**Atomicity:** `tryUseShield` is transaction-wrapped (NOT a multi-CTE) — the plan corrects an earlier exploration of CTE-based atomicity that wouldn't have worked.

--- a/docs/superpowers/plans/2026-05-12-phase-2e2-streak-shield.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e2-streak-shield.md
@@ -255,11 +255,14 @@ export class ShieldsRepository {
     return rows[0] ?? null;
   }
 
-  /** Apply lazy refill if eligible. Returns post-state. */
+  /**
+   * Apply lazy refill if eligible. Single-grant model (MAX=1, per spec v2): an
+   * Ultra-active user with 0 shields and either a NULL anchor or anchor >= 30d
+   * old gets exactly 1 shield. Race-safe via conditional UPDATE.
+   */
   async materializeRefill(
     userId: string,
     now: Date,
-    intervalMs: number,
   ): Promise<{ available: number; lastGrantAt: Date | null; isUltraActive: boolean }> {
     const current = await this.getUserShieldState(userId);
     if (!current) return { available: 0, lastGrantAt: null, isUltraActive: false };
@@ -267,31 +270,29 @@ export class ShieldsRepository {
     if (!ultraActive) {
       return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: false };
     }
-    let available = current.streakShieldsAvailable;
-    let lastGrant = current.lastShieldGrantAt;
-    if (available >= MAX_STREAK_SHIELDS) {
-      return { available, lastGrantAt: lastGrant, isUltraActive: true };
+    if (current.streakShieldsAvailable >= MAX_STREAK_SHIELDS) {
+      return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: true };
     }
-    let ticks = 0;
-    if (lastGrant === null) {
-      ticks = 1;
-      lastGrant = now;
-    } else {
-      const elapsed = now.getTime() - lastGrant.getTime();
-      ticks = Math.max(0, Math.floor(elapsed / intervalMs));
-      if (ticks > 0) {
-        lastGrant = new Date(lastGrant.getTime() + ticks * intervalMs);
-      }
+    const eligible = current.lastShieldGrantAt === null
+      || now.getTime() - current.lastShieldGrantAt.getTime() >= SHIELD_REFILL_INTERVAL_MS;
+    if (!eligible) {
+      return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: true };
     }
-    if (ticks === 0) {
-      return { available, lastGrantAt: current.lastShieldGrantAt, isUltraActive: true };
-    }
-    const newAvailable = Math.min(MAX_STREAK_SHIELDS, available + ticks);
-    await this.db
+    // Race-safe conditional UPDATE: WHERE predicate re-evaluates inside row-level lock.
+    const whereConditions = current.lastShieldGrantAt === null
+      ? and(eq(user.id, userId), eq(user.streakShieldsAvailable, 0), isNull(user.lastShieldGrantAt))
+      : and(eq(user.id, userId), eq(user.streakShieldsAvailable, 0), lt(user.lastShieldGrantAt, new Date(now.getTime() - SHIELD_REFILL_INTERVAL_MS)));
+    const updated = await this.db
       .update(user)
-      .set({ streakShieldsAvailable: newAvailable, lastShieldGrantAt: lastGrant })
-      .where(eq(user.id, userId));
-    return { available: newAvailable, lastGrantAt: lastGrant, isUltraActive: true };
+      .set({ streakShieldsAvailable: 1, lastShieldGrantAt: now })
+      .where(whereConditions)
+      .returning({ available: user.streakShieldsAvailable, lastGrantAt: user.lastShieldGrantAt });
+    if (updated.length === 0) {
+      // Concurrent grant won. Re-read.
+      const fresh = await this.getUserShieldState(userId);
+      return { available: fresh?.streakShieldsAvailable ?? 0, lastGrantAt: fresh?.lastShieldGrantAt ?? null, isUltraActive: true };
+    }
+    return { available: updated[0]!.available, lastGrantAt: updated[0]!.lastGrantAt, isUltraActive: true };
   }
 
   /** Atomic decrement + insert. Returns success if both occurred. */
@@ -384,12 +385,13 @@ export class ShieldsService {
 
   async getBalance(userId: string): Promise<Result<{ available: number; maxAvailable: number; nextRefillAt: string | null }, AppError>> {
     const now = new Date();
-    const state = await this.repo.materializeRefill(userId, now, SHIELD_REFILL_INTERVAL_MS);
+    const state = await this.repo.materializeRefill(userId, now);
     let nextRefillAt: Date | null = null;
     if (state.isUltraActive && state.available < MAX_STREAK_SHIELDS && state.lastGrantAt) {
       nextRefillAt = new Date(state.lastGrantAt.getTime() + SHIELD_REFILL_INTERVAL_MS);
     } else if (state.isUltraActive && state.available < MAX_STREAK_SHIELDS && !state.lastGrantAt) {
-      // Edge: Ultra user who somehow has no last_shield_grant_at — eligible immediately.
+      // Edge: Ultra user with NULL last_shield_grant_at but materializeRefill didn't grant
+      // (concurrent grant lost the race). nextRefillAt = now is the truthful answer.
       nextRefillAt = now;
     }
     return ok({
@@ -401,7 +403,7 @@ export class ShieldsService {
 
   async tryUseShield(userId: string, protectedDate: string): Promise<{ used: boolean; balanceAfter: number | null }> {
     // Materialize refill first so eligible Ultra users have access to a freshly-granted shield.
-    await this.repo.materializeRefill(userId, new Date(), SHIELD_REFILL_INTERVAL_MS);
+    await this.repo.materializeRefill(userId, new Date());
     return this.repo.tryUseShield(userId, protectedDate);
   }
 }
@@ -441,26 +443,29 @@ Register `shieldsRoutes` alongside `ultraRoutes`/`rankingRoutes`/etc.
 
 - [ ] **Step 5: Unit tests `shields.service.test.ts`**
 
-Cover:
+Cover (MAX = 1, single-grant semantics):
 - Non-Ultra user: balance returns `{ available: 0, nextRefillAt: null }`.
-- Ultra user, no prior grant: refill applies; `available = 1`; `nextRefillAt = now + 30d`.
-- Ultra user, 60 days since last grant, 0 shields: refill applies 2 ticks; `available = 2`.
-- Ultra user, 100 days since last grant, 1 shield: cap at MAX (3), `available = 3`, `nextRefillAt = null` (at cap).
-- Ultra user, 5 days since last grant, 1 shield: no refill (interval not elapsed); `available = 1`.
+- Ultra user, NULL `lastShieldGrantAt`: refill grants 1; response has `available: 1`, `nextRefillAt: null` (at cap).
+- Ultra user with 0 shields, last grant 31d ago: refill grants 1; `available: 1`, `nextRefillAt: null` (at cap).
+- Ultra user with 0 shields, last grant 5d ago: NO refill; `available: 0`, `nextRefillAt = lastGrant + 30d`.
+- Ultra user already at 1 shield (regardless of last grant age): no refill; `available: 1`, `nextRefillAt: null`.
 - `tryUseShield` happy path: returns `{ used: true, balanceAfter: 0 }`.
 - `tryUseShield` no shields: returns `{ used: false, balanceAfter: null }`.
 - `tryUseShield` already-protected: returns `{ used: false, balanceAfter: null }`.
 
 - [ ] **Step 6: Integration tests `shields.repository.integration.test.ts`**
 
-Cover:
+Cover (MAX = 1, single-grant semantics):
 - `tryUseShield` with shields=1: decrement to 0, insert usage row, return `{ used: true, balanceAfter: 0 }`.
 - `tryUseShield` with shields=0: returns `{ used: false, balanceAfter: null }`. No usage row inserted.
-- `tryUseShield` for already-protected date: returns `{ used: false, balanceAfter: null }`. Shields count NOT decremented (transaction rolled back).
-- CHECK constraint: direct UPDATE attempting `streak_shields_available = -1` rejected. `streak_shields_available = 4` rejected.
-- `materializeRefill` for Ultra user with NULL last_grant: applies 1 tick, sets last_grant_at = now.
-- `materializeRefill` for Ultra user with stale (90 days ago) last_grant: applies 3 ticks (capped at MAX), advances last_grant_at by 3 * interval.
-- `listProtectedDates` returns sorted ISO date strings.
+- `tryUseShield` for already-protected date: returns `{ used: false, balanceAfter: null }`. Shields count NOT decremented (verify with follow-up SELECT — transaction rolled back).
+- CHECK constraint: direct UPDATE attempting `streak_shields_available = -1` rejected. `streak_shields_available = 2` rejected.
+- `materializeRefill` for Ultra user with NULL last_grant: grants 1 shield, sets last_grant_at = now.
+- `materializeRefill` for Ultra user with stale (40 days ago) last_grant and 0 shields: grants 1 shield, sets last_grant_at = now.
+- `materializeRefill` for Ultra user with 1 shield already (regardless of stale grant): NO-op.
+- `materializeRefill` for non-Ultra user: NO-op.
+- `materializeRefill` for Ultra user with 5d-old grant and 0 shields: NO-op (interval not elapsed).
+- `listProtectedDates` returns ISO date strings.
 
 - [ ] **Step 7: Run + commit**
 

--- a/docs/superpowers/specs/2026-05-12-phase-2e2-streak-shield-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e2-streak-shield-design.md
@@ -1,21 +1,23 @@
-# Phase 2E.2 — Streak Shield (Design Spec)
+# Phase 2E.2 — Streak Shield (Design Spec, v2)
 
 **Date:** 2026-05-12
 **Phase:** 2E.2 (follow-up to 2E.1 Ultra entitlement)
 **Source spec:** `pruvi-freatures.md` §5.3 *"Escudo de streak — protege o streak em 1 dia que o usuário não conseguiu treinar. Pode ser usado 1x. Comprável avulso ou incluso no Ultra."*
 
+**Revision note:** v1 of this spec set `MAX_STREAK_SHIELDS = 3` with tick-based monthly accumulation. Self-review caught that this contradicts `pruvi-freatures.md` §5.3 line 307: *"Máximo de 1 escudo ativo por vez — não acumula."* Corrected here to MAX = 1 (binary stock). Self-review also flagged broken atomicity in the original CTE-based `tryUseShield`; this v2 mandates an explicit transaction with `SELECT … FOR UPDATE` for the user row.
+
 ## Goal
 
-Ship the streak-shield mechanic: Ultra users accumulate up to 3 shields, one per month (lazy refill on read). When a user completes a session after a 1-day gap and has shields available, one is auto-consumed to protect the missed day, preserving the current streak. Free users have 0 shields; purchase (§2E.4 billing) is out of scope here.
+Ultra users have at most 1 streak shield in stock. The shield refills monthly (on lazy read, 30 days since last grant). When a user completes a session after a 1-day gap and has the shield available, it's auto-consumed to protect the missed day, preserving the streak. Free users have 0 shields by default (the referral-reward path that grants a shield is defined in §4.2 but its implementation is deferred — see Non-goals).
 
 ## Non-goals
 
-- **Purchase a shield** (out of MVP — depends on 2E.4 billing webhooks).
-- **Manual "use shield now" endpoint** — shields auto-protect on session-complete. Manual use is not required by spec.
-- **Shield notification** ("Saved your streak with a shield!") — frontend can render based on `transitions` returned from `completeSession`. No new push channel.
-- **Recover-streak-after-break flow** — once a streak is fully broken (≥ 2 missed days), no recovery. One shield = one missed day only.
-- **Shield-balance UI for free users** — frontend will show "0 / get Ultra to unlock" but backend just returns 0.
-- **Per-user `max_shields` override** — fixed at `MAX_STREAK_SHIELDS = 3` for Ultra.
+- **Purchase a shield** (depends on 2E.4 billing webhooks).
+- **Referral-reward shield grant** — §4.2 says invite acceptance rewards "+100 XP **ou** 1 escudo de streak." Current invitation flow (Phase 2D) only awards +100 XP. Adding the shield-grant alternative is deferred to a small follow-up; the schema here supports it (just write to `streak_shields_available`).
+- **Manual "use shield now" endpoint** — shields auto-protect on session-complete. Spec §5.3 says "Escudo ativado automaticamente."
+- **Recover-from-2+-day-break** — once the streak is fully broken (≥ 2 missed days), no recovery. One shield = one missed day only (matches "Pode ser usado 1x").
+- **Billing-cycle alignment** — refill is time-based (rolling 30 days from last grant). The product doc says "na renovação" (on renewal); aligning refill timing with the billing renewal date is deferred to 2E.4 when real billing webhooks land.
+- **Push notification on shield consumption** — "Notificação no dia seguinte: *'Seu escudo protegeu seu streak de X dias!'*" is in §5.3. Implementing this requires a per-day cron or hooking the next-day session — deferred to a small follow-up. For MVP, the streak just stays intact and the frontend infers from the next `getStreaks` result.
 
 ## Mechanic
 
@@ -24,38 +26,42 @@ Ship the streak-shield mechanic: Ultra users accumulate up to 3 shields, one per
 Current streak today = consecutive completed-or-protected days ending today (or yesterday).
 
 A user who:
-- Completed Monday, Tuesday
-- Missed Wednesday
-- Completes Thursday with 1 shield available
-→ Shield auto-protects Wednesday. Streak = 4 (Mon, Tue, Wed-protected, Thu).
+- Completed Mon, Tue
+- Missed Wed
+- Completes Thu with shield available
+→ Shield auto-protects Wed. Streak = 4 (Mon, Tue, Wed-protected, Thu).
 
 A user who:
-- Completed Monday
-- Missed Tuesday, Wednesday
-- Completes Thursday with 2 shields available
-→ Spec says "Pode ser usado 1x" (one use, per missed day). MVP: only protect a single 1-day gap. If gap > 1 day, streak is broken regardless of shields available. Shields are NOT consumed in this case.
+- Completed Mon
+- Missed Tue, Wed
+- Completes Thu with shield available
+→ Gap of 2 days. Shield is NOT consumed. Streak = 1 (just Thu).
 
-### Lazy monthly refill
+### Lazy monthly refill (single-grant model)
 
 When `getBalance` or `tryUseShield` is called:
-1. Read `user.streak_shields_available` and `user.last_shield_grant_at`.
-2. If user is Ultra-active AND `(last_shield_grant_at IS NULL OR now - last_shield_grant_at >= 30 days)` AND `streak_shields_available < MAX_STREAK_SHIELDS`:
-   - Increment shields by 1, set `last_shield_grant_at = now`.
-   - Repeat if multiple intervals have elapsed (cap at 3).
+1. Read user's shield + Ultra columns.
+2. Compute Ultra-active = `is_ultra && (ultra_expires_at IS NULL OR ultra_expires_at > now)` (same predicate as `LivesRepository`).
+3. If Ultra-active AND `streak_shields_available = 0` AND `(last_shield_grant_at IS NULL OR now - last_shield_grant_at >= 30 days)`:
+   - Grant 1 shield. Set `last_shield_grant_at = now`.
+4. Return the materialized state.
 
-Compute-on-read means no cron required. Acceptable because shield balance is only read on session-complete and explicit balance queries.
+No tick loop — a stale Ultra user gets exactly 1 shield on first read, not multiple. The next eligible refill is 30 days after the new `last_shield_grant_at`.
+
+**Race:** two concurrent calls could both pass the `streak_shields_available = 0` check and both grant. Mitigated by using a single conditional UPDATE: `UPDATE user SET streak_shields_available = 1, last_shield_grant_at = $now WHERE id = $userId AND streak_shields_available = 0 AND ($lastGrant condition)`. The predicate runs inside the row-update lock; only the first concurrent UPDATE matches and modifies, the second observes `streak_shields_available = 1` and matches zero rows.
 
 ### Auto-use trigger
 
 `sessions.completeSession` hook (fire-and-forget after the session row is marked completed):
 
-1. Find the user's previous completed session date (most recent before today).
-2. If `today - prev = 2 days` (exactly one missed day yesterday):
-   - Try `ShieldsService.tryUseShield(userId, yesterday)`.
-   - On success: log the protection. Frontend will see the next `getStreaks` call return the preserved streak.
-3. If `today - prev != 2 days`, do nothing.
+1. Read the user's 2 most recent completed-session dates (newest first; today is allDates[0]).
+2. If `allDates[0] === today` and `allDates[1]` exists and `(today - allDates[1]).days === 2`:
+   - `await shieldsService.tryUseShield(userId, yesterdayDateString)`.
+3. Otherwise, no-op.
 
-The hook is fire-and-forget: a missing-shield UX glitch is preferable to a regression on session-complete.
+The hook fires after the streaks-service / dispatcher hooks already in `completeSession`.
+
+**Timezone:** "today" is computed in `America/Sao_Paulo` (BRT, UTC-3, no DST). This matches Phase 2D's `startOfWeekBrt` helper. New helper `todayInBrt(now): string` returns `YYYY-MM-DD`. The streaks repo's `getCompletedSessionDates` MUST return BRT-local dates (using `created_at AT TIME ZONE … ::date`) AND MUST return distinct dates (one row per calendar day, not per session) — confirm with `DISTINCT` or `GROUP BY` on the date expression. Without distinctness, two same-day sessions would yield `allDates = ['today', 'today']`, breaking the gap-detection math. Verify before wiring the hook; if missing, fix the query in the same task.
 
 ## Data model
 
@@ -64,7 +70,7 @@ The hook is fire-and-forget: a missing-shield UX glitch is preferable to a regre
 ```sql
 + streak_shields_available  integer NOT NULL DEFAULT 0
 + last_shield_grant_at      timestamp
-+ CHECK (streak_shields_available >= 0 AND streak_shields_available <= 3)
++ CHECK (streak_shields_available >= 0 AND streak_shields_available <= 1)
 ```
 
 ### New table: `streak_shield_usage`
@@ -80,15 +86,15 @@ CREATE UNIQUE INDEX streak_shield_usage_user_date_idx ON streak_shield_usage (us
 CREATE INDEX streak_shield_usage_user_idx ON streak_shield_usage (user_id);
 ```
 
-`UNIQUE(user_id, protected_date)` prevents double-protecting the same date (idempotency). The unique index also serves the streak-compute query: "all protected dates for user X".
+The UNIQUE index prevents double-protecting the same date (idempotency).
 
 ## Architecture
 
-### Shared constants
+### Shared constants + schemas
 
 ```typescript
 // packages/shared/src/shields.ts
-export const MAX_STREAK_SHIELDS = 3;
+export const MAX_STREAK_SHIELDS = 1;
 export const SHIELD_REFILL_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
 
 export const ShieldBalanceResponseSchema = z.object({
@@ -96,101 +102,144 @@ export const ShieldBalanceResponseSchema = z.object({
   maxAvailable: z.literal(MAX_STREAK_SHIELDS),
   nextRefillAt: z.string().datetime().nullable(),
 });
+export type ShieldBalanceResponse = z.infer<typeof ShieldBalanceResponseSchema>;
+
+export const ShieldUseResultSchema = z.object({
+  used: z.boolean(),
+  balanceAfter: z.number().int().nullable(),
+});
+export type ShieldUseResult = z.infer<typeof ShieldUseResultSchema>;
+
+// BRT day helper — moved here from streaks (or added if missing)
+export function todayInBrt(now: Date): string {
+  const brtMs = now.getTime() - 3 * 60 * 60 * 1000;
+  return new Date(brtMs).toISOString().slice(0, 10);
+}
 ```
 
 ### Feature module
 
 ```
 apps/server/src/features/shields/
-  shields.repository.ts        # getUserShieldState, materializeRefill, tryUseShield (atomic), listProtectedDates
-  shields.service.ts           # getBalance, tryUseShield (with refill side-effect)
+  shields.repository.ts        # getUserShieldState, materializeRefill, tryUseShield, listProtectedDates
+  shields.service.ts           # getBalance, tryUseShield (after materializeRefill side-effect)
   shields.route.ts             # GET /users/me/shields
   shields.service.test.ts
   shields.repository.integration.test.ts
 ```
 
-### `ShieldsRepository.tryUseShield` atomicity
-
-```sql
--- Atomic: only succeed if available > 0 AND no protection already exists for that date
-WITH decrement AS (
-  UPDATE "user"
-  SET streak_shields_available = streak_shields_available - 1
-  WHERE id = $userId AND streak_shields_available > 0
-  RETURNING streak_shields_available
-),
-insertion AS (
-  INSERT INTO streak_shield_usage (user_id, protected_date)
-  VALUES ($userId, $protectedDate)
-  ON CONFLICT (user_id, protected_date) DO NOTHING
-  RETURNING id
-)
-SELECT
-  (SELECT streak_shields_available FROM decrement) AS new_balance,
-  (SELECT id FROM insertion) AS usage_id;
-```
-
-If `decrement` returns no row (no shields) OR `insertion` conflicts (already protected), the transaction rolls back. Service-layer treats either case as "shield not consumed".
-
-**Race-free:** the entire CTE is one statement. Two concurrent calls cannot both decrement to a negative balance — the `WHERE … > 0` predicate runs inside the row lock.
-
-### `ShieldsRepository.materializeRefill`
-
-Read user shields + ultra columns + last_shield_grant_at + now. Compute how many refill ticks have elapsed (`Math.floor((now - last_grant) / 30days)`), capped at `MAX - current`. If `> 0` AND user is Ultra-active, issue a single UPDATE that increments shields and sets `last_shield_grant_at` forward by `ticks * 30 days`. Idempotent.
-
-### Streak service integration
-
-`StreaksService.getStreaks` adds a third data source: protected dates from `streak_shield_usage`. Algorithm:
+### `ShieldsRepository.materializeRefill` (race-safe)
 
 ```typescript
-const [completedDates, protectedDates] = await Promise.all([
-  repo.getCompletedSessionDates(userId),
-  shieldsRepo.listProtectedDates(userId),
-]);
-const allDates = Array.from(new Set([...completedDates, ...protectedDates])).sort().reverse();
-const { currentStreak, longestStreak } = computeStreaks(allDates);
-```
-
-Both date arrays are `YYYY-MM-DD` strings — Set dedup is correct.
-
-### Auto-use hook in `sessions.completeSession`
-
-Fire-and-forget after `repo.completeSession` succeeds:
-
-```typescript
-if (this.shieldsService) {
-  void this.maybeProtectMissedDay(userId).catch((e) =>
-    this.logger?.error({ err: e, userId }, "shield auto-use failed"),
-  );
+async materializeRefill(userId: string, now: Date): Promise<{ available: number; lastGrantAt: Date | null; isUltraActive: boolean }> {
+  const current = await this.getUserShieldState(userId);
+  if (!current) return { available: 0, lastGrantAt: null, isUltraActive: false };
+  const ultraActive = current.isUltra && (!current.ultraExpiresAt || current.ultraExpiresAt > now);
+  if (!ultraActive) {
+    return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: false };
+  }
+  if (current.streakShieldsAvailable >= MAX_STREAK_SHIELDS) {
+    return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: true };
+  }
+  const eligible = current.lastShieldGrantAt === null
+    || now.getTime() - current.lastShieldGrantAt.getTime() >= SHIELD_REFILL_INTERVAL_MS;
+  if (!eligible) {
+    return { available: current.streakShieldsAvailable, lastGrantAt: current.lastShieldGrantAt, isUltraActive: true };
+  }
+  // Conditional UPDATE — race-safe via predicate-in-update.
+  const updated = await this.db
+    .update(user)
+    .set({ streakShieldsAvailable: 1, lastShieldGrantAt: now })
+    .where(
+      and(
+        eq(user.id, userId),
+        eq(user.streakShieldsAvailable, 0),
+        // Re-check eligibility predicate
+        current.lastShieldGrantAt === null
+          ? isNull(user.lastShieldGrantAt)
+          : lt(user.lastShieldGrantAt, new Date(now.getTime() - SHIELD_REFILL_INTERVAL_MS)),
+      )
+    )
+    .returning({ available: user.streakShieldsAvailable, lastGrantAt: user.lastShieldGrantAt });
+  if (updated.length === 0) {
+    // Concurrent grant won. Re-read to return current state.
+    const fresh = await this.getUserShieldState(userId);
+    return { available: fresh?.streakShieldsAvailable ?? 0, lastGrantAt: fresh?.lastShieldGrantAt ?? null, isUltraActive: true };
+  }
+  return { available: updated[0]!.available, lastGrantAt: updated[0]!.lastGrantAt, isUltraActive: true };
 }
 ```
 
-`maybeProtectMissedDay`:
-1. Query `streaks.repository.getCompletedSessionDates(userId)` for the user's last 2 completed dates (today is first).
-2. If `allDates[0] === today` and `allDates[1]` exists and `(today - allDates[1]).days === 2`:
-   - `await shieldsService.tryUseShield(userId, yesterdayDateString)`.
+### `ShieldsRepository.tryUseShield` (transaction-wrapped)
 
-Important: this hook only fires on session-complete; the streak-protect happens at *use* time, not at *break* time. A user who misses 2+ days never triggers the hook.
+```typescript
+async tryUseShield(userId: string, protectedDate: string): Promise<{ used: boolean; balanceAfter: number | null }> {
+  try {
+    return await this.db.transaction(async (tx) => {
+      // 1. Decrement only if shields > 0.
+      const dec = await tx
+        .update(user)
+        .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} - 1` })
+        .where(and(eq(user.id, userId), gt(user.streakShieldsAvailable, 0)))
+        .returning({ available: user.streakShieldsAvailable });
+      if (dec.length === 0) return { used: false, balanceAfter: null };
+
+      // 2. Insert protection row. UNIQUE conflict → throw so the transaction rolls back the decrement.
+      try {
+        await tx.insert(streakShieldUsage).values({ userId, protectedDate });
+      } catch (e) {
+        throw new Error("ALREADY_PROTECTED");
+      }
+      return { used: true, balanceAfter: dec[0]!.available };
+    });
+  } catch (e) {
+    if (e instanceof Error && e.message === "ALREADY_PROTECTED") {
+      return { used: false, balanceAfter: null };
+    }
+    throw e;
+  }
+}
+```
+
+The transaction guarantees: either both the decrement and the insert commit, OR neither does. The UNIQUE constraint catches double-protection deterministically.
+
+### Streak service integration
+
+`StreaksService.getStreaks` merges protected dates into completed-dates set:
+
+```typescript
+const [completedDates, protectedDates] = await Promise.all([
+  this.repo.getCompletedSessionDates(userId),
+  this.shieldsRepo?.listProtectedDates(userId) ?? Promise.resolve([] as string[]),
+]);
+const allDates = Array.from(new Set([...completedDates, ...protectedDates])).sort().reverse();
+```
+
+`totalSessions` still uses `countCompletedSessions` — protected dates do NOT count as sessions.
+
+### Auto-use hook in `sessions.completeSession`
+
+Fire-and-forget after the session row commits. Uses `todayInBrt(now)` for date comparison. See "Auto-use trigger" above.
 
 ## API surface
 
 ### `GET /users/me/shields`
 
-Auth-required.
-
-Materializes refill (Ultra users) before returning. Response:
+Auth-required. Materializes refill before returning.
 
 ```json
-{
-  "available": 2,
-  "maxAvailable": 3,
-  "nextRefillAt": "2026-06-12T15:00:00.000Z"
-}
+{ "available": 1, "maxAvailable": 1, "nextRefillAt": null }
 ```
 
-`nextRefillAt` = `last_shield_grant_at + 30 days` if user is Ultra and not at cap. Null when `available === maxAvailable` OR user is not Ultra. Frontend renders countdown or "earn Ultra to start refilling".
+`nextRefillAt` semantics:
+- `null` when `available === maxAvailable` (already at cap)
+- `null` when user is not Ultra-active AND `available === 0` (no refill source)
+- `last_shield_grant_at + 30 days` when Ultra-active AND `available === 0` AND `last_shield_grant_at` is set
+- `now` when Ultra-active AND `available === 0` AND `last_shield_grant_at` is null (eligible immediately, but materializeRefill should have just granted — this branch only reachable if non-Ultra-aware race)
 
 Cached: `shields:{userId}` 60s. Invalidated on auto-use.
+
+**Free-user note:** if a free user receives a shield via the (deferred) referral path, the endpoint reads the raw `streak_shields_available` column. The endpoint does NOT hard-code 0 for non-Ultra users — it reflects DB state. `nextRefillAt` is null for non-Ultra users regardless of available count.
 
 ## Migration `0008_<name>.sql`
 
@@ -202,7 +251,7 @@ ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "last_shield_grant_at" timestamp;
 DO $$ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_streak_shields_chk') THEN
     ALTER TABLE "user" ADD CONSTRAINT "user_streak_shields_chk"
-      CHECK ("streak_shields_available" >= 0 AND "streak_shields_available" <= 3);
+      CHECK ("streak_shields_available" >= 0 AND "streak_shields_available" <= 1);
   END IF;
 END $$;
 --> statement-breakpoint
@@ -220,66 +269,64 @@ CREATE INDEX IF NOT EXISTS "streak_shield_usage_user_idx" ON "streak_shield_usag
 
 PGlite mirror in `test-client.ts`.
 
-## Shared schemas
-
-`packages/shared/src/shields.ts`:
-- `MAX_STREAK_SHIELDS = 3`
-- `SHIELD_REFILL_INTERVAL_MS`
-- `ShieldBalanceResponseSchema`
-
 ## Testing strategy
 
 ### Unit (Vitest)
 
 - `shields.service.test.ts`:
-  - `getBalance` for non-Ultra user → `available: 0, nextRefillAt: null`
-  - `getBalance` for Ultra user with stale `last_shield_grant_at` → refill applied, balance increases
-  - `getBalance` materializes max 3 ticks at once (months-of-stale)
-  - `tryUseShield` happy path → returns `{ used: true, balanceAfter }`
-  - `tryUseShield` no-shields → `{ used: false }`
-  - `tryUseShield` already-protected → `{ used: false }`
+  - `getBalance` non-Ultra user → `{ available: 0, nextRefillAt: null }`.
+  - `getBalance` Ultra user, no prior grant → 1 shield granted, `nextRefillAt = now + 30d`.
+  - `getBalance` Ultra user, 31 days since grant, 0 shields → 1 shield granted, `nextRefillAt` set.
+  - `getBalance` Ultra user, 5 days since grant, 0 shields → no refill, `nextRefillAt` is `old + 30d`.
+  - `getBalance` Ultra user with 1 shield → `nextRefillAt: null` (at cap).
+  - `tryUseShield` happy path → `{ used: true, balanceAfter: 0 }`.
+  - `tryUseShield` no shields → `{ used: false, balanceAfter: null }`.
+  - `tryUseShield` already-protected → `{ used: false, balanceAfter: null }` and (verified at integration layer) balance unchanged.
 
 - `streaks.service.test.ts`:
-  - With protected dates merged into completed-dates, streak continues across a 1-day gap.
-  - Without protected dates, gap breaks streak (regression check).
+  - Protected dates merge into completed-dates set → 1-day gap preserved.
+  - Without protected dates, same scenario gives shorter streak (regression check).
 
 - `sessions.service.test.ts`:
-  - Auto-use hook fires when previous-completed = 2 days ago AND shieldsService is injected.
-  - Hook does NOT fire when prev = 1 day ago (no missed day) or prev = 3+ days ago (gap too large).
-  - Fire-and-forget: if `tryUseShield` rejects, `completeSession` still returns `ok`.
+  - Hook fires when prev-completed = 2 days ago (BRT-relative) AND shieldsService injected.
+  - Hook does NOT fire for gap = 1 day or gap = 3+ days.
+  - No-`shieldsService` constructor: no error.
+  - Fire-and-forget: dispatcher rejection doesn't fail `completeSession`.
 
-### Integration (PGlite + real Postgres test DB)
+### Integration (real Postgres test DB)
 
 - `shields.repository.integration.test.ts`:
-  - `tryUseShield` atomicity: only succeeds when shields > 0; `streak_shields_available` decremented; usage row inserted.
-  - Double-call with same `protectedDate`: second call returns no usage_id (UNIQUE conflict).
-  - Cannot decrement below 0 (CHECK constraint).
-  - `materializeRefill` applies N ticks at once.
-
-- `streaks.repository.integration.test.ts` (extend):
-  - `getCompletedSessionDates` unchanged; verify shields data is queried separately.
+  - `tryUseShield` happy path: balance = 1 → 0, usage row inserted.
+  - `tryUseShield` already-protected: returns `{ used: false }`. Balance is UNCHANGED post-rollback (verify via follow-up SELECT).
+  - `tryUseShield` no shields: returns `{ used: false }`. No usage row inserted.
+  - CHECK constraint: direct UPDATE setting `streak_shields_available = -1` or `= 2` is rejected.
+  - `materializeRefill` for Ultra user with NULL last_grant: grants 1 shield, sets last_grant_at = now.
+  - `materializeRefill` for Ultra user already at 1 shield: no-op.
+  - `materializeRefill` for non-Ultra user: no-op.
+  - `listProtectedDates` returns ISO date strings sorted.
+  - `materializeRefill` race: two concurrent calls — only one grants (verified by post-state). PGlite is single-process; the test runs them sequentially and asserts the second call observes the freshly-granted state.
 
 ## Acceptance criteria
 
-- Migration `0008` applies cleanly + `verify:migration` passes
-- `user.streak_shields_available` + `user.last_shield_grant_at` columns + CHECK constraint
-- `streak_shield_usage` table + UNIQUE(user_id, protected_date) index
-- `ShieldsService.getBalance` lazy-refills for Ultra users
-- `ShieldsService.tryUseShield` atomic decrement + insert in one SQL
-- `StreaksService.getStreaks` reads protected dates as completed
-- `sessions.completeSession` fire-and-forget hook auto-uses shield on 1-day gap
-- `GET /users/me/shields` endpoint live
-- All existing tests pass; new tests cover edge cases above
-- `pnpm --filter server check-types` clean for production code
-- Worker boots clean (no changes to worker layer)
+- Migration `0008` applies cleanly + `verify:migration` passes.
+- `user.streak_shields_available` (0..1) + `user.last_shield_grant_at` + CHECK.
+- `streak_shield_usage` table + UNIQUE(user_id, protected_date).
+- `ShieldsService.getBalance` lazy-grants for eligible Ultra users.
+- `ShieldsService.tryUseShield` transaction-wrapped, atomic, idempotent on already-protected.
+- `StreaksService.getStreaks` reads protected dates as completed.
+- `sessions.completeSession` fire-and-forget hook auto-uses shield on 1-day BRT gap.
+- `GET /users/me/shields` returns balance + nextRefillAt per the rules above.
+- All existing tests pass; new tests cover edge cases.
+- `pnpm --filter server check-types` clean for production code.
+- Worker boots clean (regression check).
 
-## Deferred
+## Deferred (explicit follow-ups)
 
-- **Shield purchase via billing** → 2E.4 (Google Play / App Store webhooks).
-- **Streak-break recovery for ≥2 missed days** → product decision, likely never (pure-protection model is simpler).
-- **Push notification when shield is consumed** → optional polish.
-- **Per-user max shields override** → not in spec.
+- **Shield purchase via billing** → 2E.4.
+- **Referral-reward shield grant alternative (§4.2)** → small follow-up.
+- **"Shield protected your streak" push notification (§5.3)** → small follow-up.
+- **Billing-cycle-aligned refill timing** → 2E.4.
 
 ---
 
-*End of spec.*
+*End of spec v2.*

--- a/docs/superpowers/specs/2026-05-12-phase-2e2-streak-shield-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e2-streak-shield-design.md
@@ -1,0 +1,285 @@
+# Phase 2E.2 — Streak Shield (Design Spec)
+
+**Date:** 2026-05-12
+**Phase:** 2E.2 (follow-up to 2E.1 Ultra entitlement)
+**Source spec:** `pruvi-freatures.md` §5.3 *"Escudo de streak — protege o streak em 1 dia que o usuário não conseguiu treinar. Pode ser usado 1x. Comprável avulso ou incluso no Ultra."*
+
+## Goal
+
+Ship the streak-shield mechanic: Ultra users accumulate up to 3 shields, one per month (lazy refill on read). When a user completes a session after a 1-day gap and has shields available, one is auto-consumed to protect the missed day, preserving the current streak. Free users have 0 shields; purchase (§2E.4 billing) is out of scope here.
+
+## Non-goals
+
+- **Purchase a shield** (out of MVP — depends on 2E.4 billing webhooks).
+- **Manual "use shield now" endpoint** — shields auto-protect on session-complete. Manual use is not required by spec.
+- **Shield notification** ("Saved your streak with a shield!") — frontend can render based on `transitions` returned from `completeSession`. No new push channel.
+- **Recover-streak-after-break flow** — once a streak is fully broken (≥ 2 missed days), no recovery. One shield = one missed day only.
+- **Shield-balance UI for free users** — frontend will show "0 / get Ultra to unlock" but backend just returns 0.
+- **Per-user `max_shields` override** — fixed at `MAX_STREAK_SHIELDS = 3` for Ultra.
+
+## Mechanic
+
+### Streak math with shields
+
+Current streak today = consecutive completed-or-protected days ending today (or yesterday).
+
+A user who:
+- Completed Monday, Tuesday
+- Missed Wednesday
+- Completes Thursday with 1 shield available
+→ Shield auto-protects Wednesday. Streak = 4 (Mon, Tue, Wed-protected, Thu).
+
+A user who:
+- Completed Monday
+- Missed Tuesday, Wednesday
+- Completes Thursday with 2 shields available
+→ Spec says "Pode ser usado 1x" (one use, per missed day). MVP: only protect a single 1-day gap. If gap > 1 day, streak is broken regardless of shields available. Shields are NOT consumed in this case.
+
+### Lazy monthly refill
+
+When `getBalance` or `tryUseShield` is called:
+1. Read `user.streak_shields_available` and `user.last_shield_grant_at`.
+2. If user is Ultra-active AND `(last_shield_grant_at IS NULL OR now - last_shield_grant_at >= 30 days)` AND `streak_shields_available < MAX_STREAK_SHIELDS`:
+   - Increment shields by 1, set `last_shield_grant_at = now`.
+   - Repeat if multiple intervals have elapsed (cap at 3).
+
+Compute-on-read means no cron required. Acceptable because shield balance is only read on session-complete and explicit balance queries.
+
+### Auto-use trigger
+
+`sessions.completeSession` hook (fire-and-forget after the session row is marked completed):
+
+1. Find the user's previous completed session date (most recent before today).
+2. If `today - prev = 2 days` (exactly one missed day yesterday):
+   - Try `ShieldsService.tryUseShield(userId, yesterday)`.
+   - On success: log the protection. Frontend will see the next `getStreaks` call return the preserved streak.
+3. If `today - prev != 2 days`, do nothing.
+
+The hook is fire-and-forget: a missing-shield UX glitch is preferable to a regression on session-complete.
+
+## Data model
+
+### `user` extensions
+
+```sql
++ streak_shields_available  integer NOT NULL DEFAULT 0
++ last_shield_grant_at      timestamp
++ CHECK (streak_shields_available >= 0 AND streak_shields_available <= 3)
+```
+
+### New table: `streak_shield_usage`
+
+```sql
+CREATE TABLE streak_shield_usage (
+  id              serial PRIMARY KEY,
+  user_id         text NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  protected_date  date NOT NULL,
+  used_at         timestamp NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX streak_shield_usage_user_date_idx ON streak_shield_usage (user_id, protected_date);
+CREATE INDEX streak_shield_usage_user_idx ON streak_shield_usage (user_id);
+```
+
+`UNIQUE(user_id, protected_date)` prevents double-protecting the same date (idempotency). The unique index also serves the streak-compute query: "all protected dates for user X".
+
+## Architecture
+
+### Shared constants
+
+```typescript
+// packages/shared/src/shields.ts
+export const MAX_STREAK_SHIELDS = 3;
+export const SHIELD_REFILL_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const ShieldBalanceResponseSchema = z.object({
+  available: z.number().int().min(0).max(MAX_STREAK_SHIELDS),
+  maxAvailable: z.literal(MAX_STREAK_SHIELDS),
+  nextRefillAt: z.string().datetime().nullable(),
+});
+```
+
+### Feature module
+
+```
+apps/server/src/features/shields/
+  shields.repository.ts        # getUserShieldState, materializeRefill, tryUseShield (atomic), listProtectedDates
+  shields.service.ts           # getBalance, tryUseShield (with refill side-effect)
+  shields.route.ts             # GET /users/me/shields
+  shields.service.test.ts
+  shields.repository.integration.test.ts
+```
+
+### `ShieldsRepository.tryUseShield` atomicity
+
+```sql
+-- Atomic: only succeed if available > 0 AND no protection already exists for that date
+WITH decrement AS (
+  UPDATE "user"
+  SET streak_shields_available = streak_shields_available - 1
+  WHERE id = $userId AND streak_shields_available > 0
+  RETURNING streak_shields_available
+),
+insertion AS (
+  INSERT INTO streak_shield_usage (user_id, protected_date)
+  VALUES ($userId, $protectedDate)
+  ON CONFLICT (user_id, protected_date) DO NOTHING
+  RETURNING id
+)
+SELECT
+  (SELECT streak_shields_available FROM decrement) AS new_balance,
+  (SELECT id FROM insertion) AS usage_id;
+```
+
+If `decrement` returns no row (no shields) OR `insertion` conflicts (already protected), the transaction rolls back. Service-layer treats either case as "shield not consumed".
+
+**Race-free:** the entire CTE is one statement. Two concurrent calls cannot both decrement to a negative balance — the `WHERE … > 0` predicate runs inside the row lock.
+
+### `ShieldsRepository.materializeRefill`
+
+Read user shields + ultra columns + last_shield_grant_at + now. Compute how many refill ticks have elapsed (`Math.floor((now - last_grant) / 30days)`), capped at `MAX - current`. If `> 0` AND user is Ultra-active, issue a single UPDATE that increments shields and sets `last_shield_grant_at` forward by `ticks * 30 days`. Idempotent.
+
+### Streak service integration
+
+`StreaksService.getStreaks` adds a third data source: protected dates from `streak_shield_usage`. Algorithm:
+
+```typescript
+const [completedDates, protectedDates] = await Promise.all([
+  repo.getCompletedSessionDates(userId),
+  shieldsRepo.listProtectedDates(userId),
+]);
+const allDates = Array.from(new Set([...completedDates, ...protectedDates])).sort().reverse();
+const { currentStreak, longestStreak } = computeStreaks(allDates);
+```
+
+Both date arrays are `YYYY-MM-DD` strings — Set dedup is correct.
+
+### Auto-use hook in `sessions.completeSession`
+
+Fire-and-forget after `repo.completeSession` succeeds:
+
+```typescript
+if (this.shieldsService) {
+  void this.maybeProtectMissedDay(userId).catch((e) =>
+    this.logger?.error({ err: e, userId }, "shield auto-use failed"),
+  );
+}
+```
+
+`maybeProtectMissedDay`:
+1. Query `streaks.repository.getCompletedSessionDates(userId)` for the user's last 2 completed dates (today is first).
+2. If `allDates[0] === today` and `allDates[1]` exists and `(today - allDates[1]).days === 2`:
+   - `await shieldsService.tryUseShield(userId, yesterdayDateString)`.
+
+Important: this hook only fires on session-complete; the streak-protect happens at *use* time, not at *break* time. A user who misses 2+ days never triggers the hook.
+
+## API surface
+
+### `GET /users/me/shields`
+
+Auth-required.
+
+Materializes refill (Ultra users) before returning. Response:
+
+```json
+{
+  "available": 2,
+  "maxAvailable": 3,
+  "nextRefillAt": "2026-06-12T15:00:00.000Z"
+}
+```
+
+`nextRefillAt` = `last_shield_grant_at + 30 days` if user is Ultra and not at cap. Null when `available === maxAvailable` OR user is not Ultra. Frontend renders countdown or "earn Ultra to start refilling".
+
+Cached: `shields:{userId}` 60s. Invalidated on auto-use.
+
+## Migration `0008_<name>.sql`
+
+```sql
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "streak_shields_available" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "last_shield_grant_at" timestamp;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_streak_shields_chk') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_streak_shields_chk"
+      CHECK ("streak_shields_available" >= 0 AND "streak_shields_available" <= 3);
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "streak_shield_usage" (
+  "id" serial PRIMARY KEY,
+  "user_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "protected_date" date NOT NULL,
+  "used_at" timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "streak_shield_usage_user_date_idx" ON "streak_shield_usage" ("user_id", "protected_date");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "streak_shield_usage_user_idx" ON "streak_shield_usage" ("user_id");
+```
+
+PGlite mirror in `test-client.ts`.
+
+## Shared schemas
+
+`packages/shared/src/shields.ts`:
+- `MAX_STREAK_SHIELDS = 3`
+- `SHIELD_REFILL_INTERVAL_MS`
+- `ShieldBalanceResponseSchema`
+
+## Testing strategy
+
+### Unit (Vitest)
+
+- `shields.service.test.ts`:
+  - `getBalance` for non-Ultra user → `available: 0, nextRefillAt: null`
+  - `getBalance` for Ultra user with stale `last_shield_grant_at` → refill applied, balance increases
+  - `getBalance` materializes max 3 ticks at once (months-of-stale)
+  - `tryUseShield` happy path → returns `{ used: true, balanceAfter }`
+  - `tryUseShield` no-shields → `{ used: false }`
+  - `tryUseShield` already-protected → `{ used: false }`
+
+- `streaks.service.test.ts`:
+  - With protected dates merged into completed-dates, streak continues across a 1-day gap.
+  - Without protected dates, gap breaks streak (regression check).
+
+- `sessions.service.test.ts`:
+  - Auto-use hook fires when previous-completed = 2 days ago AND shieldsService is injected.
+  - Hook does NOT fire when prev = 1 day ago (no missed day) or prev = 3+ days ago (gap too large).
+  - Fire-and-forget: if `tryUseShield` rejects, `completeSession` still returns `ok`.
+
+### Integration (PGlite + real Postgres test DB)
+
+- `shields.repository.integration.test.ts`:
+  - `tryUseShield` atomicity: only succeeds when shields > 0; `streak_shields_available` decremented; usage row inserted.
+  - Double-call with same `protectedDate`: second call returns no usage_id (UNIQUE conflict).
+  - Cannot decrement below 0 (CHECK constraint).
+  - `materializeRefill` applies N ticks at once.
+
+- `streaks.repository.integration.test.ts` (extend):
+  - `getCompletedSessionDates` unchanged; verify shields data is queried separately.
+
+## Acceptance criteria
+
+- Migration `0008` applies cleanly + `verify:migration` passes
+- `user.streak_shields_available` + `user.last_shield_grant_at` columns + CHECK constraint
+- `streak_shield_usage` table + UNIQUE(user_id, protected_date) index
+- `ShieldsService.getBalance` lazy-refills for Ultra users
+- `ShieldsService.tryUseShield` atomic decrement + insert in one SQL
+- `StreaksService.getStreaks` reads protected dates as completed
+- `sessions.completeSession` fire-and-forget hook auto-uses shield on 1-day gap
+- `GET /users/me/shields` endpoint live
+- All existing tests pass; new tests cover edge cases above
+- `pnpm --filter server check-types` clean for production code
+- Worker boots clean (no changes to worker layer)
+
+## Deferred
+
+- **Shield purchase via billing** → 2E.4 (Google Play / App Store webhooks).
+- **Streak-break recovery for ≥2 missed days** → product decision, likely never (pure-protection model is simpler).
+- **Push notification when shield is consumed** → optional polish.
+- **Per-user max shields override** → not in spec.
+
+---
+
+*End of spec.*

--- a/packages/db/src/migrations/0008_known_lockjaw.sql
+++ b/packages/db/src/migrations/0008_known_lockjaw.sql
@@ -2,12 +2,12 @@ ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "streak_shields_available" integer N
 --> statement-breakpoint
 ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "last_shield_grant_at" timestamp;
 --> statement-breakpoint
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_streak_shields_chk') THEN
-    ALTER TABLE "user" ADD CONSTRAINT "user_streak_shields_chk"
-      CHECK ("streak_shields_available" >= 0 AND "streak_shields_available" <= 1);
-  END IF;
-END $$;
+-- Drop-and-recreate so the constraint reflects the current bound (per spec v2 §5.3 MAX = 1).
+-- Idempotent: IF EXISTS guard handles fresh installs.
+ALTER TABLE "user" DROP CONSTRAINT IF EXISTS "user_streak_shields_chk";
+--> statement-breakpoint
+ALTER TABLE "user" ADD CONSTRAINT "user_streak_shields_chk"
+  CHECK ("streak_shields_available" >= 0 AND "streak_shields_available" <= 1);
 --> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "streak_shield_usage" (
   "id" serial PRIMARY KEY,

--- a/packages/db/src/migrations/0008_known_lockjaw.sql
+++ b/packages/db/src/migrations/0008_known_lockjaw.sql
@@ -5,7 +5,7 @@ ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "last_shield_grant_at" timestamp;
 DO $$ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_streak_shields_chk') THEN
     ALTER TABLE "user" ADD CONSTRAINT "user_streak_shields_chk"
-      CHECK ("streak_shields_available" >= 0 AND "streak_shields_available" <= 3);
+      CHECK ("streak_shields_available" >= 0 AND "streak_shields_available" <= 1);
   END IF;
 END $$;
 --> statement-breakpoint

--- a/packages/db/src/migrations/0008_known_lockjaw.sql
+++ b/packages/db/src/migrations/0008_known_lockjaw.sql
@@ -1,0 +1,21 @@
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "streak_shields_available" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "last_shield_grant_at" timestamp;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_streak_shields_chk') THEN
+    ALTER TABLE "user" ADD CONSTRAINT "user_streak_shields_chk"
+      CHECK ("streak_shields_available" >= 0 AND "streak_shields_available" <= 3);
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "streak_shield_usage" (
+  "id" serial PRIMARY KEY,
+  "user_id" text NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "protected_date" date NOT NULL,
+  "used_at" timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "streak_shield_usage_user_date_idx" ON "streak_shield_usage" ("user_id", "protected_date");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "streak_shield_usage_user_idx" ON "streak_shield_usage" ("user_id");

--- a/packages/db/src/migrations/meta/0008_snapshot.json
+++ b/packages/db/src/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1521 @@
+{
+  "id": "05b75080-524e-4f84-b73e-25e5f3da9816",
+  "prevId": "a160ebfe-fc30-4a12-8e91-1bb147d9178d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives": {
+          "name": "lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lives_last_regen_at": {
+          "name": "lives_last_regen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "selected_exam": {
+          "name": "selected_exam",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulties": {
+          "name": "difficulties",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "daily_study_time_minutes": {
+          "name": "daily_study_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ultra": {
+          "name": "is_ultra",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ultra_expires_at": {
+          "name": "ultra_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)"
+        },
+        "notification_hour": {
+          "name": "notification_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 19
+        },
+        "streak_reminders_enabled": {
+          "name": "streak_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "achievement_notifications_enabled": {
+          "name": "achievement_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "streak_shields_available": {
+          "name": "streak_shields_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_shield_grant_at": {
+          "name": "last_shield_grant_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_session": {
+      "name": "daily_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_correct": {
+          "name": "questions_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastery_snapshot": {
+          "name": "mastery_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_session_user_created_idx": {
+          "name": "daily_session_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_session_user_id_user_id_fk": {
+          "name": "daily_session_user_id_user_id_fk",
+          "tableFrom": "daily_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "friendship_requester_idx": {
+          "name": "friendship_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendship_recipient_idx": {
+          "name": "friendship_recipient_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendship_requester_id_user_id_fk": {
+          "name": "friendship_requester_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_recipient_id_user_id_fk": {
+          "name": "friendship_recipient_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subject_name_unique": {
+          "name": "subject_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "subject_slug_unique": {
+          "name": "subject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopic": {
+      "name": "subtopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtopic_topic_order_idx": {
+          "name": "subtopic_topic_order_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopic_topic_id_topic_id_fk": {
+          "name": "subtopic_topic_id_topic_id_fk",
+          "tableFrom": "subtopic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtopic_topic_slug_uniq": {
+          "name": "subtopic_topic_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topic_subject_order_idx": {
+          "name": "topic_subject_order_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_subject_id_subject_id_fk": {
+          "name": "topic_subject_id_subject_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_subject_slug_uniq": {
+          "name": "topic_subject_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_option_index": {
+          "name": "correct_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_calculation": {
+          "name": "requires_calculation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtopic_id": {
+          "name": "subtopic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_subject_difficulty_idx": {
+          "name": "question_subject_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_subtopic_difficulty_idx": {
+          "name": "question_subtopic_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_subject_id_subject_id_fk": {
+          "name": "question_subject_id_subject_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_subtopic_id_subtopic_id_fk": {
+          "name": "question_subtopic_id_subtopic_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subtopic",
+          "columnsFrom": [
+            "subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_log": {
+      "name": "review_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "easiness_factor": {
+          "name": "easiness_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_log_user_next_review_idx": {
+          "name": "review_log_user_next_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_log_user_question_idx": {
+          "name": "review_log_user_question_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_log_user_id_user_id_fk": {
+          "name": "review_log_user_id_user_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_log_question_id_question_id_fk": {
+          "name": "review_log_question_id_question_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_token": {
+      "name": "push_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_token_user_idx": {
+          "name": "push_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_token_user_id_user_id_fk": {
+          "name": "push_token_user_id_user_id_fk",
+          "tableFrom": "push_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_token_token_unique": {
+          "name": "push_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_acceptance": {
+      "name": "invitation_acceptance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_acceptance_inviter_idx": {
+          "name": "invitation_acceptance_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_acceptance_inviter_id_user_id_fk": {
+          "name": "invitation_acceptance_inviter_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_acceptance_invitee_id_user_id_fk": {
+          "name": "invitation_acceptance_invitee_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invitee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_acceptance_invitee_id_unique": {
+          "name": "invitation_acceptance_invitee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_shield_usage": {
+      "name": "streak_shield_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protected_date": {
+          "name": "protected_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "streak_shield_usage_user_date_idx": {
+          "name": "streak_shield_usage_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protected_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "streak_shield_usage_user_idx": {
+          "name": "streak_shield_usage_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "streak_shield_usage_user_id_user_id_fk": {
+          "name": "streak_shield_usage_user_id_user_id_fk",
+          "tableFrom": "streak_shield_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778545868777,
       "tag": "0007_open_valeria_richards",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1778547463046,
+      "tag": "0008_known_lockjaw",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -30,6 +30,8 @@ export const user = pgTable("user", {
   notificationHour: integer("notification_hour").notNull().default(19),
   streakRemindersEnabled: boolean("streak_reminders_enabled").notNull().default(true),
   achievementNotificationsEnabled: boolean("achievement_notifications_enabled").notNull().default(true),
+  streakShieldsAvailable: integer("streak_shields_available").notNull().default(0),
+  lastShieldGrantAt: timestamp("last_shield_grant_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -7,3 +7,4 @@ export * from "./daily-sessions";
 export * from "./push-tokens";
 export * from "./friendship";
 export * from "./invitation-acceptance";
+export * from "./streak-shield-usage";

--- a/packages/db/src/schema/streak-shield-usage.ts
+++ b/packages/db/src/schema/streak-shield-usage.ts
@@ -1,0 +1,21 @@
+import { relations } from "drizzle-orm";
+import { date, index, pgTable, serial, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const streakShieldUsage = pgTable(
+  "streak_shield_usage",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    protectedDate: date("protected_date").notNull(),
+    usedAt: timestamp("used_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("streak_shield_usage_user_date_idx").on(table.userId, table.protectedDate),
+    index("streak_shield_usage_user_idx").on(table.userId),
+  ],
+);
+
+export const streakShieldUsageRelations = relations(streakShieldUsage, ({ one }) => ({
+  user: one(user, { fields: [streakShieldUsage.userId], references: [user.id] }),
+}));

--- a/packages/db/src/test-client.ts
+++ b/packages/db/src/test-client.ts
@@ -31,7 +31,7 @@ export async function createTestDb() {
       is_ultra BOOLEAN NOT NULL DEFAULT false,
       ultra_expires_at TIMESTAMP,
       CONSTRAINT user_ultra_expiry_chk CHECK (ultra_expires_at IS NULL OR is_ultra = true),
-      streak_shields_available INTEGER NOT NULL DEFAULT 0 CONSTRAINT user_streak_shields_chk CHECK (streak_shields_available >= 0 AND streak_shields_available <= 3),
+      streak_shields_available INTEGER NOT NULL DEFAULT 0 CONSTRAINT user_streak_shields_chk CHECK (streak_shields_available >= 0 AND streak_shields_available <= 1),
       last_shield_grant_at TIMESTAMP,
       created_at TIMESTAMP NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMP NOT NULL DEFAULT NOW()

--- a/packages/db/src/test-client.ts
+++ b/packages/db/src/test-client.ts
@@ -31,11 +31,24 @@ export async function createTestDb() {
       is_ultra BOOLEAN NOT NULL DEFAULT false,
       ultra_expires_at TIMESTAMP,
       CONSTRAINT user_ultra_expiry_chk CHECK (ultra_expires_at IS NULL OR is_ultra = true),
+      streak_shields_available INTEGER NOT NULL DEFAULT 0 CONSTRAINT user_streak_shields_chk CHECK (streak_shields_available >= 0 AND streak_shields_available <= 3),
+      last_shield_grant_at TIMESTAMP,
       created_at TIMESTAMP NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMP NOT NULL DEFAULT NOW()
     );
 
     CREATE INDEX IF NOT EXISTS "user_ultra_expiry_idx" ON "user" (ultra_expires_at) WHERE is_ultra = true;
+
+    CREATE TABLE IF NOT EXISTS "streak_shield_usage" (
+      id SERIAL PRIMARY KEY,
+      user_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+      protected_date DATE NOT NULL,
+      used_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS "streak_shield_usage_user_date_idx" ON "streak_shield_usage" (user_id, protected_date);
+
+    CREATE INDEX IF NOT EXISTS "streak_shield_usage_user_idx" ON "streak_shield_usage" (user_id);
 
     CREATE TABLE IF NOT EXISTS "session" (
       id TEXT PRIMARY KEY,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,3 +15,4 @@ export * from "./notifications";
 export * from "./social";
 export * from "./weekly";
 export * from "./ultra";
+export * from "./shields";

--- a/packages/shared/src/shields.test.ts
+++ b/packages/shared/src/shields.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { ShieldBalanceResponseSchema, MAX_STREAK_SHIELDS } from "./shields";
+
+describe("ShieldBalanceResponseSchema", () => {
+  it("accepts a valid balance", () => {
+    expect(ShieldBalanceResponseSchema.safeParse({
+      available: 2, maxAvailable: 3, nextRefillAt: "2026-06-12T00:00:00.000Z",
+    }).success).toBe(true);
+  });
+  it("accepts null nextRefillAt", () => {
+    expect(ShieldBalanceResponseSchema.safeParse({
+      available: 0, maxAvailable: 3, nextRefillAt: null,
+    }).success).toBe(true);
+  });
+  it("rejects available > MAX_STREAK_SHIELDS", () => {
+    expect(ShieldBalanceResponseSchema.safeParse({
+      available: 4, maxAvailable: 3, nextRefillAt: null,
+    }).success).toBe(false);
+  });
+  it("rejects negative available", () => {
+    expect(ShieldBalanceResponseSchema.safeParse({
+      available: -1, maxAvailable: 3, nextRefillAt: null,
+    }).success).toBe(false);
+  });
+  it("MAX_STREAK_SHIELDS = 3", () => {
+    expect(MAX_STREAK_SHIELDS).toBe(3);
+  });
+});

--- a/packages/shared/src/shields.test.ts
+++ b/packages/shared/src/shields.test.ts
@@ -1,28 +1,51 @@
 import { describe, expect, it } from "vitest";
-import { ShieldBalanceResponseSchema, MAX_STREAK_SHIELDS } from "./shields";
+import { ShieldBalanceResponseSchema, ShieldUseResultSchema, MAX_STREAK_SHIELDS, todayInBrt } from "./shields";
 
 describe("ShieldBalanceResponseSchema", () => {
-  it("accepts a valid balance", () => {
+  it("accepts a valid balance at cap", () => {
     expect(ShieldBalanceResponseSchema.safeParse({
-      available: 2, maxAvailable: 3, nextRefillAt: "2026-06-12T00:00:00.000Z",
+      available: 1, maxAvailable: 1, nextRefillAt: null,
     }).success).toBe(true);
   });
-  it("accepts null nextRefillAt", () => {
+  it("accepts a zero balance with nextRefillAt", () => {
     expect(ShieldBalanceResponseSchema.safeParse({
-      available: 0, maxAvailable: 3, nextRefillAt: null,
+      available: 0, maxAvailable: 1, nextRefillAt: "2026-06-12T00:00:00.000Z",
     }).success).toBe(true);
   });
   it("rejects available > MAX_STREAK_SHIELDS", () => {
     expect(ShieldBalanceResponseSchema.safeParse({
-      available: 4, maxAvailable: 3, nextRefillAt: null,
+      available: 2, maxAvailable: 1, nextRefillAt: null,
     }).success).toBe(false);
   });
   it("rejects negative available", () => {
     expect(ShieldBalanceResponseSchema.safeParse({
-      available: -1, maxAvailable: 3, nextRefillAt: null,
+      available: -1, maxAvailable: 1, nextRefillAt: null,
     }).success).toBe(false);
   });
-  it("MAX_STREAK_SHIELDS = 3", () => {
-    expect(MAX_STREAK_SHIELDS).toBe(3);
+  it("MAX_STREAK_SHIELDS = 1", () => {
+    expect(MAX_STREAK_SHIELDS).toBe(1);
+  });
+});
+
+describe("ShieldUseResultSchema", () => {
+  it("accepts used=true with numeric balanceAfter", () => {
+    expect(ShieldUseResultSchema.safeParse({ used: true, balanceAfter: 0 }).success).toBe(true);
+  });
+  it("accepts used=false with null balanceAfter", () => {
+    expect(ShieldUseResultSchema.safeParse({ used: false, balanceAfter: null }).success).toBe(true);
+  });
+});
+
+describe("todayInBrt", () => {
+  it("returns BRT date for noon UTC (=09:00 BRT)", () => {
+    expect(todayInBrt(new Date("2026-05-12T12:00:00Z"))).toBe("2026-05-12");
+  });
+  it("returns previous day when UTC has rolled over but BRT has not", () => {
+    // 2026-05-13 02:00 UTC = 2026-05-12 23:00 BRT
+    expect(todayInBrt(new Date("2026-05-13T02:00:00Z"))).toBe("2026-05-12");
+  });
+  it("returns same day at BRT midnight boundary", () => {
+    // 2026-05-12 03:00 UTC = 2026-05-12 00:00 BRT
+    expect(todayInBrt(new Date("2026-05-12T03:00:00Z"))).toBe("2026-05-12");
   });
 });

--- a/packages/shared/src/shields.ts
+++ b/packages/shared/src/shields.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-export const MAX_STREAK_SHIELDS = 3;
+export const MAX_STREAK_SHIELDS = 1;
+/** BRT = UTC-3, no DST (Brazil dropped DST in 2019). */
 export const SHIELD_REFILL_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
 
 export const ShieldBalanceResponseSchema = z.object({
@@ -9,3 +10,15 @@ export const ShieldBalanceResponseSchema = z.object({
   nextRefillAt: z.string().datetime().nullable(),
 });
 export type ShieldBalanceResponse = z.infer<typeof ShieldBalanceResponseSchema>;
+
+export const ShieldUseResultSchema = z.object({
+  used: z.boolean(),
+  balanceAfter: z.number().int().nullable(),
+});
+export type ShieldUseResult = z.infer<typeof ShieldUseResultSchema>;
+
+/** Returns the BRT-local YYYY-MM-DD for a given instant. */
+export function todayInBrt(now: Date): string {
+  const brtMs = now.getTime() - 3 * 60 * 60 * 1000;
+  return new Date(brtMs).toISOString().slice(0, 10);
+}

--- a/packages/shared/src/shields.ts
+++ b/packages/shared/src/shields.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const MAX_STREAK_SHIELDS = 3;
+export const SHIELD_REFILL_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const ShieldBalanceResponseSchema = z.object({
+  available: z.number().int().min(0).max(MAX_STREAK_SHIELDS),
+  maxAvailable: z.literal(MAX_STREAK_SHIELDS),
+  nextRefillAt: z.string().datetime().nullable(),
+});
+export type ShieldBalanceResponse = z.infer<typeof ShieldBalanceResponseSchema>;


### PR DESCRIPTION
## Summary
Second slice of Phase 2E (Ultra/monetization). Ships the streak-shield mechanic per pruvi-freatures.md §5.3:

- Ultra users have at most **1 shield in stock** (binary, "não acumula" per spec).
- **Lazy monthly grant**: on read, Ultra-active users get 1 shield if `last_shield_grant_at` is NULL or ≥ 30 days old.
- **Auto-protect on 1-day gap**: when a user completes a session after exactly one missed day (BRT-relative), `sessions.completeSession` fires a fire-and-forget hook that consumes the shield to protect yesterday. Streak survives.
- Streak compute now reads `streak_shield_usage` rows as "completed" days.
- New `GET /users/me/shields` with 60s cache.

## Workflow note
This phase introduced a new explicit gate sequence (per saved memory `feedback_workflow_self_review_gates.md`):

1. Spec → Opus self-review → fix blockers → commit v2 (caught: CTE-not-atomic + MAX=3-contradicts-product-doc).
2. Plan → Opus self-review → fix blockers → commit (caught: stale MAX=3 in plan, raw-UTC date math in auto-use hook, missing DISTINCT instruction).
3. Per-task implementation (Sonnet 4.6) + Opus review after each task.
4. **Final Opus spec-coverage review** (the new gate) → caught 2 missed items: the 60s cache wrapper on `GET /users/me/shields` was specified but never wired, and `listProtectedDates` lacked ORDER BY despite the spec mandating sorted output. Both fixed in commit `5103f47`.

## Data model — migration `0008_known_lockjaw.sql`
- `user.streak_shields_available integer NOT NULL DEFAULT 0` + CHECK `<= 1` (drop-and-recreate so dev DBs that had a stale `<= 3` constraint from the v1 draft pick up the corrected bound).
- `user.last_shield_grant_at timestamp` (nullable).
- New `streak_shield_usage(id, user_id, protected_date, used_at)` with UNIQUE on `(user_id, protected_date)`.

PGlite mirror updated in lockstep.

## Architecture
- **`ShieldsRepository.tryUseShield`**: explicit `db.transaction` — conditional decrement (`WHERE shields > 0`) + UNIQUE-constrained insert; UNIQUE conflict re-thrown as `"ALREADY_PROTECTED"` to roll back the decrement. Returns `ShieldUseResult` from `@pruvi/shared`.
- **`ShieldsRepository.materializeRefill`**: race-safe conditional UPDATE — `WHERE shields = 0 AND (last_grant IS NULL OR last_grant < now - 30d)`. Predicate runs inside the row-level lock; second concurrent caller observes the just-granted state and falls through to a fresh read.
- **`StreaksService.getStreaks`**: merges `getCompletedSessionDates(userId)` with `listProtectedDates(userId)` via Set dedup. Both arrays are `YYYY-MM-DD` BRT-local strings.
- **`SessionsService.maybeProtectMissedDay`**: fire-and-forget hook. Reads the user's 2 most-recent BRT dates from streaks. If `dates[0] === today` and `dates[1]` is exactly 2 BRT-days ago, calls `tryUseShield(userId, yesterday)`. Errors swallowed by structured `FastifyBaseLogger`.

## Timezone correctness
The existing `getCompletedSessionDates` was using UTC `created_at::date` (silent UTC bug). Fixed during this phase to `(created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo')::date` with `selectDistinct`. The dependent `computeStreaks` helper also updated to use `todayInBrt(now)` (new shared helper). Without this alignment, all BRT-evening users (00:00-03:00 UTC = 21:00-00:00 BRT prev day) would have their streak zeroed.

## Test plan
- [x] 186 unit tests (8 new shields + 5 new sessions hook + 2 new streaks merge + 5 new shields-shared)
- [x] 101 integration tests (13 new shields including atomic tryUseShield, transaction rollback on already-protected, CHECK boundary at `2`, race-safety sequential, listProtectedDates ascending)
- [x] `pnpm verify:migration` clean
- [x] `pnpm --filter server check-types` clean for production code
- [x] Worker boots clean (no worker-layer changes)

## Per-task review findings + fixes
- Task 3: reviewer flagged upper-bound CHECK test using `10` instead of boundary `2`. Tightened (commit `0c4c55d`). Migration `0008` itself had stale `<= 3` constraint on dev DBs blocked by idempotency guard — switched to DROP+ADD (commit `f34b375`).
- Task 4: reviewer flagged that `computeStreaks` still used UTC anchor while the repo now returned BRT dates — real regression caught. Aligned to `todayInBrt` in service AND test helpers (commit `22372e6`).
- Task 5: reviewer flagged 3 `console.error` calls in adjacent dispatcher block. Aligned to structured logger (commit `123b50e`).
- Final review: caught missing 60s cache + invalidation, and missing ORDER BY on `listProtectedDates`. Both fixed in commit `5103f47`.

## Non-goals (explicitly NOT shipped)
- No shield-purchase endpoint (depends on 2E.4 billing).
- No referral-reward shield grant (§4.2 alternative path — deferred to small follow-up).
- No "shield protected your streak" push notification (§5.3 — deferred).
- No billing-cycle-aligned refill (rolling 30 days, deferred to 2E.4).
- No manual "use shield now" endpoint.
- No recover-from-2+-day-break.

## Spec & plan
- `docs/superpowers/specs/2026-05-12-phase-2e2-streak-shield-design.md` (v2)
- `docs/superpowers/plans/2026-05-12-phase-2e2-streak-shield.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streak Shield mechanic for Ultra users: shields automatically protect your streak when you miss a single day between sessions.
  * Shields refill automatically every 30 days of inactivity.
  * New endpoint to check shield balance and next refill date.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CeCamillo/pruvi/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->