### PR TITLE
feat: phase 2e.3 — simulado semanal (ultra perk, race-safe lifecycle)

### DIFF
--- a/apps/server/src/features/simulados/index.ts
+++ b/apps/server/src/features/simulados/index.ts
@@ -1,0 +1,1 @@
+export { simuladosRoutes } from "./simulados.route";

--- a/apps/server/src/features/simulados/simulados.repository.integration.test.ts
+++ b/apps/server/src/features/simulados/simulados.repository.integration.test.ts
@@ -247,4 +247,55 @@ describe("SimuladosRepository (integration)", () => {
       expect(res.kind).toBe("not_found");
     });
   });
+
+  describe("listPriorCompletedSimulados", () => {
+    it("returns up to N most recent COMPLETED prior simulados, oldest first, with per-subject breakdown", async () => {
+      await insertUser("u-hist-1");
+      // Seed 20 questions across 2 subjects (FK prereqs handled inside seedQuestions)
+      await seedQuestions(20, 2);
+      const weeks = ["2026-04-05", "2026-04-12", "2026-04-19", "2026-04-26", "2026-05-03", "2026-05-10"];
+      for (const w of weeks) {
+        const { simulado, questions } = await repo.startOrGetSimulado("u-hist-1", w, 10);
+        // Answer all correctly so each is completed
+        for (const q of questions) {
+          await repo.recordAnswer(simulado.id, "u-hist-1", q.questionId, q.correctOptionIndex);
+        }
+      }
+      // current week is 2026-05-10 → prior = 5 most recent before it; we ask for 4
+      const history = await repo.listPriorCompletedSimulados("u-hist-1", "2026-05-10", 4);
+      expect(history.map((h) => h.weekStart)).toEqual(["2026-04-12", "2026-04-19", "2026-04-26", "2026-05-03"]);
+      // Per-subject breakdown sums to total
+      for (const h of history) {
+        const sum = h.perSubject.reduce((s, p) => s + p.total, 0);
+        expect(sum).toBe(h.total);
+      }
+    });
+
+    it("excludes IN-PROGRESS simulados", async () => {
+      await insertUser("u-hist-2");
+      await seedQuestions(5, 1);
+      const { simulado: prior, questions: pq } = await repo.startOrGetSimulado("u-hist-2", "2026-05-03", 5);
+      for (const q of pq) await repo.recordAnswer(prior.id, "u-hist-2", q.questionId, q.correctOptionIndex);
+      // Current week — started but not completed
+      await repo.startOrGetSimulado("u-hist-2", "2026-05-10", 5);
+      const history = await repo.listPriorCompletedSimulados("u-hist-2", "2026-05-10", 4);
+      expect(history.length).toBe(1);
+      expect(history[0]!.weekStart).toBe("2026-05-03");
+    });
+
+    it("getResultsAggregate returns per-subject breakdown for one simulado", async () => {
+      await insertUser("u-agg-1");
+      await seedQuestions(6, 2); // 3 questions for each of 2 subjects
+      const { simulado, questions } = await repo.startOrGetSimulado("u-agg-1", "2026-05-10", 6);
+      // Answer first 4 correctly, last 2 wrong
+      for (let i = 0; i < 4; i++) await repo.recordAnswer(simulado.id, "u-agg-1", questions[i]!.questionId, questions[i]!.correctOptionIndex);
+      for (let i = 4; i < 6; i++) await repo.recordAnswer(simulado.id, "u-agg-1", questions[i]!.questionId, (questions[i]!.correctOptionIndex + 1) % 4);
+      const agg = await repo.getResultsAggregate(simulado.id);
+      expect(agg.correct).toBe(4);
+      expect(agg.total).toBe(6);
+      const ps = agg.perSubject.sort((a, b) => a.subjectId - b.subjectId);
+      expect(ps).toHaveLength(2);
+      expect(ps.reduce((s, p) => s + p.total, 0)).toBe(6);
+    });
+  });
 });

--- a/apps/server/src/features/simulados/simulados.repository.integration.test.ts
+++ b/apps/server/src/features/simulados/simulados.repository.integration.test.ts
@@ -113,4 +113,112 @@ describe("SimuladosRepository (integration)", () => {
       expect(b.created).toBe(false);
     });
   });
+
+  describe("recordAnswer", () => {
+    it("records first answer, increments correct_count on correct, returns correct outcome", async () => {
+      await insertUser("u-ans-1");
+      await seedQuestions(35);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-1", "2026-05-10", 35);
+      const q = questions[0]!;
+      const correctOpt = q.correctOptionIndex;
+      const result = await repo.recordAnswer(simulado.id, "u-ans-1", q.questionId, correctOpt);
+      expect(result.kind).toBe("recorded");
+      if (result.kind === "recorded") {
+        expect(result.isCorrect).toBe(true);
+        expect(result.completed).toBe(false);
+        expect(result.answeredCount).toBe(1);
+      }
+    });
+
+    it("first-answer-wins idempotency: second answer with different option returns original outcome", async () => {
+      await insertUser("u-ans-2");
+      await seedQuestions(35);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-2", "2026-05-10", 35);
+      const q = questions[0]!;
+      const correctOpt = q.correctOptionIndex;
+      const wrongOpt = (correctOpt + 1) % 4;
+      await repo.recordAnswer(simulado.id, "u-ans-2", q.questionId, correctOpt);
+      const second = await repo.recordAnswer(simulado.id, "u-ans-2", q.questionId, wrongOpt);
+      expect(second.kind).toBe("already_answered");
+      if (second.kind === "already_answered") {
+        expect(second.isCorrect).toBe(true);
+        expect(second.selectedOptionIndex).toBe(correctOpt);
+      }
+    });
+
+    it("auto-completes when the last unanswered question is answered", async () => {
+      await insertUser("u-ans-3");
+      await seedQuestions(5);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-3", "2026-05-10", 5);
+      for (let i = 0; i < 4; i++) {
+        const q = questions[i]!;
+        await repo.recordAnswer(simulado.id, "u-ans-3", q.questionId, q.correctOptionIndex);
+      }
+      const final = await repo.recordAnswer(simulado.id, "u-ans-3", questions[4]!.questionId, questions[4]!.correctOptionIndex);
+      expect(final.kind).toBe("recorded");
+      if (final.kind === "recorded") {
+        expect(final.completed).toBe(true);
+        expect(final.answeredCount).toBe(5);
+      }
+    });
+
+    it("returns kind='not_found' when simulado doesn't exist or isn't owned by user", async () => {
+      await insertUser("u-ans-4a");
+      await insertUser("u-ans-4b");
+      await seedQuestions(35);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-4a", "2026-05-10", 35);
+      const result = await repo.recordAnswer(simulado.id, "u-ans-4b", questions[0]!.questionId, 0);
+      expect(result.kind).toBe("not_found");
+    });
+
+    it("returns kind='bad_question' when questionId doesn't belong to this simulado", async () => {
+      await insertUser("u-ans-5");
+      await seedQuestions(40);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-5", "2026-05-10", 35);
+      const includedIds = new Set(questions.map((q) => q.questionId));
+      // Find a question NOT in the simulado
+      const allQuestions = await db.select({ id: question.id }).from(question);
+      const outsider = allQuestions.find((q) => !includedIds.has(q.id))!;
+      const result = await repo.recordAnswer(simulado.id, "u-ans-5", outsider.id, 0);
+      expect(result.kind).toBe("bad_question");
+    });
+
+    it("returns kind='already_completed' when simulado is already finalized", async () => {
+      await insertUser("u-ans-6");
+      await seedQuestions(35);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-6", "2026-05-10", 35);
+      await repo.forceComplete(simulado.id, "u-ans-6");
+      const result = await repo.recordAnswer(simulado.id, "u-ans-6", questions[0]!.questionId, 0);
+      expect(result.kind).toBe("already_completed");
+    });
+  });
+
+  describe("forceComplete", () => {
+    it("sets completed_at when not yet completed", async () => {
+      await insertUser("u-fc-1");
+      await seedQuestions(35);
+      const { simulado } = await repo.startOrGetSimulado("u-fc-1", "2026-05-10", 35);
+      const res = await repo.forceComplete(simulado.id, "u-fc-1");
+      expect(res.kind).toBe("completed");
+      if (res.kind === "completed") expect(res.completedAt).toBeInstanceOf(Date);
+    });
+
+    it("is idempotent on already-completed simulado", async () => {
+      await insertUser("u-fc-2");
+      await seedQuestions(35);
+      const { simulado } = await repo.startOrGetSimulado("u-fc-2", "2026-05-10", 35);
+      await repo.forceComplete(simulado.id, "u-fc-2");
+      const res = await repo.forceComplete(simulado.id, "u-fc-2");
+      expect(res.kind).toBe("completed");
+    });
+
+    it("returns not_found for unowned simulado", async () => {
+      await insertUser("u-fc-3a");
+      await insertUser("u-fc-3b");
+      await seedQuestions(35);
+      const { simulado } = await repo.startOrGetSimulado("u-fc-3a", "2026-05-10", 35);
+      const res = await repo.forceComplete(simulado.id, "u-fc-3b");
+      expect(res.kind).toBe("not_found");
+    });
+  });
 });

--- a/apps/server/src/features/simulados/simulados.repository.integration.test.ts
+++ b/apps/server/src/features/simulados/simulados.repository.integration.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { setupTestDb, cleanupTestDb, teardownTestDb, getTestDb } from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { question } from "@pruvi/db/schema/questions";
+import { subject } from "@pruvi/db/schema/subjects";
+import { topic, subtopic } from "@pruvi/db/schema/topics";
+import { SimuladosRepository } from "./simulados.repository";
+
+describe("SimuladosRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new SimuladosRepository(db);
+
+  beforeAll(async () => setupTestDb());
+  beforeEach(async () => cleanupTestDb());
+  afterAll(async () => teardownTestDb());
+
+  async function insertUser(id: string) {
+    await db.insert(user).values({
+      id,
+      name: `U ${id}`,
+      email: `${id}@e.com`,
+      emailVerified: false,
+      inviteCode: `c${id.replace(/-/g, "").slice(0, 8)}`,
+      username: null,
+      updatedAt: new Date(),
+    });
+  }
+
+  /** Sets up subject/topic/subtopic FK prereqs and inserts `n` questions distributed
+   *  across the requested number of subjects. Returns the created subject IDs. */
+  async function seedQuestions(n: number, subjectCount = 1): Promise<number[]> {
+    const subjects = await db
+      .insert(subject)
+      .values(Array.from({ length: subjectCount }, (_, i) => ({ name: `S${i + 1}`, slug: `s${i + 1}` })))
+      .returning();
+    const subtopicsBySubject = new Map<number, number>();
+    for (const s of subjects) {
+      const [t] = await db
+        .insert(topic)
+        .values({ subjectId: s.id, name: `T-${s.id}`, slug: `t-${s.id}`, displayOrder: 0 })
+        .returning();
+      const [st] = await db
+        .insert(subtopic)
+        .values({ topicId: t!.id, name: `ST-${s.id}`, slug: `st-${s.id}`, displayOrder: 0 })
+        .returning();
+      subtopicsBySubject.set(s.id, st!.id);
+    }
+    for (let i = 0; i < n; i++) {
+      const subj = subjects[i % subjects.length]!;
+      await db.insert(question).values({
+        subjectId: subj.id,
+        subtopicId: subtopicsBySubject.get(subj.id)!,
+        content: `Q${i + 1}`,
+        options: ["a", "b", "c", "d"],
+        correctOptionIndex: i % 4,
+        difficulty: "easy" as const,
+        requiresCalculation: false,
+      });
+    }
+    return subjects.map((s) => s.id);
+  }
+
+  describe("selectQuestionsForSimulado", () => {
+    it("returns deterministic ordering for same (userId, weekStart)", async () => {
+      await insertUser("u1");
+      await seedQuestions(50);
+      const a = await repo.selectQuestionsForSimulado("u1", "2026-05-10", 35);
+      const b = await repo.selectQuestionsForSimulado("u1", "2026-05-10", 35);
+      expect(a.map((q) => q.id)).toEqual(b.map((q) => q.id));
+      expect(a.length).toBe(35);
+      expect(new Set(a.map((q) => q.id)).size).toBe(35);
+    });
+
+    it("returns all available when bank is smaller than requested count", async () => {
+      await insertUser("u2");
+      await seedQuestions(10);
+      const a = await repo.selectQuestionsForSimulado("u2", "2026-05-10", 35);
+      expect(a.length).toBe(10);
+      expect(new Set(a.map((q) => q.id)).size).toBe(10);
+    });
+
+    it("returns different ordering for different (userId, weekStart)", async () => {
+      await insertUser("u3");
+      await seedQuestions(50);
+      const a = await repo.selectQuestionsForSimulado("u3", "2026-05-10", 10);
+      const b = await repo.selectQuestionsForSimulado("u3", "2026-05-17", 10);
+      // Same seed inputs produce different orderings (probabilistic; with 50 questions and 10 picks, collision risk is negligible)
+      expect(a.map((q) => q.id)).not.toEqual(b.map((q) => q.id));
+    });
+  });
+
+  describe("startOrGetSimulado", () => {
+    it("creates a new simulado with questions when none exists for (user, week)", async () => {
+      await insertUser("u4");
+      await seedQuestions(40);
+      const { simulado, questions, created } = await repo.startOrGetSimulado("u4", "2026-05-10", 35);
+      expect(created).toBe(true);
+      expect(simulado.questionsCount).toBe(35);
+      expect(simulado.correctCount).toBe(0);
+      expect(simulado.completedAt).toBeNull();
+      expect(questions.length).toBe(35);
+      expect(questions[0]!.position).toBe(0);
+      expect(questions[34]!.position).toBe(34);
+    });
+
+    it("is idempotent: second call returns the same simulado.id", async () => {
+      await insertUser("u5");
+      await seedQuestions(40);
+      const a = await repo.startOrGetSimulado("u5", "2026-05-10", 35);
+      const b = await repo.startOrGetSimulado("u5", "2026-05-10", 35);
+      expect(a.simulado.id).toBe(b.simulado.id);
+      expect(a.questions.map((q) => q.questionId)).toEqual(b.questions.map((q) => q.questionId));
+      expect(b.created).toBe(false);
+    });
+  });
+});

--- a/apps/server/src/features/simulados/simulados.repository.integration.test.ts
+++ b/apps/server/src/features/simulados/simulados.repository.integration.test.ts
@@ -5,6 +5,8 @@ import { question } from "@pruvi/db/schema/questions";
 import { subject } from "@pruvi/db/schema/subjects";
 import { topic, subtopic } from "@pruvi/db/schema/topics";
 import { SimuladosRepository } from "./simulados.repository";
+import { weeklySimulado, weeklySimuladoQuestion } from "@pruvi/db/schema/weekly-simulado";
+import { eq } from "drizzle-orm";
 
 describe("SimuladosRepository (integration)", () => {
   const db = getTestDb();
@@ -296,6 +298,51 @@ describe("SimuladosRepository (integration)", () => {
       const ps = agg.perSubject.sort((a, b) => a.subjectId - b.subjectId);
       expect(ps).toHaveLength(2);
       expect(ps.reduce((s, p) => s + p.total, 0)).toBe(6);
+    });
+  });
+
+  describe("DB constraints", () => {
+    it("deleting weekly_simulado cascades to weekly_simulado_question", async () => {
+      await insertUser("u-cascade-1");
+      await seedQuestions(5, 1);
+      const { simulado } = await repo.startOrGetSimulado("u-cascade-1", "2026-05-10", 5);
+      // Verify rows exist
+      const before = await db.select().from(weeklySimuladoQuestion);
+      expect(before.length).toBeGreaterThan(0);
+      // Delete parent
+      await db.delete(weeklySimulado).where(eq(weeklySimulado.id, simulado.id));
+      // Child rows should be gone
+      const after = await db
+        .select()
+        .from(weeklySimuladoQuestion)
+        .where(eq(weeklySimuladoQuestion.simuladoId, simulado.id));
+      expect(after.length).toBe(0);
+    });
+
+    it("UNIQUE constraint rejects duplicate (user_id, week_start_date)", async () => {
+      await insertUser("u-uq-1");
+      await seedQuestions(5, 1);
+      await db.insert(weeklySimulado).values({ userId: "u-uq-1", weekStartDate: "2026-05-10", questionsCount: 5 });
+      await expect(
+        db.insert(weeklySimulado).values({ userId: "u-uq-1", weekStartDate: "2026-05-10", questionsCount: 5 }).execute(),
+      ).rejects.toThrow();
+    });
+
+    it("UNIQUE constraint rejects duplicate (simulado_id, question_id)", async () => {
+      await insertUser("u-uq-2");
+      const [subjId] = await seedQuestions(5, 1);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-uq-2", "2026-05-10", 5);
+      await expect(
+        db
+          .insert(weeklySimuladoQuestion)
+          .values({
+            simuladoId: simulado.id,
+            position: 99,
+            questionId: questions[0]!.questionId,
+          })
+          .execute(),
+      ).rejects.toThrow();
+      void subjId;
     });
   });
 });

--- a/apps/server/src/features/simulados/simulados.repository.integration.test.ts
+++ b/apps/server/src/features/simulados/simulados.repository.integration.test.ts
@@ -193,6 +193,32 @@ describe("SimuladosRepository (integration)", () => {
     });
   });
 
+  describe("getOneForUser", () => {
+    it("returns null when the simulado is not owned by the requesting user", async () => {
+      await insertUser("u-gou-1a");
+      await insertUser("u-gou-1b");
+      await seedQuestions(10);
+      const { simulado } = await repo.startOrGetSimulado("u-gou-1a", "2026-05-10", 10);
+      const result = await repo.getOneForUser(simulado.id, "u-gou-1b");
+      expect(result).toBeNull();
+    });
+
+    it("returns simulado and questions with correct shape and ascending position ordering for the owner", async () => {
+      await insertUser("u-gou-2");
+      await seedQuestions(10);
+      const questionsCount = 10;
+      const { simulado } = await repo.startOrGetSimulado("u-gou-2", "2026-05-10", questionsCount);
+      const result = await repo.getOneForUser(simulado.id, "u-gou-2");
+      expect(result).not.toBeNull();
+      expect(result!.simulado.id).toBe(simulado.id);
+      expect(result!.questions.length).toBe(questionsCount);
+      // Positions must be strictly ascending from 0
+      for (let i = 0; i < result!.questions.length; i++) {
+        expect(result!.questions[i]!.position).toBe(i);
+      }
+    });
+  });
+
   describe("forceComplete", () => {
     it("sets completed_at when not yet completed", async () => {
       await insertUser("u-fc-1");

--- a/apps/server/src/features/simulados/simulados.repository.ts
+++ b/apps/server/src/features/simulados/simulados.repository.ts
@@ -1,0 +1,208 @@
+import { and, asc, eq, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { question } from "@pruvi/db/schema/questions";
+import { weeklySimulado, weeklySimuladoQuestion } from "@pruvi/db/schema/weekly-simulado";
+
+type Db = typeof DbClient;
+
+export type SimuladoRow = {
+  id: number;
+  userId: string;
+  weekStartDate: string;
+  startedAt: Date;
+  completedAt: Date | null;
+  questionsCount: number;
+  correctCount: number;
+};
+
+export type SimuladoQuestionRow = {
+  position: number;
+  questionId: number;
+  content: string;
+  options: string[];
+  correctOptionIndex: number;
+  explanation: string | null;
+  subjectId: number;
+  subtopicId: number;
+  requiresCalculation: boolean;
+  selectedOptionIndex: number | null;
+  isCorrect: boolean | null;
+};
+
+export class SimuladosRepository {
+  constructor(private db: Db) {}
+
+  /**
+   * Deterministic pseudo-random sample of `count` questions for a given
+   * (userId, weekStart). Repeatable as long as the bank doesn't change.
+   * If bank size < count, returns all available (graceful degradation).
+   */
+  async selectQuestionsForSimulado(userId: string, weekStart: string, count: number) {
+    const seed = `${userId}|${weekStart}`;
+    const rows = await this.db
+      .select({
+        id: question.id,
+        subjectId: question.subjectId,
+        subtopicId: question.subtopicId,
+        content: question.content,
+        options: question.options,
+        correctOptionIndex: question.correctOptionIndex,
+        explanation: question.explanation,
+        requiresCalculation: question.requiresCalculation,
+      })
+      .from(question)
+      .orderBy(sql`md5(${question.id}::text || ${seed})`)
+      .limit(count);
+    return rows;
+  }
+
+  /**
+   * Idempotent under concurrency: uses INSERT ... ON CONFLICT DO NOTHING
+   * RETURNING. If conflict path is taken, re-reads the existing row.
+   * Question selection + bulk insert happen inside the same transaction so
+   * a simulado is never visible without its question set.
+   */
+  async startOrGetSimulado(userId: string, weekStart: string, requestedCount: number) {
+    return await this.db.transaction(async (tx) => {
+      // Attempt insert; ON CONFLICT (user_id, week_start_date) DO NOTHING.
+      const selection = await tx
+        .select({
+          id: question.id,
+          subjectId: question.subjectId,
+          subtopicId: question.subtopicId,
+          content: question.content,
+          options: question.options,
+          correctOptionIndex: question.correctOptionIndex,
+          explanation: question.explanation,
+          requiresCalculation: question.requiresCalculation,
+        })
+        .from(question)
+        .orderBy(sql`md5(${question.id}::text || ${`${userId}|${weekStart}`})`)
+        .limit(requestedCount);
+      const effectiveCount = selection.length;
+
+      const inserted = await tx
+        .insert(weeklySimulado)
+        .values({ userId, weekStartDate: weekStart, questionsCount: effectiveCount })
+        .onConflictDoNothing({ target: [weeklySimulado.userId, weeklySimulado.weekStartDate] })
+        .returning();
+
+      if (inserted.length > 0) {
+        const simulado = inserted[0]!;
+        // Bulk insert question rows.
+        if (effectiveCount > 0) {
+          await tx.insert(weeklySimuladoQuestion).values(
+            selection.map((q, idx) => ({
+              simuladoId: simulado.id,
+              position: idx,
+              questionId: q.id,
+            })),
+          );
+        }
+        const questions = selection.map((q, idx) => ({
+          position: idx,
+          questionId: q.id,
+          content: q.content,
+          options: q.options as string[],
+          correctOptionIndex: q.correctOptionIndex,
+          explanation: q.explanation,
+          subjectId: q.subjectId,
+          subtopicId: q.subtopicId,
+          requiresCalculation: q.requiresCalculation,
+          selectedOptionIndex: null as number | null,
+          isCorrect: null as boolean | null,
+        }));
+        return { simulado: this.toSimuladoRow(simulado), questions, created: true };
+      }
+
+      // Conflict path — re-read existing row + question set (inline; uses tx not this.db so
+      // it sees any uncommitted state in this transaction, though in practice the conflict
+      // means another committed transaction wrote it).
+      const existing = await tx
+        .select()
+        .from(weeklySimulado)
+        .where(and(eq(weeklySimulado.userId, userId), eq(weeklySimulado.weekStartDate, weekStart)))
+        .limit(1);
+      const simulado = existing[0];
+      if (!simulado) throw new Error("startOrGetSimulado: conflict but no existing row");
+      const rows = await tx
+        .select({
+          position: weeklySimuladoQuestion.position,
+          questionId: weeklySimuladoQuestion.questionId,
+          selectedOptionIndex: weeklySimuladoQuestion.selectedOptionIndex,
+          isCorrect: weeklySimuladoQuestion.isCorrect,
+          content: question.content,
+          options: question.options,
+          correctOptionIndex: question.correctOptionIndex,
+          explanation: question.explanation,
+          subjectId: question.subjectId,
+          subtopicId: question.subtopicId,
+          requiresCalculation: question.requiresCalculation,
+        })
+        .from(weeklySimuladoQuestion)
+        .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+        .where(eq(weeklySimuladoQuestion.simuladoId, simulado.id))
+        .orderBy(asc(weeklySimuladoQuestion.position));
+      const existingQs: SimuladoQuestionRow[] = rows.map((r) => ({
+        position: r.position,
+        questionId: r.questionId,
+        content: r.content,
+        options: r.options as string[],
+        correctOptionIndex: r.correctOptionIndex,
+        explanation: r.explanation,
+        subjectId: r.subjectId,
+        subtopicId: r.subtopicId,
+        requiresCalculation: r.requiresCalculation,
+        selectedOptionIndex: r.selectedOptionIndex,
+        isCorrect: r.isCorrect,
+      }));
+      return { simulado: this.toSimuladoRow(simulado), questions: existingQs, created: false };
+    });
+  }
+
+  private toSimuladoRow(row: typeof weeklySimulado.$inferSelect): SimuladoRow {
+    return {
+      id: row.id,
+      userId: row.userId,
+      weekStartDate: typeof row.weekStartDate === "string" ? row.weekStartDate : new Date(row.weekStartDate).toISOString().slice(0, 10),
+      startedAt: row.startedAt,
+      completedAt: row.completedAt,
+      questionsCount: row.questionsCount,
+      correctCount: row.correctCount,
+    };
+  }
+
+  private async fetchQuestionsForSimulado(simuladoId: number): Promise<SimuladoQuestionRow[]> {
+    const rows = await this.db
+      .select({
+        position: weeklySimuladoQuestion.position,
+        questionId: weeklySimuladoQuestion.questionId,
+        selectedOptionIndex: weeklySimuladoQuestion.selectedOptionIndex,
+        isCorrect: weeklySimuladoQuestion.isCorrect,
+        content: question.content,
+        options: question.options,
+        correctOptionIndex: question.correctOptionIndex,
+        explanation: question.explanation,
+        subjectId: question.subjectId,
+        subtopicId: question.subtopicId,
+        requiresCalculation: question.requiresCalculation,
+      })
+      .from(weeklySimuladoQuestion)
+      .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+      .where(eq(weeklySimuladoQuestion.simuladoId, simuladoId))
+      .orderBy(asc(weeklySimuladoQuestion.position));
+    return rows.map((r) => ({
+      position: r.position,
+      questionId: r.questionId,
+      content: r.content,
+      options: r.options as string[],
+      correctOptionIndex: r.correctOptionIndex,
+      explanation: r.explanation,
+      subjectId: r.subjectId,
+      subtopicId: r.subtopicId,
+      requiresCalculation: r.requiresCalculation,
+      selectedOptionIndex: r.selectedOptionIndex,
+      isCorrect: r.isCorrect,
+    }));
+  }
+}

--- a/apps/server/src/features/simulados/simulados.repository.ts
+++ b/apps/server/src/features/simulados/simulados.repository.ts
@@ -402,6 +402,24 @@ export class SimuladosRepository {
     };
   }
 
+  async findByUserAndWeek(userId: string, weekStart: string): Promise<SimuladoRow | null> {
+    const rows = await this.db
+      .select()
+      .from(weeklySimulado)
+      .where(and(eq(weeklySimulado.userId, userId), eq(weeklySimulado.weekStartDate, weekStart)))
+      .limit(1);
+    const r = rows[0];
+    return r ? this.toSimuladoRow(r) : null;
+  }
+
+  async countAnswered(simuladoId: number): Promise<number> {
+    const res = await this.db
+      .select({ value: count() })
+      .from(weeklySimuladoQuestion)
+      .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), isNotNull(weeklySimuladoQuestion.selectedOptionIndex)));
+    return Number(res[0]!.value);
+  }
+
   private async fetchQuestionsForSimulado(simuladoId: number): Promise<SimuladoQuestionRow[]> {
     const rows = await this.db
       .select({

--- a/apps/server/src/features/simulados/simulados.repository.ts
+++ b/apps/server/src/features/simulados/simulados.repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, count, eq, isNull, sql } from "drizzle-orm";
 import type { db as DbClient } from "@pruvi/db";
 import { question } from "@pruvi/db/schema/questions";
 import { weeklySimulado, weeklySimuladoQuestion } from "@pruvi/db/schema/weekly-simulado";
@@ -28,6 +28,17 @@ export type SimuladoQuestionRow = {
   selectedOptionIndex: number | null;
   isCorrect: boolean | null;
 };
+
+export type RecordAnswerResult =
+  | { kind: "recorded"; isCorrect: boolean; correctOptionIndex: number; explanation: string | null; answeredCount: number; completed: boolean }
+  | { kind: "already_answered"; isCorrect: boolean; selectedOptionIndex: number; correctOptionIndex: number; explanation: string | null; answeredCount: number; completed: boolean }
+  | { kind: "not_found" }
+  | { kind: "bad_question" }
+  | { kind: "already_completed" };
+
+export type ForceCompleteResult =
+  | { kind: "completed"; completedAt: Date }
+  | { kind: "not_found" };
 
 export class SimuladosRepository {
   constructor(private db: Db) {}
@@ -170,6 +181,128 @@ export class SimuladosRepository {
       questionsCount: row.questionsCount,
       correctCount: row.correctCount,
     };
+  }
+
+  /**
+   * Race-safe under Read Committed via `SELECT ... FOR UPDATE` on the parent
+   * simulado row. Serializes concurrent answers on the same simulado to
+   * eliminate auto-completion races. First-answer-wins idempotency on the
+   * question row via WHERE selected_option_index IS NULL predicate.
+   */
+  async recordAnswer(simuladoId: number, userId: string, questionId: number, selectedOptionIndex: number): Promise<RecordAnswerResult> {
+    return await this.db.transaction(async (tx) => {
+      // 1. Lock parent row using Drizzle's typed .for("update"). Check ownership and completion.
+      const lockedRows = await tx
+        .select({
+          id: weeklySimulado.id,
+          userId: weeklySimulado.userId,
+          completedAt: weeklySimulado.completedAt,
+          correctCount: weeklySimulado.correctCount,
+          questionsCount: weeklySimulado.questionsCount,
+        })
+        .from(weeklySimulado)
+        .where(eq(weeklySimulado.id, simuladoId))
+        .for("update")
+        .limit(1);
+      const parent = lockedRows[0];
+      if (!parent || parent.userId !== userId) return { kind: "not_found" };
+      if (parent.completedAt !== null) return { kind: "already_completed" };
+
+      // 2. Look up the question within this simulado.
+      const qRow = await tx
+        .select({
+          selectedOptionIndex: weeklySimuladoQuestion.selectedOptionIndex,
+          isCorrect: weeklySimuladoQuestion.isCorrect,
+          correctOptionIndex: question.correctOptionIndex,
+          explanation: question.explanation,
+        })
+        .from(weeklySimuladoQuestion)
+        .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+        .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), eq(weeklySimuladoQuestion.questionId, questionId)))
+        .limit(1);
+      const qr = qRow[0];
+      if (!qr) return { kind: "bad_question" };
+
+      const correctOpt = qr.correctOptionIndex;
+      const explanation = qr.explanation;
+
+      // 3. If already answered, return the recorded outcome (first answer wins).
+      if (qr.selectedOptionIndex !== null) {
+        const answered = await tx
+          .select({ value: count() })
+          .from(weeklySimuladoQuestion)
+          .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), sql`${weeklySimuladoQuestion.selectedOptionIndex} IS NOT NULL`));
+        return {
+          kind: "already_answered",
+          isCorrect: qr.isCorrect ?? false,
+          selectedOptionIndex: qr.selectedOptionIndex,
+          correctOptionIndex: correctOpt,
+          explanation,
+          answeredCount: Number(answered[0]!.value),
+          completed: false,
+        };
+      }
+
+      // 4. Record the new answer (conditional on IS NULL to be race-safe).
+      const isCorrect = selectedOptionIndex === correctOpt;
+      await tx
+        .update(weeklySimuladoQuestion)
+        .set({ selectedOptionIndex, isCorrect, answeredAt: new Date() })
+        .where(and(
+          eq(weeklySimuladoQuestion.simuladoId, simuladoId),
+          eq(weeklySimuladoQuestion.questionId, questionId),
+          isNull(weeklySimuladoQuestion.selectedOptionIndex),
+        ));
+
+      // 5. Increment correct_count if correct.
+      if (isCorrect) {
+        await tx
+          .update(weeklySimulado)
+          .set({ correctCount: sql`${weeklySimulado.correctCount} + 1` })
+          .where(eq(weeklySimulado.id, simuladoId));
+      }
+
+      // 6. Count remaining unanswered. Because parent is FOR UPDATE-locked, no
+      //    other answer transaction can have committed since step 1.
+      const unanswered = await tx
+        .select({ value: count() })
+        .from(weeklySimuladoQuestion)
+        .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), isNull(weeklySimuladoQuestion.selectedOptionIndex)));
+      const remaining = Number(unanswered[0]!.value);
+      let completed = false;
+      if (remaining === 0) {
+        await tx
+          .update(weeklySimulado)
+          .set({ completedAt: new Date() })
+          .where(and(eq(weeklySimulado.id, simuladoId), isNull(weeklySimulado.completedAt)));
+        completed = true;
+      }
+      const answeredCount = parent.questionsCount - remaining;
+      return { kind: "recorded", isCorrect, correctOptionIndex: correctOpt, explanation, answeredCount, completed };
+    });
+  }
+
+  async forceComplete(simuladoId: number, userId: string): Promise<ForceCompleteResult> {
+    const result = await this.db
+      .update(weeklySimulado)
+      .set({ completedAt: sql`COALESCE(${weeklySimulado.completedAt}, now())` })
+      .where(and(eq(weeklySimulado.id, simuladoId), eq(weeklySimulado.userId, userId)))
+      .returning({ completedAt: weeklySimulado.completedAt });
+    const row = result[0];
+    if (!row) return { kind: "not_found" };
+    return { kind: "completed", completedAt: row.completedAt! };
+  }
+
+  async getOneForUser(simuladoId: number, userId: string): Promise<{ simulado: SimuladoRow; questions: SimuladoQuestionRow[] } | null> {
+    const rows = await this.db
+      .select()
+      .from(weeklySimulado)
+      .where(and(eq(weeklySimulado.id, simuladoId), eq(weeklySimulado.userId, userId)))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    const questions = await this.fetchQuestionsForSimulado(row.id);
+    return { simulado: this.toSimuladoRow(row), questions };
   }
 
   private async fetchQuestionsForSimulado(simuladoId: number): Promise<SimuladoQuestionRow[]> {

--- a/apps/server/src/features/simulados/simulados.repository.ts
+++ b/apps/server/src/features/simulados/simulados.repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, eq, isNull, sql } from "drizzle-orm";
+import { and, asc, count, eq, isNotNull, isNull, sql } from "drizzle-orm";
 import type { db as DbClient } from "@pruvi/db";
 import { question } from "@pruvi/db/schema/questions";
 import { weeklySimulado, weeklySimuladoQuestion } from "@pruvi/db/schema/weekly-simulado";
@@ -231,7 +231,7 @@ export class SimuladosRepository {
         const answered = await tx
           .select({ value: count() })
           .from(weeklySimuladoQuestion)
-          .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), sql`${weeklySimuladoQuestion.selectedOptionIndex} IS NOT NULL`));
+          .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), isNotNull(weeklySimuladoQuestion.selectedOptionIndex)));
         return {
           kind: "already_answered",
           isCorrect: qr.isCorrect ?? false,
@@ -239,7 +239,7 @@ export class SimuladosRepository {
           correctOptionIndex: correctOpt,
           explanation,
           answeredCount: Number(answered[0]!.value),
-          completed: false,
+          completed: parent.completedAt !== null,
         };
       }
 

--- a/apps/server/src/features/simulados/simulados.repository.ts
+++ b/apps/server/src/features/simulados/simulados.repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, eq, isNotNull, isNull, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, isNotNull, isNull, lt, sql } from "drizzle-orm";
 import type { db as DbClient } from "@pruvi/db";
 import { question } from "@pruvi/db/schema/questions";
 import { weeklySimulado, weeklySimuladoQuestion } from "@pruvi/db/schema/weekly-simulado";
@@ -303,6 +303,103 @@ export class SimuladosRepository {
     if (!row) return null;
     const questions = await this.fetchQuestionsForSimulado(row.id);
     return { simulado: this.toSimuladoRow(row), questions };
+  }
+
+  /**
+   * Returns up to `limit` most recent COMPLETED simulados strictly BEFORE
+   * `currentWeekStart`, ordered oldest first, with per-subject breakdown.
+   */
+  async listPriorCompletedSimulados(
+    userId: string,
+    currentWeekStart: string,
+    limit: number,
+  ): Promise<
+    Array<{
+      weekStart: string;
+      correct: number;
+      total: number;
+      perSubject: Array<{ subjectId: number; correct: number; total: number }>;
+    }>
+  > {
+    const recent = await this.db
+      .select({
+        id: weeklySimulado.id,
+        weekStartDate: weeklySimulado.weekStartDate,
+        correctCount: weeklySimulado.correctCount,
+        questionsCount: weeklySimulado.questionsCount,
+      })
+      .from(weeklySimulado)
+      .where(
+        and(
+          eq(weeklySimulado.userId, userId),
+          isNotNull(weeklySimulado.completedAt),
+          lt(weeklySimulado.weekStartDate, currentWeekStart),
+        ),
+      )
+      .orderBy(desc(weeklySimulado.weekStartDate))
+      .limit(limit);
+    if (recent.length === 0) return [];
+
+    const ids = recent.map((r) => r.id);
+    const perSubjectRows = await this.db
+      .select({
+        simuladoId: weeklySimuladoQuestion.simuladoId,
+        subjectId: question.subjectId,
+        correct: sql<number>`SUM(CASE WHEN ${weeklySimuladoQuestion.isCorrect} = true THEN 1 ELSE 0 END)`,
+        total: count(),
+      })
+      .from(weeklySimuladoQuestion)
+      .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+      .where(inArray(weeklySimuladoQuestion.simuladoId, ids))
+      .groupBy(weeklySimuladoQuestion.simuladoId, question.subjectId);
+
+    const bySimulado = new Map<number, Array<{ subjectId: number; correct: number; total: number }>>();
+    for (const r of perSubjectRows) {
+      const list = bySimulado.get(r.simuladoId) ?? [];
+      list.push({ subjectId: r.subjectId, correct: Number(r.correct), total: Number(r.total) });
+      bySimulado.set(r.simuladoId, list);
+    }
+
+    return recent
+      .map((r) => ({
+        weekStart: typeof r.weekStartDate === "string" ? r.weekStartDate : new Date(r.weekStartDate).toISOString().slice(0, 10),
+        correct: r.correctCount,
+        total: r.questionsCount,
+        perSubject: bySimulado.get(r.id) ?? [],
+      }))
+      .reverse(); // oldest first
+  }
+
+  /** Per-subject aggregate for a single simulado. */
+  async getResultsAggregate(simuladoId: number): Promise<{
+    correct: number;
+    total: number;
+    perSubject: Array<{ subjectId: number; correct: number; total: number }>;
+  }> {
+    const head = await this.db
+      .select({ correctCount: weeklySimulado.correctCount, questionsCount: weeklySimulado.questionsCount })
+      .from(weeklySimulado)
+      .where(eq(weeklySimulado.id, simuladoId))
+      .limit(1);
+    const h = head[0];
+    if (!h) return { correct: 0, total: 0, perSubject: [] };
+
+    const perSubject = await this.db
+      .select({
+        subjectId: question.subjectId,
+        correct: sql<number>`SUM(CASE WHEN ${weeklySimuladoQuestion.isCorrect} = true THEN 1 ELSE 0 END)`,
+        total: count(),
+      })
+      .from(weeklySimuladoQuestion)
+      .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+      .where(eq(weeklySimuladoQuestion.simuladoId, simuladoId))
+      .groupBy(question.subjectId);
+
+    return {
+      correct: h.correctCount,
+      total: h.questionsCount,
+      perSubject: perSubject.map((p) => ({ subjectId: p.subjectId, correct: Number(p.correct), total: Number(p.total) })),
+    };
   }
 
   private async fetchQuestionsForSimulado(simuladoId: number): Promise<SimuladoQuestionRow[]> {

--- a/apps/server/src/features/simulados/simulados.route.ts
+++ b/apps/server/src/features/simulados/simulados.route.ts
@@ -21,7 +21,7 @@ const CURRENT_CACHE_TTL = 60;
 export const simuladosRoutes: FastifyPluginAsyncZod = async (fastify) => {
   const repo = new SimuladosRepository(db);
   const ultra = new UltraService(new UltraRepository(db));
-  const service = new SimuladosService(repo, ultra, fastify.log);
+  const service = new SimuladosService(repo, ultra);
 
   fastify.get(
     "/simulados/current",

--- a/apps/server/src/features/simulados/simulados.route.ts
+++ b/apps/server/src/features/simulados/simulados.route.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import {
+  SimuladoAnswerBodySchema,
+  SimuladoAnswerResponseSchema,
+  SimuladoCurrentResponseSchema,
+  SimuladoDetailResponseSchema,
+  SimuladoResultsResponseSchema,
+  SimuladoStartResponseSchema,
+  type SimuladoCurrentResponse,
+} from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { successResponse, unwrapResult } from "../../types";
+import { SimuladosRepository } from "./simulados.repository";
+import { SimuladosService } from "./simulados.service";
+import { UltraRepository } from "../ultra/ultra.repository";
+import { UltraService } from "../ultra/ultra.service";
+
+const CURRENT_CACHE_TTL = 60;
+
+export const simuladosRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const repo = new SimuladosRepository(db);
+  const ultra = new UltraService(new UltraRepository(db));
+  const service = new SimuladosService(repo, ultra, fastify.log);
+
+  fastify.get(
+    "/simulados/current",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: SimuladoCurrentResponseSchema }) } },
+    },
+    async (request) => {
+      const cacheKey = `simulado:current:${request.userId}`;
+      const cached = await fastify.cache.get<SimuladoCurrentResponse>(cacheKey);
+      if (cached) return successResponse(cached);
+      const data = unwrapResult(await service.getCurrent(request.userId)).data;
+      await fastify.cache.set(cacheKey, data, CURRENT_CACHE_TTL);
+      return successResponse(data);
+    },
+  );
+
+  fastify.post(
+    "/simulados/start",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: SimuladoStartResponseSchema }) } },
+    },
+    async (request) => {
+      const data = unwrapResult(await service.start(request.userId)).data;
+      await fastify.cache.del(`simulado:current:${request.userId}`);
+      return successResponse(data);
+    },
+  );
+
+  fastify.get(
+    "/simulados/:id",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ id: z.coerce.number().int() }),
+        response: { 200: z.object({ success: z.literal(true), data: SimuladoDetailResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const { id } = request.params;
+      const data = unwrapResult(await service.getDetail(id, request.userId)).data;
+      return successResponse(data);
+    },
+  );
+
+  fastify.post(
+    "/simulados/:id/answer",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ id: z.coerce.number().int() }),
+        body: SimuladoAnswerBodySchema,
+        response: { 200: z.object({ success: z.literal(true), data: SimuladoAnswerResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const { id } = request.params;
+      const { questionId, selectedOptionIndex } = request.body;
+      const data = unwrapResult(await service.recordAnswer(id, request.userId, questionId, selectedOptionIndex)).data;
+      await fastify.cache.del(`simulado:current:${request.userId}`);
+      return successResponse(data);
+    },
+  );
+
+  fastify.post(
+    "/simulados/:id/complete",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ id: z.coerce.number().int() }),
+        response: { 200: z.object({ success: z.literal(true), data: z.object({ id: z.number().int(), completedAt: z.string() }) }) },
+      },
+    },
+    async (request) => {
+      const { id } = request.params;
+      const data = unwrapResult(await service.forceComplete(id, request.userId)).data;
+      await fastify.cache.del(`simulado:current:${request.userId}`);
+      return successResponse(data);
+    },
+  );
+
+  fastify.get(
+    "/simulados/:id/results",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ id: z.coerce.number().int() }),
+        response: { 200: z.object({ success: z.literal(true), data: SimuladoResultsResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const { id } = request.params;
+      const data = unwrapResult(await service.getResults(id, request.userId)).data;
+      return successResponse(data);
+    },
+  );
+};

--- a/apps/server/src/features/simulados/simulados.service.test.ts
+++ b/apps/server/src/features/simulados/simulados.service.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { SimuladosService } from "./simulados.service";
-import { ok } from "neverthrow";
 import type { UltraService } from "../ultra/ultra.service";
 import type { SimuladosRepository } from "./simulados.repository";
 

--- a/apps/server/src/features/simulados/simulados.service.test.ts
+++ b/apps/server/src/features/simulados/simulados.service.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect, vi } from "vitest";
+import { SimuladosService } from "./simulados.service";
+import { ok } from "neverthrow";
+import type { UltraService } from "../ultra/ultra.service";
+import type { SimuladosRepository } from "./simulados.repository";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUltra(isUltraValue: boolean) {
+  return { isUltra: vi.fn().mockResolvedValue(isUltraValue) } as unknown as UltraService;
+}
+
+function makeRepo(overrides: Partial<Record<keyof SimuladosRepository, unknown>> = {}) {
+  return {
+    findByUserAndWeek: vi.fn().mockResolvedValue(null),
+    listPriorCompletedSimulados: vi.fn().mockResolvedValue([]),
+    countAnswered: vi.fn().mockResolvedValue(0),
+    getOneForUser: vi.fn().mockResolvedValue(null),
+    recordAnswer: vi.fn(),
+    forceComplete: vi.fn(),
+    getResultsAggregate: vi.fn(),
+    startOrGetSimulado: vi.fn(),
+    ...overrides,
+  } as unknown as SimuladosRepository;
+}
+
+const NOW = new Date("2026-05-10T15:00:00Z"); // Sunday 12:00 BRT → weekStart=2026-05-10
+
+// ---------------------------------------------------------------------------
+// A9 Ultra-lapse exemption (required, fully fleshed-out per plan)
+// ---------------------------------------------------------------------------
+
+describe("SimuladosService — A9 Ultra-lapse exemption", () => {
+  function buildSut(opts: { isUltra: boolean; existingSimulado: unknown | null }) {
+    const ultra = { isUltra: vi.fn().mockResolvedValue(opts.isUltra) } as unknown as import("../ultra/ultra.service").UltraService;
+    const repo = {
+      findByUserAndWeek: vi.fn().mockResolvedValue(opts.existingSimulado),
+      listPriorCompletedSimulados: vi.fn().mockResolvedValue([]),
+      countAnswered: vi.fn().mockResolvedValue(0),
+      getOneForUser: vi.fn(),
+      recordAnswer: vi.fn(),
+      forceComplete: vi.fn(),
+      getResultsAggregate: vi.fn(),
+      startOrGetSimulado: vi.fn(),
+    } as unknown as import("./simulados.repository").SimuladosRepository;
+    return { service: new SimuladosService(repo, ultra), ultra, repo };
+  }
+
+  it("getCurrent: lapsed Ultra with existing in-progress simulado returns 200 (no 403)", async () => {
+    const existing = {
+      id: 42, userId: "u1", weekStartDate: "2026-05-10",
+      startedAt: new Date("2026-05-10T12:00:00Z"), completedAt: null,
+      questionsCount: 35, correctCount: 4,
+    };
+    const { service, ultra } = buildSut({ isUltra: false, existingSimulado: existing });
+    const r = await service.getCurrent("u1", new Date("2026-05-10T15:00:00Z"));
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.status).toBe("in_progress");
+      expect(r.value.simulado?.id).toBe(42);
+    }
+    // Critical: the Ultra check must NOT have been called when an existing simulado was found.
+    expect(ultra.isUltra).not.toHaveBeenCalled();
+  });
+
+  it("getCurrent: lapsed Ultra with NO simulado for the current week returns 403", async () => {
+    const { service } = buildSut({ isUltra: false, existingSimulado: null });
+    const r = await service.getCurrent("u1", new Date("2026-05-10T15:00:00Z"));
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.message).toContain("ULTRA_REQUIRED");
+  });
+
+  it("start: lapsed Ultra always returns 403, even if an old simulado exists", async () => {
+    const { service } = buildSut({ isUltra: false, existingSimulado: null });
+    const r = await service.start("u1", new Date("2026-05-10T15:00:00Z"));
+    expect(r.isErr()).toBe(true);
+  });
+
+  it("recordAnswer: lapsed Ultra with owned simulado succeeds (Ultra check skipped)", async () => {
+    const ultra = { isUltra: vi.fn().mockResolvedValue(false) } as unknown as import("../ultra/ultra.service").UltraService;
+    const repo = {
+      recordAnswer: vi.fn().mockResolvedValue({
+        kind: "recorded", isCorrect: true, correctOptionIndex: 0, explanation: null,
+        answeredCount: 1, completed: false,
+      }),
+    } as unknown as import("./simulados.repository").SimuladosRepository;
+    const service = new SimuladosService(repo, ultra);
+    const r = await service.recordAnswer(42, "u1", 100, 0);
+    expect(r.isOk()).toBe(true);
+    expect(ultra.isUltra).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCurrent
+// ---------------------------------------------------------------------------
+
+describe("SimuladosService.getCurrent", () => {
+  it("non-Ultra with no simulado returns ForbiddenError ULTRA_REQUIRED", async () => {
+    const service = new SimuladosService(makeRepo(), makeUltra(false));
+    const r = await service.getCurrent("u1", NOW);
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) {
+      expect(r.error.statusCode).toBe(403);
+      expect(r.error.message).toContain("ULTRA_REQUIRED");
+    }
+  });
+
+  it("Ultra + no simulado → status not_started, simulado null", async () => {
+    const repo = makeRepo({ listPriorCompletedSimulados: vi.fn().mockResolvedValue([]) });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.getCurrent("u1", NOW);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.status).toBe("not_started");
+      expect(r.value.simulado).toBeNull();
+      expect(r.value.weekStart).toBe("2026-05-10");
+      expect(r.value.weekEnd).toBe("2026-05-17");
+    }
+  });
+
+  it("Ultra + in-progress simulado → status in_progress with correct fields", async () => {
+    const existing = {
+      id: 7, userId: "u1", weekStartDate: "2026-05-10",
+      startedAt: new Date("2026-05-10T10:00:00Z"), completedAt: null,
+      questionsCount: 35, correctCount: 3,
+    };
+    const repo = makeRepo({
+      findByUserAndWeek: vi.fn().mockResolvedValue(existing),
+      countAnswered: vi.fn().mockResolvedValue(5),
+    });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.getCurrent("u1", NOW);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.status).toBe("in_progress");
+      expect(r.value.simulado?.id).toBe(7);
+      expect(r.value.simulado?.answeredCount).toBe(5);
+      expect(r.value.simulado?.correctCount).toBe(3);
+    }
+  });
+
+  it("Ultra + completed simulado → status completed", async () => {
+    const existing = {
+      id: 8, userId: "u1", weekStartDate: "2026-05-10",
+      startedAt: new Date("2026-05-10T10:00:00Z"),
+      completedAt: new Date("2026-05-10T11:00:00Z"),
+      questionsCount: 35, correctCount: 20,
+    };
+    const repo = makeRepo({
+      findByUserAndWeek: vi.fn().mockResolvedValue(existing),
+      countAnswered: vi.fn().mockResolvedValue(35),
+    });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.getCurrent("u1", NOW);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.status).toBe("completed");
+      expect(r.value.simulado?.completedAt).toBeDefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// start
+// ---------------------------------------------------------------------------
+
+describe("SimuladosService.start", () => {
+  it("non-Ultra → ForbiddenError 403", async () => {
+    const service = new SimuladosService(makeRepo(), makeUltra(false));
+    const r = await service.start("u1", NOW);
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.statusCode).toBe(403);
+  });
+
+  it("Ultra → calls repo.startOrGetSimulado with (userId, weekStart, 35) and returns stripped question list", async () => {
+    const mockSimulado = {
+      id: 1, userId: "u1", weekStartDate: "2026-05-10",
+      startedAt: new Date("2026-05-10T10:00:00Z"), completedAt: null,
+      questionsCount: 2, correctCount: 0,
+    };
+    const mockQuestions = [
+      {
+        position: 0, questionId: 10, content: "Q1", options: ["a", "b", "c", "d"],
+        subjectId: 1, subtopicId: 1, requiresCalculation: false,
+        correctOptionIndex: 2, explanation: "exp1",
+        selectedOptionIndex: null, isCorrect: null,
+      },
+      {
+        position: 1, questionId: 11, content: "Q2", options: ["a", "b", "c", "d"],
+        subjectId: 1, subtopicId: 1, requiresCalculation: false,
+        correctOptionIndex: 0, explanation: null,
+        selectedOptionIndex: null, isCorrect: null,
+      },
+    ];
+    const startOrGetSimulado = vi.fn().mockResolvedValue({ simulado: mockSimulado, questions: mockQuestions, created: true });
+    const repo = makeRepo({ startOrGetSimulado });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.start("u1", NOW);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      // Verify repo called with correct args
+      expect(startOrGetSimulado).toHaveBeenCalledWith("u1", "2026-05-10", 35);
+      // Verify correctOptionIndex and explanation are stripped from returned questions
+      for (const q of r.value.questions) {
+        expect(q).not.toHaveProperty("correctOptionIndex");
+        expect(q).not.toHaveProperty("explanation");
+      }
+      expect(r.value.questions[0]?.questionId).toBe(10);
+      expect(r.value.simulado.id).toBe(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordAnswer
+// ---------------------------------------------------------------------------
+
+describe("SimuladosService.recordAnswer", () => {
+  it("not_found → NotFoundError 404", async () => {
+    const repo = makeRepo({ recordAnswer: vi.fn().mockResolvedValue({ kind: "not_found" }) });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.recordAnswer(1, "u1", 10, 0);
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.statusCode).toBe(404);
+  });
+
+  it("bad_question → ValidationError 400", async () => {
+    const repo = makeRepo({ recordAnswer: vi.fn().mockResolvedValue({ kind: "bad_question" }) });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.recordAnswer(1, "u1", 999, 0);
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.statusCode).toBe(400);
+  });
+
+  it("already_completed → ConflictError 409", async () => {
+    const repo = makeRepo({ recordAnswer: vi.fn().mockResolvedValue({ kind: "already_completed" }) });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.recordAnswer(1, "u1", 10, 0);
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.statusCode).toBe(409);
+  });
+
+  it("recorded → ok with correct response shape", async () => {
+    const repo = makeRepo({
+      recordAnswer: vi.fn().mockResolvedValue({
+        kind: "recorded", isCorrect: true, correctOptionIndex: 2, explanation: "exp",
+        answeredCount: 3, completed: false,
+      }),
+    });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.recordAnswer(1, "u1", 10, 2);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.isCorrect).toBe(true);
+      expect(r.value.correctOptionIndex).toBe(2);
+      expect(r.value.explanation).toBe("exp");
+      expect(r.value.answeredCount).toBe(3);
+      expect(r.value.completed).toBe(false);
+    }
+  });
+
+  it("already_answered → ok with originally-recorded outcome", async () => {
+    const repo = makeRepo({
+      recordAnswer: vi.fn().mockResolvedValue({
+        kind: "already_answered", isCorrect: true, selectedOptionIndex: 2,
+        correctOptionIndex: 2, explanation: null, answeredCount: 5, completed: false,
+      }),
+    });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.recordAnswer(1, "u1", 10, 3);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.isCorrect).toBe(true);
+      expect(r.value.correctOptionIndex).toBe(2);
+    }
+  });
+
+  it("does NOT call ultra.isUltra (A9 exemption)", async () => {
+    const ultra = makeUltra(false);
+    const repo = makeRepo({
+      recordAnswer: vi.fn().mockResolvedValue({
+        kind: "recorded", isCorrect: false, correctOptionIndex: 1, explanation: null,
+        answeredCount: 1, completed: false,
+      }),
+    });
+    const service = new SimuladosService(repo, ultra);
+    await service.recordAnswer(1, "u1", 10, 0);
+    expect(ultra.isUltra).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forceComplete
+// ---------------------------------------------------------------------------
+
+describe("SimuladosService.forceComplete", () => {
+  it("not_found → NotFoundError 404", async () => {
+    const repo = makeRepo({ forceComplete: vi.fn().mockResolvedValue({ kind: "not_found" }) });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.forceComplete(1, "u1");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.statusCode).toBe(404);
+  });
+
+  it("completed → ok with id and completedAt", async () => {
+    const completedAt = new Date("2026-05-10T14:00:00Z");
+    const repo = makeRepo({
+      forceComplete: vi.fn().mockResolvedValue({ kind: "completed", completedAt }),
+    });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.forceComplete(5, "u1");
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.id).toBe(5);
+      expect(r.value.completedAt).toBe(completedAt.toISOString());
+    }
+  });
+
+  it("does NOT call ultra.isUltra (A9 exemption)", async () => {
+    const ultra = makeUltra(false);
+    const completedAt = new Date();
+    const repo = makeRepo({
+      forceComplete: vi.fn().mockResolvedValue({ kind: "completed", completedAt }),
+    });
+    const service = new SimuladosService(repo, ultra);
+    await service.forceComplete(1, "u1");
+    expect(ultra.isUltra).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDetail
+// ---------------------------------------------------------------------------
+
+describe("SimuladosService.getDetail", () => {
+  it("not owned → NotFoundError 404", async () => {
+    const service = new SimuladosService(makeRepo(), makeUltra(true));
+    const r = await service.getDetail(99, "u1");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.statusCode).toBe(404);
+  });
+
+  it("in-progress: unanswered questions hide correctOptionIndex and explanation", async () => {
+    const simulado = {
+      id: 1, userId: "u1", weekStartDate: "2026-05-10",
+      startedAt: new Date("2026-05-10T10:00:00Z"), completedAt: null,
+      questionsCount: 2, correctCount: 1,
+    };
+    const questions = [
+      {
+        position: 0, questionId: 10, content: "Q1", options: ["a","b","c","d"],
+        subjectId: 1, subtopicId: 1, requiresCalculation: false,
+        correctOptionIndex: 2, explanation: "exp1",
+        selectedOptionIndex: 2, isCorrect: true, // answered
+      },
+      {
+        position: 1, questionId: 11, content: "Q2", options: ["a","b","c","d"],
+        subjectId: 1, subtopicId: 1, requiresCalculation: false,
+        correctOptionIndex: 0, explanation: "exp2",
+        selectedOptionIndex: null, isCorrect: null, // unanswered
+      },
+    ];
+    const repo = makeRepo({ getOneForUser: vi.fn().mockResolvedValue({ simulado, questions }) });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.getDetail(1, "u1");
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      const answered = r.value.questions[0]!;
+      const unanswered = r.value.questions[1]!;
+      // Answered question reveals correctOptionIndex and explanation
+      expect(answered.correctOptionIndex).toBe(2);
+      expect(answered.explanation).toBe("exp1");
+      // Unanswered question hides them
+      expect(unanswered.correctOptionIndex).toBeNull();
+      expect(unanswered.explanation).toBeNull();
+    }
+  });
+
+  it("completed: ALL questions reveal correctOptionIndex and explanation", async () => {
+    const simulado = {
+      id: 2, userId: "u1", weekStartDate: "2026-05-10",
+      startedAt: new Date("2026-05-10T10:00:00Z"),
+      completedAt: new Date("2026-05-10T11:00:00Z"),
+      questionsCount: 1, correctCount: 0,
+    };
+    const questions = [
+      {
+        position: 0, questionId: 10, content: "Q1", options: ["a","b","c","d"],
+        subjectId: 1, subtopicId: 1, requiresCalculation: false,
+        correctOptionIndex: 3, explanation: "exp3",
+        selectedOptionIndex: null, isCorrect: null, // unanswered but simulado is completed
+      },
+    ];
+    const repo = makeRepo({ getOneForUser: vi.fn().mockResolvedValue({ simulado, questions }) });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.getDetail(2, "u1");
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      // Even unanswered question reveals correctOptionIndex when simulado is completed
+      expect(r.value.questions[0]!.correctOptionIndex).toBe(3);
+      expect(r.value.questions[0]!.explanation).toBe("exp3");
+    }
+  });
+
+  it("does NOT call ultra.isUltra (A9 exemption)", async () => {
+    const ultra = makeUltra(false);
+    const service = new SimuladosService(makeRepo(), ultra);
+    await service.getDetail(99, "u1");
+    expect(ultra.isUltra).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getResults
+// ---------------------------------------------------------------------------
+
+describe("SimuladosService.getResults", () => {
+  it("not owned → NotFoundError 404", async () => {
+    const service = new SimuladosService(makeRepo(), makeUltra(true));
+    const r = await service.getResults(99, "u1");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.statusCode).toBe(404);
+  });
+
+  it("in-progress → ValidationError 400", async () => {
+    const simulado = {
+      id: 3, userId: "u1", weekStartDate: "2026-05-10",
+      startedAt: new Date("2026-05-10T10:00:00Z"), completedAt: null,
+      questionsCount: 35, correctCount: 0,
+    };
+    const repo = makeRepo({
+      getOneForUser: vi.fn().mockResolvedValue({ simulado, questions: [] }),
+    });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.getResults(3, "u1");
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.statusCode).toBe(400);
+  });
+
+  it("completed → ok with aggregate and history", async () => {
+    const simulado = {
+      id: 4, userId: "u1", weekStartDate: "2026-05-10",
+      startedAt: new Date("2026-05-10T10:00:00Z"),
+      completedAt: new Date("2026-05-10T11:00:00Z"),
+      questionsCount: 35, correctCount: 25,
+    };
+    const aggregate = {
+      correct: 25, total: 35,
+      perSubject: [{ subjectId: 1, correct: 15, total: 20 }, { subjectId: 2, correct: 10, total: 15 }],
+    };
+    const history = [
+      { weekStart: "2026-05-03", correct: 20, total: 35, perSubject: [] },
+    ];
+    const repo = makeRepo({
+      getOneForUser: vi.fn().mockResolvedValue({ simulado, questions: [] }),
+      getResultsAggregate: vi.fn().mockResolvedValue(aggregate),
+      listPriorCompletedSimulados: vi.fn().mockResolvedValue(history),
+    });
+    const service = new SimuladosService(repo, makeUltra(true));
+    const r = await service.getResults(4, "u1");
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.correct).toBe(25);
+      expect(r.value.total).toBe(35);
+      expect(r.value.weekStart).toBe("2026-05-10");
+      expect(r.value.perSubject).toHaveLength(2);
+      expect(r.value.history).toHaveLength(1);
+    }
+  });
+
+  it("does NOT call ultra.isUltra (A9 exemption)", async () => {
+    const ultra = makeUltra(false);
+    const service = new SimuladosService(makeRepo(), ultra);
+    await service.getResults(99, "u1");
+    expect(ultra.isUltra).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/features/simulados/simulados.service.ts
+++ b/apps/server/src/features/simulados/simulados.service.ts
@@ -1,0 +1,171 @@
+import { ok, err, type Result } from "neverthrow";
+import { AppError, NotFoundError, ValidationError, ForbiddenError, ConflictError } from "../../utils/errors";
+import {
+  SIMULADO_QUESTION_COUNT,
+  weekBoundsForSimulado,
+  type SimuladoCurrentResponse,
+  type SimuladoStartResponse,
+  type SimuladoDetailResponse,
+  type SimuladoAnswerResponse,
+  type SimuladoResultsResponse,
+} from "@pruvi/shared";
+import type { SimuladosRepository, SimuladoQuestionRow } from "./simulados.repository";
+import type { UltraService } from "../ultra/ultra.service";
+import type { FastifyBaseLogger } from "fastify";
+
+const HISTORY_LIMIT = 4;
+
+export class SimuladosService {
+  constructor(
+    private repo: SimuladosRepository,
+    private ultra: UltraService,
+    private logger?: FastifyBaseLogger,
+  ) {}
+
+  /** Strips correctOptionIndex + explanation from questions that haven't been answered
+   *  (and the simulado is not completed). Once the simulado is completed, all
+   *  questions reveal both fields. */
+  private sanitizeQuestions(questions: SimuladoQuestionRow[], simuladoCompleted: boolean) {
+    return questions.map((q) => {
+      const reveal = simuladoCompleted || q.selectedOptionIndex !== null;
+      return {
+        position: q.position,
+        questionId: q.questionId,
+        content: q.content,
+        options: q.options,
+        subjectId: q.subjectId,
+        subtopicId: q.subtopicId,
+        requiresCalculation: q.requiresCalculation,
+        selectedOptionIndex: q.selectedOptionIndex,
+        isCorrect: q.isCorrect,
+        correctOptionIndex: reveal ? q.correctOptionIndex : null,
+        explanation: reveal ? q.explanation : null,
+      };
+    });
+  }
+
+  async getCurrent(userId: string, now = new Date()): Promise<Result<SimuladoCurrentResponse, AppError>> {
+    // Per spec §4 / A9: Ultra check is deferred. A user who started a simulado while Ultra
+    // was active retains read access even if Ultra has lapsed. We only enforce ULTRA_REQUIRED
+    // when there is NO simulado for the current week (i.e., they'd be requesting a `not_started`
+    // view that would normally lead to /start, which IS Ultra-gated).
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    const existing = await this.repo.findByUserAndWeek(userId, weekStart);
+    const history = await this.repo.listPriorCompletedSimulados(userId, weekStart, HISTORY_LIMIT);
+    if (!existing) {
+      if (!(await this.ultra.isUltra(userId))) return err(new ForbiddenError("ULTRA_REQUIRED"));
+      return ok({ weekStart, weekEnd, status: "not_started", simulado: null, history });
+    }
+    const status: SimuladoCurrentResponse["status"] = existing.completedAt ? "completed" : "in_progress";
+    const answeredCount = await this.repo.countAnswered(existing.id);
+    return ok({
+      weekStart,
+      weekEnd,
+      status,
+      simulado: {
+        id: existing.id,
+        startedAt: existing.startedAt.toISOString(),
+        completedAt: existing.completedAt?.toISOString() ?? null,
+        questionsCount: existing.questionsCount,
+        answeredCount,
+        correctCount: existing.correctCount,
+      },
+      history,
+    });
+  }
+
+  async start(userId: string, now = new Date()): Promise<Result<SimuladoStartResponse, AppError>> {
+    if (!(await this.ultra.isUltra(userId))) return err(new ForbiddenError("ULTRA_REQUIRED"));
+    const { weekStart } = weekBoundsForSimulado(now);
+    const { simulado, questions } = await this.repo.startOrGetSimulado(userId, weekStart, SIMULADO_QUESTION_COUNT);
+    return ok({
+      simulado: { id: simulado.id, startedAt: simulado.startedAt.toISOString(), questionsCount: simulado.questionsCount },
+      questions: questions.map((q) => ({
+        position: q.position,
+        questionId: q.questionId,
+        content: q.content,
+        options: q.options,
+        subjectId: q.subjectId,
+        subtopicId: q.subtopicId,
+        requiresCalculation: q.requiresCalculation,
+      })),
+    });
+  }
+
+  // Intentionally NOT gated by ultra.isUltra — see spec §4 A9 (Ultra-lapse mid-simulado).
+  async getDetail(simuladoId: number, userId: string): Promise<Result<SimuladoDetailResponse, AppError>> {
+    const found = await this.repo.getOneForUser(simuladoId, userId);
+    if (!found) return err(new NotFoundError("Simulado not found"));
+    const completed = found.simulado.completedAt !== null;
+    return ok({
+      simulado: {
+        id: found.simulado.id,
+        weekStart: found.simulado.weekStartDate,
+        startedAt: found.simulado.startedAt.toISOString(),
+        completedAt: found.simulado.completedAt?.toISOString() ?? null,
+        questionsCount: found.simulado.questionsCount,
+        answeredCount: found.questions.filter((q) => q.selectedOptionIndex !== null).length,
+        correctCount: found.simulado.correctCount,
+        status: completed ? "completed" : "in_progress",
+      },
+      questions: this.sanitizeQuestions(found.questions, completed),
+    });
+  }
+
+  // Intentionally NOT gated by ultra.isUltra — see spec §4 A9.
+  async recordAnswer(
+    simuladoId: number,
+    userId: string,
+    questionId: number,
+    selectedOptionIndex: number,
+  ): Promise<Result<SimuladoAnswerResponse, AppError>> {
+    const r = await this.repo.recordAnswer(simuladoId, userId, questionId, selectedOptionIndex);
+    switch (r.kind) {
+      case "not_found":
+        return err(new NotFoundError("Simulado not found"));
+      case "bad_question":
+        return err(new ValidationError("Question does not belong to this simulado"));
+      case "already_completed":
+        return err(new ConflictError("Simulado already completed"));
+      case "recorded":
+        return ok({
+          isCorrect: r.isCorrect,
+          correctOptionIndex: r.correctOptionIndex,
+          explanation: r.explanation,
+          answeredCount: r.answeredCount,
+          completed: r.completed,
+        });
+      case "already_answered":
+        return ok({
+          isCorrect: r.isCorrect,
+          correctOptionIndex: r.correctOptionIndex,
+          explanation: r.explanation,
+          answeredCount: r.answeredCount,
+          completed: r.completed,
+        });
+    }
+  }
+
+  // Intentionally NOT gated by ultra.isUltra — see spec §4 A9.
+  async forceComplete(simuladoId: number, userId: string): Promise<Result<{ id: number; completedAt: string }, AppError>> {
+    const r = await this.repo.forceComplete(simuladoId, userId);
+    if (r.kind === "not_found") return err(new NotFoundError("Simulado not found"));
+    return ok({ id: simuladoId, completedAt: r.completedAt.toISOString() });
+  }
+
+  // Intentionally NOT gated by ultra.isUltra — see spec §4 A9.
+  async getResults(simuladoId: number, userId: string): Promise<Result<SimuladoResultsResponse, AppError>> {
+    const found = await this.repo.getOneForUser(simuladoId, userId);
+    if (!found) return err(new NotFoundError("Simulado not found"));
+    if (!found.simulado.completedAt) return err(new ValidationError("Simulado not yet completed"));
+    const agg = await this.repo.getResultsAggregate(simuladoId);
+    const history = await this.repo.listPriorCompletedSimulados(userId, found.simulado.weekStartDate, HISTORY_LIMIT);
+    return ok({
+      weekStart: found.simulado.weekStartDate,
+      correct: agg.correct,
+      total: agg.total,
+      perSubject: agg.perSubject,
+      history,
+    });
+  }
+}

--- a/apps/server/src/features/simulados/simulados.service.ts
+++ b/apps/server/src/features/simulados/simulados.service.ts
@@ -11,7 +11,6 @@ import {
 } from "@pruvi/shared";
 import type { SimuladosRepository, SimuladoQuestionRow } from "./simulados.repository";
 import type { UltraService } from "../ultra/ultra.service";
-import type { FastifyBaseLogger } from "fastify";
 
 const HISTORY_LIMIT = 4;
 
@@ -19,7 +18,6 @@ export class SimuladosService {
   constructor(
     private repo: SimuladosRepository,
     private ultra: UltraService,
-    private logger?: FastifyBaseLogger,
   ) {}
 
   /** Strips correctOptionIndex + explanation from questions that haven't been answered

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -13,6 +13,7 @@ import { tokensRoutes, preferencesRoutes } from "./features/notifications";
 import { invitationsRoutes, friendshipsRoutes, rankingRoutes } from "./features/social";
 import { ultraRoutes } from "./features/ultra/ultra.route";
 import { shieldsRoutes } from "./features/shields/shields.route";
+import { simuladosRoutes } from "./features/simulados";
 import { livesRoutes } from "./features/lives";
 import { onboardingRoutes } from "./features/onboarding";
 import { progressRoutes } from "./features/progress";
@@ -88,6 +89,7 @@ export async function buildApp() {
   await app.register(rankingRoutes);
   await app.register(ultraRoutes);
   await app.register(shieldsRoutes);
+  await app.register(simuladosRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/apps/server/src/test/db-helpers.ts
+++ b/apps/server/src/test/db-helpers.ts
@@ -63,7 +63,9 @@ export async function setupTestDb() {
 export async function cleanupTestDb() {
   const db = getTestDb();
   await db.execute(sql`
-    TRUNCATE TABLE push_token, review_log, daily_session, question, subtopic, topic, subject,
+    TRUNCATE TABLE weekly_simulado_question, weekly_simulado,
+      push_token, review_log, daily_session, streak_shield_usage,
+      question, subtopic, topic, subject,
       account, session, verification, "user" CASCADE
   `);
 }

--- a/docs/superpowers/plans/2026-05-12-phase-2e3-simulado-semanal.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e3-simulado-semanal.md
@@ -1,0 +1,1565 @@
+# Phase 2E.3 — Simulado Semanal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement task-by-task. Steps use checkbox (`- [ ]`) syntax. Per the user-enforced workflow, EVERY task gets Gate C (Opus 4.7 per-task review) before moving to the next.
+
+**Goal:** Backend-only delivery of a weekly mock exam for Ultra users (35 questions, BRT Sunday-Sunday window, per-subject results, 4-week prior history), strictly per the v2 spec at `docs/superpowers/specs/2026-05-12-phase-2e3-simulado-semanal-design.md`.
+
+**Architecture:** New `simulados` feature module (route + service + repository) under `apps/server/src/features/`, two new tables (`weekly_simulado`, `weekly_simulado_question`), one new shared time helper, one new Sunday-anchored week helper, Zod schemas in `@pruvi/shared`. Ultra entitlement gating via the existing `UltraService.isUltra` method. Race safety via INSERT-ON-CONFLICT for `/start` and `SELECT ... FOR UPDATE` for `/answer`. 60s response cache on `/current` with explicit invalidation.
+
+**Tech Stack:** Drizzle ORM + drizzle-kit, Fastify 5 + fastify-type-provider-zod, neverthrow Result, PGlite/Postgres for tests, Zod validation, BullMQ unused for this phase.
+
+---
+
+## Task 1 — Shared time constant, simulado week helper, Zod schemas
+
+**Files:**
+- Create: `packages/shared/src/time.ts`
+- Modify: `packages/shared/src/weekly.ts`
+- Create: `packages/shared/src/simulado.ts`
+- Create: `packages/shared/src/simulado.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] **Step 1.1: Create the shared BRT time constant**
+
+Create `packages/shared/src/time.ts`:
+
+```ts
+/** Brazil time offset: UTC-3, no DST (Brazil suspended DST in 2019). */
+export const BRT_OFFSET_MS = 3 * 60 * 60 * 1000;
+```
+
+- [ ] **Step 1.2: Make `weekly.ts` import the shared constant**
+
+Replace the top of `packages/shared/src/weekly.ts`:
+
+```ts
+import { BRT_OFFSET_MS } from "./time";
+
+export function startOfWeekBrt(now: Date): Date {
+  const brtMs = now.getTime() - BRT_OFFSET_MS;
+  const brt = new Date(brtMs);
+  const dow = brt.getUTCDay();
+  const daysBack = (dow + 6) % 7;
+  brt.setUTCDate(brt.getUTCDate() - daysBack);
+  brt.setUTCHours(0, 0, 0, 0);
+  return new Date(brt.getTime() + BRT_OFFSET_MS);
+}
+```
+
+- [ ] **Step 1.3: Create `simulado.ts` with constants, helper, and Zod schemas**
+
+Create `packages/shared/src/simulado.ts`:
+
+```ts
+import { z } from "zod";
+import { BRT_OFFSET_MS } from "./time";
+
+export const SIMULADO_QUESTION_COUNT = 35;
+
+/** Sunday-anchored BRT week bounds. Returns BRT calendar dates as YYYY-MM-DD.
+ *  Subtraction is applied before truncation so the returned string is the BRT
+ *  calendar date, not the UTC calendar date. */
+export function weekBoundsForSimulado(now: Date): { weekStart: string; weekEnd: string } {
+  const brtMs = now.getTime() - BRT_OFFSET_MS;
+  const brt = new Date(brtMs);
+  const dow = brt.getUTCDay(); // 0=Sun..6=Sat
+  brt.setUTCDate(brt.getUTCDate() - dow);
+  brt.setUTCHours(0, 0, 0, 0);
+  const start = new Date(brt);
+  const end = new Date(brt);
+  end.setUTCDate(end.getUTCDate() + 7);
+  return {
+    weekStart: start.toISOString().slice(0, 10),
+    weekEnd: end.toISOString().slice(0, 10),
+  };
+}
+
+const PerSubjectSchema = z.object({
+  subjectId: z.number().int(),
+  correct: z.number().int(),
+  total: z.number().int(),
+});
+
+const HistoryEntrySchema = z.object({
+  weekStart: z.string(),
+  correct: z.number().int(),
+  total: z.number().int(),
+  perSubject: z.array(PerSubjectSchema),
+});
+
+export const SimuladoCurrentResponseSchema = z.object({
+  weekStart: z.string(),
+  weekEnd: z.string(),
+  status: z.enum(["not_started", "in_progress", "completed"]),
+  simulado: z
+    .object({
+      id: z.number().int(),
+      startedAt: z.string(),
+      completedAt: z.string().nullable(),
+      questionsCount: z.number().int(),
+      answeredCount: z.number().int(),
+      correctCount: z.number().int(),
+    })
+    .nullable(),
+  history: z.array(HistoryEntrySchema),
+});
+export type SimuladoCurrentResponse = z.infer<typeof SimuladoCurrentResponseSchema>;
+
+export const SimuladoQuestionSchema = z.object({
+  position: z.number().int(),
+  questionId: z.number().int(),
+  content: z.string(),
+  options: z.array(z.string()),
+  subjectId: z.number().int(),
+  subtopicId: z.number().int(),
+  requiresCalculation: z.boolean(),
+});
+export type SimuladoQuestion = z.infer<typeof SimuladoQuestionSchema>;
+
+export const SimuladoStartResponseSchema = z.object({
+  simulado: z.object({
+    id: z.number().int(),
+    startedAt: z.string(),
+    questionsCount: z.number().int(),
+  }),
+  questions: z.array(SimuladoQuestionSchema),
+});
+export type SimuladoStartResponse = z.infer<typeof SimuladoStartResponseSchema>;
+
+export const SimuladoAnsweredQuestionSchema = SimuladoQuestionSchema.extend({
+  selectedOptionIndex: z.number().int().nullable(),
+  isCorrect: z.boolean().nullable(),
+  correctOptionIndex: z.number().int().nullable(),
+  explanation: z.string().nullable(),
+});
+export type SimuladoAnsweredQuestion = z.infer<typeof SimuladoAnsweredQuestionSchema>;
+
+export const SimuladoDetailResponseSchema = z.object({
+  simulado: z.object({
+    id: z.number().int(),
+    weekStart: z.string(),
+    startedAt: z.string(),
+    completedAt: z.string().nullable(),
+    questionsCount: z.number().int(),
+    answeredCount: z.number().int(),
+    correctCount: z.number().int(),
+    status: z.enum(["in_progress", "completed"]),
+  }),
+  questions: z.array(SimuladoAnsweredQuestionSchema),
+});
+export type SimuladoDetailResponse = z.infer<typeof SimuladoDetailResponseSchema>;
+
+export const SimuladoAnswerBodySchema = z.object({
+  questionId: z.number().int(),
+  selectedOptionIndex: z.number().int().min(0).max(3),
+});
+export type SimuladoAnswerBody = z.infer<typeof SimuladoAnswerBodySchema>;
+
+export const SimuladoAnswerResponseSchema = z.object({
+  isCorrect: z.boolean(),
+  correctOptionIndex: z.number().int(),
+  explanation: z.string().nullable(),
+  answeredCount: z.number().int(),
+  completed: z.boolean(),
+});
+export type SimuladoAnswerResponse = z.infer<typeof SimuladoAnswerResponseSchema>;
+
+export const SimuladoResultsResponseSchema = z.object({
+  weekStart: z.string(),
+  correct: z.number().int(),
+  total: z.number().int(),
+  perSubject: z.array(PerSubjectSchema),
+  history: z.array(HistoryEntrySchema),
+});
+export type SimuladoResultsResponse = z.infer<typeof SimuladoResultsResponseSchema>;
+```
+
+- [ ] **Step 1.4: Write the failing tests**
+
+Create `packages/shared/src/simulado.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { weekBoundsForSimulado, SIMULADO_QUESTION_COUNT } from "./simulado";
+
+describe("SIMULADO_QUESTION_COUNT", () => {
+  it("is 35 (mid-range of product spec 30-40)", () => {
+    expect(SIMULADO_QUESTION_COUNT).toBe(35);
+  });
+});
+
+describe("weekBoundsForSimulado", () => {
+  it("for Sunday 12:00 BRT (15:00 UTC), weekStart is that same Sunday's BRT date", () => {
+    // 2026-05-10 (Sunday) 15:00 UTC == 12:00 BRT
+    const now = new Date("2026-05-10T15:00:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-10");
+    expect(weekEnd).toBe("2026-05-17");
+  });
+
+  it("for Saturday 23:00 BRT (2026-05-09 23:00 BRT == 2026-05-10 02:00 UTC), weekStart is the PREVIOUS Sunday", () => {
+    const now = new Date("2026-05-10T02:00:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-03");
+    expect(weekEnd).toBe("2026-05-10");
+  });
+
+  it("for Sunday 02:00 BRT (Sun 05:00 UTC), weekStart is THAT Sunday's BRT date", () => {
+    const now = new Date("2026-05-10T05:00:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-10");
+    expect(weekEnd).toBe("2026-05-17");
+  });
+
+  it("for Sunday 01:00 UTC (Saturday 22:00 BRT), weekStart is the PREVIOUS Sunday", () => {
+    const now = new Date("2026-05-10T01:00:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-03");
+    expect(weekEnd).toBe("2026-05-10");
+  });
+});
+```
+
+- [ ] **Step 1.5: Export from `packages/shared/src/index.ts`**
+
+Add at the end of the existing exports list:
+
+```ts
+export * from "./time";
+export * from "./simulado";
+```
+
+(The existing `export * from "./shields"` line stays.)
+
+- [ ] **Step 1.6: Run the tests and commit**
+
+```bash
+cd packages/shared && bun test src/simulado.test.ts
+```
+Expected: all pass.
+
+Then from repo root:
+```bash
+git add packages/shared/src/time.ts packages/shared/src/weekly.ts packages/shared/src/simulado.ts packages/shared/src/simulado.test.ts packages/shared/src/index.ts
+git commit -m "feat(shared): simulado week helper, schemas, shared brt constant"
+```
+
+---
+
+## Task 2 — DB schema + drizzle migration
+
+**Files:**
+- Create: `packages/db/src/schema/weekly-simulado.ts`
+- Modify: `packages/db/src/schema/index.ts`
+- Create: `packages/db/src/migrations/0009_<generated-name>.sql` (auto-generated by drizzle-kit)
+- Create: `packages/db/src/migrations/meta/0009_snapshot.json`
+- Modify: `packages/db/src/migrations/meta/_journal.json`
+
+- [ ] **Step 2.1: Define the schema**
+
+Create `packages/db/src/schema/weekly-simulado.ts`:
+
+```ts
+import { relations } from "drizzle-orm";
+import { boolean, date, foreignKey, index, integer, pgTable, primaryKey, serial, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+import { question } from "./questions";
+
+export const weeklySimulado = pgTable(
+  "weekly_simulado",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    weekStartDate: date("week_start_date").notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true }).defaultNow().notNull(),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    questionsCount: integer("questions_count").notNull(),
+    correctCount: integer("correct_count").notNull().default(0),
+  },
+  (t) => [
+    uniqueIndex("weekly_simulado_user_week_uq").on(t.userId, t.weekStartDate),
+    index("weekly_simulado_user_week_idx").on(t.userId, t.weekStartDate),
+  ],
+);
+
+export const weeklySimuladoQuestion = pgTable(
+  "weekly_simulado_question",
+  {
+    simuladoId: integer("simulado_id").notNull().references(() => weeklySimulado.id, { onDelete: "cascade" }),
+    position: integer("position").notNull(),
+    questionId: integer("question_id").notNull().references(() => question.id, { onDelete: "restrict" }),
+    selectedOptionIndex: integer("selected_option_index"),
+    isCorrect: boolean("is_correct"),
+    answeredAt: timestamp("answered_at", { withTimezone: true }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.simuladoId, t.position] }),
+    uniqueIndex("weekly_simulado_question_simulado_question_uq").on(t.simuladoId, t.questionId),
+    index("weekly_simulado_question_simulado_idx").on(t.simuladoId),
+  ],
+);
+
+export const weeklySimuladoRelations = relations(weeklySimulado, ({ many, one }) => ({
+  user: one(user, { fields: [weeklySimulado.userId], references: [user.id] }),
+  questions: many(weeklySimuladoQuestion),
+}));
+
+export const weeklySimuladoQuestionRelations = relations(weeklySimuladoQuestion, ({ one }) => ({
+  simulado: one(weeklySimulado, { fields: [weeklySimuladoQuestion.simuladoId], references: [weeklySimulado.id] }),
+  question: one(question, { fields: [weeklySimuladoQuestion.questionId], references: [question.id] }),
+}));
+```
+
+- [ ] **Step 2.2: Register in schema index**
+
+Modify `packages/db/src/schema/index.ts` — add:
+
+```ts
+export * from "./weekly-simulado";
+```
+
+- [ ] **Step 2.3: Generate the migration**
+
+Run from `packages/db`:
+
+```bash
+bun run db:generate
+```
+
+(Use whichever script the package defines for `drizzle-kit generate`.)
+
+Verify the generated SQL contains:
+- `CREATE TABLE "weekly_simulado"` with all columns
+- `CREATE TABLE "weekly_simulado_question"` with composite PK
+- The two UNIQUE indexes
+- ON DELETE CASCADE for `user_id` and `simulado_id` references
+- ON DELETE RESTRICT for `question_id` reference
+
+If the generator names the new file `0009_<word>.sql`, that's fine; note the filename. If the generator pulled in unrelated diffs (e.g., stale snapshot), STOP and ask — do not commit unrelated migration changes.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add packages/db/src/schema/weekly-simulado.ts packages/db/src/schema/index.ts packages/db/src/migrations/
+git commit -m "feat(db): weekly_simulado + weekly_simulado_question tables"
+```
+
+---
+
+## Task 3 — Repository: `selectQuestionsForSimulado` + `startSimulado` (INSERT ... ON CONFLICT)
+
+**Files:**
+- Create: `apps/server/src/features/simulados/simulados.repository.ts`
+- Create: `apps/server/src/features/simulados/simulados.repository.integration.test.ts`
+
+- [ ] **Step 3.1: Skeleton repository**
+
+Create `apps/server/src/features/simulados/simulados.repository.ts`:
+
+```ts
+import { and, asc, count, desc, eq, isNull, lt, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { user } from "@pruvi/db/schema/auth";
+import { question } from "@pruvi/db/schema/questions";
+import { weeklySimulado, weeklySimuladoQuestion } from "@pruvi/db/schema/weekly-simulado";
+
+type Db = typeof DbClient;
+
+export type SimuladoRow = {
+  id: number;
+  userId: string;
+  weekStartDate: string;
+  startedAt: Date;
+  completedAt: Date | null;
+  questionsCount: number;
+  correctCount: number;
+};
+
+export type SimuladoQuestionRow = {
+  position: number;
+  questionId: number;
+  content: string;
+  options: string[];
+  correctOptionIndex: number;
+  explanation: string | null;
+  subjectId: number;
+  subtopicId: number;
+  requiresCalculation: boolean;
+  selectedOptionIndex: number | null;
+  isCorrect: boolean | null;
+};
+
+export class SimuladosRepository {
+  constructor(private db: Db) {}
+}
+```
+
+- [ ] **Step 3.2: Failing integration tests for selectQuestionsForSimulado + startSimulado**
+
+Create `apps/server/src/features/simulados/simulados.repository.integration.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { setupTestDb, cleanupTestDb, teardownTestDb, getTestDb } from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { question } from "@pruvi/db/schema/questions";
+import { SimuladosRepository } from "./simulados.repository";
+
+describe("SimuladosRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new SimuladosRepository(db);
+
+  beforeAll(async () => setupTestDb());
+  beforeEach(async () => cleanupTestDb());
+  afterAll(async () => teardownTestDb());
+
+  async function insertUser(id: string) {
+    await db.insert(user).values({
+      id,
+      name: `U ${id}`,
+      email: `${id}@e.com`,
+      emailVerified: false,
+      inviteCode: `c${id.replace(/-/g, "").slice(0, 8)}`,
+      username: null,
+      updatedAt: new Date(),
+    });
+  }
+
+  async function seedQuestions(n: number, subjectId = 1) {
+    for (let i = 1; i <= n; i++) {
+      await db.insert(question).values({
+        subjectId,
+        subtopicId: 1,
+        content: `Q${i}`,
+        options: ["a", "b", "c", "d"],
+        correctOptionIndex: i % 4,
+        difficulty: 1,
+        requiresCalculation: false,
+      });
+    }
+  }
+
+  describe("selectQuestionsForSimulado", () => {
+    it("returns deterministic ordering for same (userId, weekStart)", async () => {
+      await insertUser("u1");
+      await seedQuestions(50);
+      const a = await repo.selectQuestionsForSimulado("u1", "2026-05-10", 35);
+      const b = await repo.selectQuestionsForSimulado("u1", "2026-05-10", 35);
+      expect(a.map((q) => q.id)).toEqual(b.map((q) => q.id));
+      expect(a.length).toBe(35);
+      expect(new Set(a.map((q) => q.id)).size).toBe(35);
+    });
+
+    it("returns all available when bank is smaller than requested count", async () => {
+      await insertUser("u2");
+      await seedQuestions(10);
+      const a = await repo.selectQuestionsForSimulado("u2", "2026-05-10", 35);
+      expect(a.length).toBe(10);
+      expect(new Set(a.map((q) => q.id)).size).toBe(10);
+    });
+
+    it("returns different ordering for different (userId, weekStart)", async () => {
+      await insertUser("u3");
+      await seedQuestions(50);
+      const a = await repo.selectQuestionsForSimulado("u3", "2026-05-10", 10);
+      const b = await repo.selectQuestionsForSimulado("u3", "2026-05-17", 10);
+      // Same seed inputs produce different orderings (probabilistic; with 50 questions and 10 picks, collision risk is negligible)
+      expect(a.map((q) => q.id)).not.toEqual(b.map((q) => q.id));
+    });
+  });
+
+  describe("startOrGetSimulado", () => {
+    it("creates a new simulado with questions when none exists for (user, week)", async () => {
+      await insertUser("u4");
+      await seedQuestions(40);
+      const { simulado, questions, created } = await repo.startOrGetSimulado("u4", "2026-05-10", 35);
+      expect(created).toBe(true);
+      expect(simulado.questionsCount).toBe(35);
+      expect(simulado.correctCount).toBe(0);
+      expect(simulado.completedAt).toBeNull();
+      expect(questions.length).toBe(35);
+      expect(questions[0]!.position).toBe(0);
+      expect(questions[34]!.position).toBe(34);
+    });
+
+    it("is idempotent: second call returns the same simulado.id", async () => {
+      await insertUser("u5");
+      await seedQuestions(40);
+      const a = await repo.startOrGetSimulado("u5", "2026-05-10", 35);
+      const b = await repo.startOrGetSimulado("u5", "2026-05-10", 35);
+      expect(a.simulado.id).toBe(b.simulado.id);
+      expect(a.questions.map((q) => q.questionId)).toEqual(b.questions.map((q) => q.questionId));
+      expect(b.created).toBe(false);
+    });
+  });
+});
+```
+
+Run: `cd apps/server && bun test src/features/simulados/simulados.repository.integration.test.ts`
+Expected: FAIL — methods not implemented.
+
+- [ ] **Step 3.3: Implement `selectQuestionsForSimulado`**
+
+Append to `simulados.repository.ts` inside the class:
+
+```ts
+  /**
+   * Deterministic pseudo-random sample of `count` questions for a given
+   * (userId, weekStart). Repeatable as long as the bank doesn't change.
+   * If bank size < count, returns all available (graceful degradation).
+   */
+  async selectQuestionsForSimulado(userId: string, weekStart: string, count: number) {
+    const seed = `${userId}|${weekStart}`;
+    const rows = await this.db
+      .select({
+        id: question.id,
+        subjectId: question.subjectId,
+        subtopicId: question.subtopicId,
+        content: question.content,
+        options: question.options,
+        correctOptionIndex: question.correctOptionIndex,
+        explanation: question.explanation,
+        requiresCalculation: question.requiresCalculation,
+      })
+      .from(question)
+      .orderBy(sql`md5(${question.id}::text || ${seed})`)
+      .limit(count);
+    return rows;
+  }
+```
+
+- [ ] **Step 3.4: Implement `startOrGetSimulado` (INSERT ... ON CONFLICT)**
+
+Append:
+
+```ts
+  /**
+   * Idempotent under concurrency: uses INSERT ... ON CONFLICT DO NOTHING
+   * RETURNING. If conflict path is taken, re-reads the existing row.
+   * Question selection + bulk insert happen inside the same transaction so
+   * a simulado is never visible without its question set.
+   */
+  async startOrGetSimulado(userId: string, weekStart: string, requestedCount: number) {
+    return await this.db.transaction(async (tx) => {
+      // Attempt insert; ON CONFLICT (user_id, week_start_date) DO NOTHING.
+      const selection = await tx
+        .select({
+          id: question.id,
+          subjectId: question.subjectId,
+          subtopicId: question.subtopicId,
+          content: question.content,
+          options: question.options,
+          correctOptionIndex: question.correctOptionIndex,
+          explanation: question.explanation,
+          requiresCalculation: question.requiresCalculation,
+        })
+        .from(question)
+        .orderBy(sql`md5(${question.id}::text || ${`${userId}|${weekStart}`})`)
+        .limit(requestedCount);
+      const effectiveCount = selection.length;
+
+      const inserted = await tx
+        .insert(weeklySimulado)
+        .values({ userId, weekStartDate: weekStart, questionsCount: effectiveCount })
+        .onConflictDoNothing({ target: [weeklySimulado.userId, weeklySimulado.weekStartDate] })
+        .returning();
+
+      if (inserted.length > 0) {
+        const simulado = inserted[0]!;
+        // Bulk insert question rows.
+        if (effectiveCount > 0) {
+          await tx.insert(weeklySimuladoQuestion).values(
+            selection.map((q, idx) => ({
+              simuladoId: simulado.id,
+              position: idx,
+              questionId: q.id,
+            })),
+          );
+        }
+        const questions = selection.map((q, idx) => ({
+          position: idx,
+          questionId: q.id,
+          content: q.content,
+          options: q.options as string[],
+          correctOptionIndex: q.correctOptionIndex,
+          explanation: q.explanation,
+          subjectId: q.subjectId,
+          subtopicId: q.subtopicId,
+          requiresCalculation: q.requiresCalculation,
+          selectedOptionIndex: null as number | null,
+          isCorrect: null as boolean | null,
+        }));
+        return { simulado: this.toSimuladoRow(simulado), questions, created: true };
+      }
+
+      // Conflict path — re-read existing row + question set.
+      const existing = await tx
+        .select()
+        .from(weeklySimulado)
+        .where(and(eq(weeklySimulado.userId, userId), eq(weeklySimulado.weekStartDate, weekStart)))
+        .limit(1);
+      const simulado = existing[0];
+      if (!simulado) throw new Error("startOrGetSimulado: conflict but no existing row");
+      const existingQs = await this.fetchQuestionsForSimulado(tx, simulado.id);
+      return { simulado: this.toSimuladoRow(simulado), questions: existingQs, created: false };
+    });
+  }
+
+  private toSimuladoRow(row: typeof weeklySimulado.$inferSelect): SimuladoRow {
+    return {
+      id: row.id,
+      userId: row.userId,
+      weekStartDate: typeof row.weekStartDate === "string" ? row.weekStartDate : new Date(row.weekStartDate).toISOString().slice(0, 10),
+      startedAt: row.startedAt,
+      completedAt: row.completedAt,
+      questionsCount: row.questionsCount,
+      correctCount: row.correctCount,
+    };
+  }
+
+  private async fetchQuestionsForSimulado(tx: Db | Parameters<Db["transaction"]>[0] extends (tx: infer T) => unknown ? T : never, simuladoId: number): Promise<SimuladoQuestionRow[]> {
+    const rows = await (tx as Db)
+      .select({
+        position: weeklySimuladoQuestion.position,
+        questionId: weeklySimuladoQuestion.questionId,
+        selectedOptionIndex: weeklySimuladoQuestion.selectedOptionIndex,
+        isCorrect: weeklySimuladoQuestion.isCorrect,
+        content: question.content,
+        options: question.options,
+        correctOptionIndex: question.correctOptionIndex,
+        explanation: question.explanation,
+        subjectId: question.subjectId,
+        subtopicId: question.subtopicId,
+        requiresCalculation: question.requiresCalculation,
+      })
+      .from(weeklySimuladoQuestion)
+      .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+      .where(eq(weeklySimuladoQuestion.simuladoId, simuladoId))
+      .orderBy(asc(weeklySimuladoQuestion.position));
+    return rows.map((r) => ({
+      position: r.position,
+      questionId: r.questionId,
+      content: r.content,
+      options: r.options as string[],
+      correctOptionIndex: r.correctOptionIndex,
+      explanation: r.explanation,
+      subjectId: r.subjectId,
+      subtopicId: r.subtopicId,
+      requiresCalculation: r.requiresCalculation,
+      selectedOptionIndex: r.selectedOptionIndex,
+      isCorrect: r.isCorrect,
+    }));
+  }
+```
+
+- [ ] **Step 3.5: Run tests, verify pass, commit**
+
+```bash
+cd apps/server && bun test src/features/simulados/simulados.repository.integration.test.ts
+```
+Expected: all pass.
+
+```bash
+git add apps/server/src/features/simulados/simulados.repository.ts apps/server/src/features/simulados/simulados.repository.integration.test.ts
+git commit -m "feat(simulados): repository — deterministic question selection and start-or-get"
+```
+
+---
+
+## Task 4 — Repository: race-safe `recordAnswer`, `forceComplete`, `getOneForUser`
+
+**Files:**
+- Modify: `apps/server/src/features/simulados/simulados.repository.ts`
+- Modify: `apps/server/src/features/simulados/simulados.repository.integration.test.ts`
+
+- [ ] **Step 4.1: Failing tests**
+
+Append to `simulados.repository.integration.test.ts`:
+
+```ts
+  describe("recordAnswer", () => {
+    it("records first answer, increments correct_count on correct, returns correct outcome", async () => {
+      await insertUser("u-ans-1");
+      await seedQuestions(35);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-1", "2026-05-10", 35);
+      const q = questions[0]!;
+      const correctOpt = q.correctOptionIndex;
+      const result = await repo.recordAnswer(simulado.id, "u-ans-1", q.questionId, correctOpt);
+      expect(result.kind).toBe("recorded");
+      if (result.kind === "recorded") {
+        expect(result.isCorrect).toBe(true);
+        expect(result.completed).toBe(false);
+        expect(result.answeredCount).toBe(1);
+      }
+    });
+
+    it("first-answer-wins idempotency: second answer with different option returns original outcome", async () => {
+      await insertUser("u-ans-2");
+      await seedQuestions(35);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-2", "2026-05-10", 35);
+      const q = questions[0]!;
+      const correctOpt = q.correctOptionIndex;
+      const wrongOpt = (correctOpt + 1) % 4;
+      await repo.recordAnswer(simulado.id, "u-ans-2", q.questionId, correctOpt);
+      const second = await repo.recordAnswer(simulado.id, "u-ans-2", q.questionId, wrongOpt);
+      expect(second.kind).toBe("already_answered");
+      if (second.kind === "already_answered") {
+        expect(second.isCorrect).toBe(true);
+        expect(second.selectedOptionIndex).toBe(correctOpt);
+      }
+    });
+
+    it("auto-completes when the last unanswered question is answered", async () => {
+      await insertUser("u-ans-3");
+      await seedQuestions(5);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-3", "2026-05-10", 5);
+      for (let i = 0; i < 4; i++) {
+        const q = questions[i]!;
+        await repo.recordAnswer(simulado.id, "u-ans-3", q.questionId, q.correctOptionIndex);
+      }
+      const final = await repo.recordAnswer(simulado.id, "u-ans-3", questions[4]!.questionId, questions[4]!.correctOptionIndex);
+      expect(final.kind).toBe("recorded");
+      if (final.kind === "recorded") {
+        expect(final.completed).toBe(true);
+        expect(final.answeredCount).toBe(5);
+      }
+    });
+
+    it("returns kind='not_found' when simulado doesn't exist or isn't owned by user", async () => {
+      await insertUser("u-ans-4a");
+      await insertUser("u-ans-4b");
+      await seedQuestions(35);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-4a", "2026-05-10", 35);
+      const result = await repo.recordAnswer(simulado.id, "u-ans-4b", questions[0]!.questionId, 0);
+      expect(result.kind).toBe("not_found");
+    });
+
+    it("returns kind='bad_question' when questionId doesn't belong to this simulado", async () => {
+      await insertUser("u-ans-5");
+      await seedQuestions(40);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-5", "2026-05-10", 35);
+      const includedIds = new Set(questions.map((q) => q.questionId));
+      // Find a question NOT in the simulado
+      const allQuestions = await db.select({ id: question.id }).from(question);
+      const outsider = allQuestions.find((q) => !includedIds.has(q.id))!;
+      const result = await repo.recordAnswer(simulado.id, "u-ans-5", outsider.id, 0);
+      expect(result.kind).toBe("bad_question");
+    });
+
+    it("returns kind='already_completed' when simulado is already finalized", async () => {
+      await insertUser("u-ans-6");
+      await seedQuestions(35);
+      const { simulado, questions } = await repo.startOrGetSimulado("u-ans-6", "2026-05-10", 35);
+      await repo.forceComplete(simulado.id, "u-ans-6");
+      const result = await repo.recordAnswer(simulado.id, "u-ans-6", questions[0]!.questionId, 0);
+      expect(result.kind).toBe("already_completed");
+    });
+  });
+
+  describe("forceComplete", () => {
+    it("sets completed_at when not yet completed", async () => {
+      await insertUser("u-fc-1");
+      await seedQuestions(35);
+      const { simulado } = await repo.startOrGetSimulado("u-fc-1", "2026-05-10", 35);
+      const res = await repo.forceComplete(simulado.id, "u-fc-1");
+      expect(res.kind).toBe("completed");
+      if (res.kind === "completed") expect(res.completedAt).toBeInstanceOf(Date);
+    });
+
+    it("is idempotent on already-completed simulado", async () => {
+      await insertUser("u-fc-2");
+      await seedQuestions(35);
+      const { simulado } = await repo.startOrGetSimulado("u-fc-2", "2026-05-10", 35);
+      await repo.forceComplete(simulado.id, "u-fc-2");
+      const res = await repo.forceComplete(simulado.id, "u-fc-2");
+      expect(res.kind).toBe("completed");
+    });
+
+    it("returns not_found for unowned simulado", async () => {
+      await insertUser("u-fc-3a");
+      await insertUser("u-fc-3b");
+      await seedQuestions(35);
+      const { simulado } = await repo.startOrGetSimulado("u-fc-3a", "2026-05-10", 35);
+      const res = await repo.forceComplete(simulado.id, "u-fc-3b");
+      expect(res.kind).toBe("not_found");
+    });
+  });
+```
+
+Run: expect FAIL.
+
+- [ ] **Step 4.2: Implement `recordAnswer`**
+
+Add the result type at the top of `simulados.repository.ts` (after existing types):
+
+```ts
+export type RecordAnswerResult =
+  | { kind: "recorded"; isCorrect: boolean; correctOptionIndex: number; explanation: string | null; answeredCount: number; completed: boolean }
+  | { kind: "already_answered"; isCorrect: boolean; selectedOptionIndex: number; correctOptionIndex: number; explanation: string | null; answeredCount: number; completed: boolean }
+  | { kind: "not_found" }
+  | { kind: "bad_question" }
+  | { kind: "already_completed" };
+
+export type ForceCompleteResult =
+  | { kind: "completed"; completedAt: Date }
+  | { kind: "not_found" };
+```
+
+Inside the class, add:
+
+```ts
+  /**
+   * Race-safe under Read Committed via `SELECT ... FOR UPDATE` on the parent
+   * simulado row. Serializes concurrent answers on the same simulado to
+   * eliminate auto-completion races. First-answer-wins idempotency on the
+   * question row via WHERE selected_option_index IS NULL predicate.
+   */
+  async recordAnswer(simuladoId: number, userId: string, questionId: number, selectedOptionIndex: number): Promise<RecordAnswerResult> {
+    return await this.db.transaction(async (tx) => {
+      // 1. Lock parent row; check ownership and completion.
+      const locked = await tx.execute(sql`
+        SELECT id, user_id, completed_at, correct_count, questions_count
+        FROM weekly_simulado WHERE id = ${simuladoId} FOR UPDATE
+      `);
+      const parent = (locked.rows ?? locked)[0] as { id: number; user_id: string; completed_at: Date | null; correct_count: number; questions_count: number } | undefined;
+      if (!parent || parent.user_id !== userId) return { kind: "not_found" };
+      if (parent.completed_at !== null) return { kind: "already_completed" };
+
+      // 2. Look up the question within this simulado.
+      const qRow = await tx
+        .select({
+          selectedOptionIndex: weeklySimuladoQuestion.selectedOptionIndex,
+          isCorrect: weeklySimuladoQuestion.isCorrect,
+          correctOptionIndex: question.correctOptionIndex,
+          explanation: question.explanation,
+        })
+        .from(weeklySimuladoQuestion)
+        .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+        .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), eq(weeklySimuladoQuestion.questionId, questionId)))
+        .limit(1);
+      const qr = qRow[0];
+      if (!qr) return { kind: "bad_question" };
+
+      const correctOpt = qr.correctOptionIndex;
+      const explanation = qr.explanation;
+
+      // 3. If already answered, return the recorded outcome (first answer wins).
+      if (qr.selectedOptionIndex !== null) {
+        const answered = await tx
+          .select({ value: count() })
+          .from(weeklySimuladoQuestion)
+          .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), sql`${weeklySimuladoQuestion.selectedOptionIndex} IS NOT NULL`));
+        return {
+          kind: "already_answered",
+          isCorrect: qr.isCorrect ?? false,
+          selectedOptionIndex: qr.selectedOptionIndex,
+          correctOptionIndex: correctOpt,
+          explanation,
+          answeredCount: Number(answered[0]!.value),
+          completed: false,
+        };
+      }
+
+      // 4. Record the new answer.
+      const isCorrect = selectedOptionIndex === correctOpt;
+      await tx
+        .update(weeklySimuladoQuestion)
+        .set({ selectedOptionIndex, isCorrect, answeredAt: new Date() })
+        .where(and(
+          eq(weeklySimuladoQuestion.simuladoId, simuladoId),
+          eq(weeklySimuladoQuestion.questionId, questionId),
+          isNull(weeklySimuladoQuestion.selectedOptionIndex),
+        ));
+
+      // 5. Increment correct_count if correct.
+      if (isCorrect) {
+        await tx
+          .update(weeklySimulado)
+          .set({ correctCount: sql`${weeklySimulado.correctCount} + 1` })
+          .where(eq(weeklySimulado.id, simuladoId));
+      }
+
+      // 6. Count remaining unanswered. Because parent is FOR UPDATE-locked, no
+      //    other answer transaction can have committed since step 1.
+      const unanswered = await tx
+        .select({ value: count() })
+        .from(weeklySimuladoQuestion)
+        .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), isNull(weeklySimuladoQuestion.selectedOptionIndex)));
+      const remaining = Number(unanswered[0]!.value);
+      let completed = false;
+      if (remaining === 0) {
+        await tx
+          .update(weeklySimulado)
+          .set({ completedAt: new Date() })
+          .where(and(eq(weeklySimulado.id, simuladoId), isNull(weeklySimulado.completedAt)));
+        completed = true;
+      }
+      const answeredCount = parent.questions_count - remaining;
+      return { kind: "recorded", isCorrect, correctOptionIndex: correctOpt, explanation, answeredCount, completed };
+    });
+  }
+
+  async forceComplete(simuladoId: number, userId: string): Promise<ForceCompleteResult> {
+    const result = await this.db
+      .update(weeklySimulado)
+      .set({ completedAt: sql`COALESCE(${weeklySimulado.completedAt}, now())` })
+      .where(and(eq(weeklySimulado.id, simuladoId), eq(weeklySimulado.userId, userId)))
+      .returning({ completedAt: weeklySimulado.completedAt });
+    const row = result[0];
+    if (!row) return { kind: "not_found" };
+    return { kind: "completed", completedAt: row.completedAt! };
+  }
+
+  async getOneForUser(simuladoId: number, userId: string): Promise<{ simulado: SimuladoRow; questions: SimuladoQuestionRow[] } | null> {
+    const rows = await this.db
+      .select()
+      .from(weeklySimulado)
+      .where(and(eq(weeklySimulado.id, simuladoId), eq(weeklySimulado.userId, userId)))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    const questions = await this.fetchQuestionsForSimulado(this.db, row.id);
+    return { simulado: this.toSimuladoRow(row), questions };
+  }
+```
+
+**Note on `tx.execute(sql\`... FOR UPDATE\`)`:** drizzle-orm's `.for("update")` is supported on `.select()`; prefer:
+
+```ts
+const lockedRows = await tx
+  .select({ id: weeklySimulado.id, userId: weeklySimulado.userId, completedAt: weeklySimulado.completedAt, correctCount: weeklySimulado.correctCount, questionsCount: weeklySimulado.questionsCount })
+  .from(weeklySimulado)
+  .where(eq(weeklySimulado.id, simuladoId))
+  .for("update")
+  .limit(1);
+const parent = lockedRows[0];
+```
+
+Use the typed `.for("update")` form rather than raw `sql\`SELECT ... FOR UPDATE\``. Adjust the implementation accordingly (the field names map to `parent.userId`, `parent.completedAt`, `parent.questionsCount`).
+
+- [ ] **Step 4.3: Run tests, fix, commit**
+
+```bash
+cd apps/server && bun test src/features/simulados/simulados.repository.integration.test.ts
+```
+Expected: all pass.
+
+```bash
+git add apps/server/src/features/simulados/simulados.repository.ts apps/server/src/features/simulados/simulados.repository.integration.test.ts
+git commit -m "feat(simulados): repository — race-safe recordAnswer, forceComplete, getOneForUser"
+```
+
+---
+
+## Task 5 — Repository: history queries
+
+**Files:**
+- Modify: `apps/server/src/features/simulados/simulados.repository.ts`
+- Modify: `apps/server/src/features/simulados/simulados.repository.integration.test.ts`
+
+- [ ] **Step 5.1: Failing tests**
+
+Append to the integration test file:
+
+```ts
+  describe("listPriorCompletedSimulados", () => {
+    it("returns up to N most recent COMPLETED prior simulados, oldest first, with per-subject breakdown", async () => {
+      await insertUser("u-hist-1");
+      // Seed enough questions across 2 subjects
+      for (let i = 1; i <= 20; i++) {
+        await db.insert(question).values({
+          subjectId: i <= 10 ? 1 : 2,
+          subtopicId: 1,
+          content: `Q${i}`,
+          options: ["a","b","c","d"],
+          correctOptionIndex: 0,
+          difficulty: 1,
+          requiresCalculation: false,
+        });
+      }
+      const weeks = ["2026-04-05", "2026-04-12", "2026-04-19", "2026-04-26", "2026-05-03", "2026-05-10"];
+      for (const w of weeks) {
+        const { simulado, questions } = await repo.startOrGetSimulado("u-hist-1", w, 10);
+        // Answer all correctly so each is completed
+        for (const q of questions) {
+          await repo.recordAnswer(simulado.id, "u-hist-1", q.questionId, q.correctOptionIndex);
+        }
+      }
+      // current week is 2026-05-10 → prior = 5 most recent before it; we ask for 4
+      const history = await repo.listPriorCompletedSimulados("u-hist-1", "2026-05-10", 4);
+      expect(history.map((h) => h.weekStart)).toEqual(["2026-04-12", "2026-04-19", "2026-04-26", "2026-05-03"]);
+      // Per-subject breakdown sums to total
+      for (const h of history) {
+        const sum = h.perSubject.reduce((s, p) => s + p.total, 0);
+        expect(sum).toBe(h.total);
+      }
+    });
+
+    it("excludes IN-PROGRESS simulados", async () => {
+      await insertUser("u-hist-2");
+      for (let i = 1; i <= 5; i++) {
+        await db.insert(question).values({ subjectId: 1, subtopicId: 1, content: `Q${i}`, options: ["a","b","c","d"], correctOptionIndex: 0, difficulty: 1, requiresCalculation: false });
+      }
+      const { simulado: prior, questions: pq } = await repo.startOrGetSimulado("u-hist-2", "2026-05-03", 5);
+      for (const q of pq) await repo.recordAnswer(prior.id, "u-hist-2", q.questionId, q.correctOptionIndex);
+      // Current week — started but not completed
+      await repo.startOrGetSimulado("u-hist-2", "2026-05-10", 5);
+      const history = await repo.listPriorCompletedSimulados("u-hist-2", "2026-05-10", 4);
+      expect(history.length).toBe(1);
+      expect(history[0]!.weekStart).toBe("2026-05-03");
+    });
+
+    it("getResultsAggregate returns per-subject breakdown for one simulado", async () => {
+      await insertUser("u-agg-1");
+      for (let i = 1; i <= 6; i++) {
+        await db.insert(question).values({ subjectId: i <= 3 ? 1 : 2, subtopicId: 1, content: `Q${i}`, options: ["a","b","c","d"], correctOptionIndex: 0, difficulty: 1, requiresCalculation: false });
+      }
+      const { simulado, questions } = await repo.startOrGetSimulado("u-agg-1", "2026-05-10", 6);
+      // Answer first 4 correctly, last 2 wrong
+      for (let i = 0; i < 4; i++) await repo.recordAnswer(simulado.id, "u-agg-1", questions[i]!.questionId, questions[i]!.correctOptionIndex);
+      for (let i = 4; i < 6; i++) await repo.recordAnswer(simulado.id, "u-agg-1", questions[i]!.questionId, (questions[i]!.correctOptionIndex + 1) % 4);
+      const agg = await repo.getResultsAggregate(simulado.id);
+      expect(agg.correct).toBe(4);
+      expect(agg.total).toBe(6);
+      const ps = agg.perSubject.sort((a, b) => a.subjectId - b.subjectId);
+      expect(ps).toHaveLength(2);
+      expect(ps.reduce((s, p) => s + p.total, 0)).toBe(6);
+    });
+  });
+```
+
+Run: expect FAIL.
+
+- [ ] **Step 5.2: Implement the history queries**
+
+Append to `simulados.repository.ts`:
+
+```ts
+  /**
+   * Returns up to `limit` most recent COMPLETED simulados strictly BEFORE
+   * `currentWeekStart`, ordered oldest first, with per-subject breakdown.
+   */
+  async listPriorCompletedSimulados(userId: string, currentWeekStart: string, limit: number): Promise<Array<{ weekStart: string; correct: number; total: number; perSubject: Array<{ subjectId: number; correct: number; total: number }> }>> {
+    const recent = await this.db
+      .select({ id: weeklySimulado.id, weekStartDate: weeklySimulado.weekStartDate, correctCount: weeklySimulado.correctCount, questionsCount: weeklySimulado.questionsCount })
+      .from(weeklySimulado)
+      .where(and(
+        eq(weeklySimulado.userId, userId),
+        sql`${weeklySimulado.completedAt} IS NOT NULL`,
+        lt(weeklySimulado.weekStartDate, currentWeekStart),
+      ))
+      .orderBy(desc(weeklySimulado.weekStartDate))
+      .limit(limit);
+    if (recent.length === 0) return [];
+
+    const ids = recent.map((r) => r.id);
+    const perSubjectRows = await this.db
+      .select({
+        simuladoId: weeklySimuladoQuestion.simuladoId,
+        subjectId: question.subjectId,
+        correct: sql<number>`SUM(CASE WHEN ${weeklySimuladoQuestion.isCorrect} = true THEN 1 ELSE 0 END)`,
+        total: count(),
+      })
+      .from(weeklySimuladoQuestion)
+      .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+      .where(sql`${weeklySimuladoQuestion.simuladoId} IN (${sql.join(ids.map((id) => sql`${id}`), sql`, `)})`)
+      .groupBy(weeklySimuladoQuestion.simuladoId, question.subjectId);
+
+    const bySimulado = new Map<number, Array<{ subjectId: number; correct: number; total: number }>>();
+    for (const r of perSubjectRows) {
+      const list = bySimulado.get(r.simuladoId) ?? [];
+      list.push({ subjectId: r.subjectId, correct: Number(r.correct), total: Number(r.total) });
+      bySimulado.set(r.simuladoId, list);
+    }
+
+    return recent
+      .map((r) => ({
+        weekStart: typeof r.weekStartDate === "string" ? r.weekStartDate : new Date(r.weekStartDate).toISOString().slice(0, 10),
+        correct: r.correctCount,
+        total: r.questionsCount,
+        perSubject: bySimulado.get(r.id) ?? [],
+      }))
+      .reverse(); // oldest first
+  }
+
+  /** Per-subject aggregate for a single simulado. */
+  async getResultsAggregate(simuladoId: number): Promise<{ correct: number; total: number; perSubject: Array<{ subjectId: number; correct: number; total: number }> }> {
+    const head = await this.db
+      .select({ correctCount: weeklySimulado.correctCount, questionsCount: weeklySimulado.questionsCount })
+      .from(weeklySimulado)
+      .where(eq(weeklySimulado.id, simuladoId))
+      .limit(1);
+    const h = head[0];
+    if (!h) return { correct: 0, total: 0, perSubject: [] };
+
+    const perSubject = await this.db
+      .select({
+        subjectId: question.subjectId,
+        correct: sql<number>`SUM(CASE WHEN ${weeklySimuladoQuestion.isCorrect} = true THEN 1 ELSE 0 END)`,
+        total: count(),
+      })
+      .from(weeklySimuladoQuestion)
+      .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+      .where(eq(weeklySimuladoQuestion.simuladoId, simuladoId))
+      .groupBy(question.subjectId);
+
+    return {
+      correct: h.correctCount,
+      total: h.questionsCount,
+      perSubject: perSubject.map((p) => ({ subjectId: p.subjectId, correct: Number(p.correct), total: Number(p.total) })),
+    };
+  }
+```
+
+- [ ] **Step 5.3: Run, commit**
+
+```bash
+cd apps/server && bun test src/features/simulados/simulados.repository.integration.test.ts
+git add apps/server/src/features/simulados/simulados.repository.ts apps/server/src/features/simulados/simulados.repository.integration.test.ts
+git commit -m "feat(simulados): repository — prior completed history and per-subject aggregate"
+```
+
+---
+
+## Task 6 — Service: entitlement gating, lifecycle orchestration
+
+**Files:**
+- Create: `apps/server/src/features/simulados/simulados.service.ts`
+- Create: `apps/server/src/features/simulados/simulados.service.test.ts`
+
+- [ ] **Step 6.1: Failing tests**
+
+Create `simulados.service.test.ts`. Mirror the style of `shields.service.test.ts` — mock the repo and the ultra service.
+
+Required test cases (skeleton; fill in full code following the project's mocking pattern):
+- `getCurrent`: non-Ultra → `err(ULTRA_REQUIRED)`; Ultra + no simulado → status `not_started`, simulado null, history populated; Ultra + in-progress simulado → status `in_progress`; Ultra + completed → status `completed`.
+- `start`: non-Ultra → 403; Ultra → calls repo.startOrGetSimulado with `(userId, weekStart, SIMULADO_QUESTION_COUNT)` and returns `{ simulado, questions }` stripped of `correctOptionIndex` and `explanation` for unanswered questions.
+- `getDetail(id, userId)`: non-Ultra → 403; not owned → NotFoundError; owned → returns sanitized question list (correct answer + explanation only on answered or completed questions).
+- `recordAnswer`: non-Ultra → 403; not_found → NotFoundError; bad_question → 400; already_completed → 409; recorded → returns response shape; already_answered → returns recorded outcome.
+- `forceComplete`: non-Ultra → 403; not_found → 404; otherwise ok.
+- `getResults`: non-Ultra → 403; not owned → 404; in-progress → 400 (results not available until completed); completed → returns aggregate + history.
+
+For Ultra-lapse-after-start (acceptance A9): the service should NOT block `recordAnswer` / `forceComplete` / `getDetail` / `getResults` when `isUltra` is currently false but the simulado exists and is owned. **This means**: in `recordAnswer`, `forceComplete`, `getDetail`, `getResults`, we do NOT call `ultra.isUltra` — we only check Ultra at `getCurrent` and `start`. Document this in a comment on the methods that intentionally skip the Ultra check.
+
+- [ ] **Step 6.2: Implement the service**
+
+Create `simulados.service.ts`:
+
+```ts
+import { ok, err, type Result } from "neverthrow";
+import { AppError, NotFoundError, ValidationError, ForbiddenError, ConflictError } from "../../utils/errors";
+import {
+  SIMULADO_QUESTION_COUNT,
+  weekBoundsForSimulado,
+  type SimuladoCurrentResponse,
+  type SimuladoStartResponse,
+  type SimuladoDetailResponse,
+  type SimuladoAnswerResponse,
+  type SimuladoResultsResponse,
+} from "@pruvi/shared";
+import type { SimuladosRepository, SimuladoQuestionRow, SimuladoRow } from "./simulados.repository";
+import type { UltraService } from "../ultra/ultra.service";
+import type { FastifyBaseLogger } from "fastify";
+
+const HISTORY_LIMIT = 4;
+
+export class SimuladosService {
+  constructor(
+    private repo: SimuladosRepository,
+    private ultra: UltraService,
+    private logger?: FastifyBaseLogger,
+  ) {}
+
+  /** Strips correctOptionIndex + explanation from questions that haven't been answered
+   *  (and the simulado is not completed). Once the simulado is completed, all
+   *  questions reveal both fields. */
+  private sanitizeQuestions(questions: SimuladoQuestionRow[], simuladoCompleted: boolean) {
+    return questions.map((q) => {
+      const reveal = simuladoCompleted || q.selectedOptionIndex !== null;
+      return {
+        position: q.position,
+        questionId: q.questionId,
+        content: q.content,
+        options: q.options,
+        subjectId: q.subjectId,
+        subtopicId: q.subtopicId,
+        requiresCalculation: q.requiresCalculation,
+        selectedOptionIndex: q.selectedOptionIndex,
+        isCorrect: q.isCorrect,
+        correctOptionIndex: reveal ? q.correctOptionIndex : null,
+        explanation: reveal ? q.explanation : null,
+      };
+    });
+  }
+
+  async getCurrent(userId: string, now = new Date()): Promise<Result<SimuladoCurrentResponse, AppError>> {
+    if (!(await this.ultra.isUltra(userId))) return err(new ForbiddenError("ULTRA_REQUIRED"));
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    const existing = await this.repo.findByUserAndWeek(userId, weekStart);
+    const history = await this.repo.listPriorCompletedSimulados(userId, weekStart, HISTORY_LIMIT);
+    if (!existing) {
+      return ok({ weekStart, weekEnd, status: "not_started", simulado: null, history });
+    }
+    const status: SimuladoCurrentResponse["status"] = existing.completedAt ? "completed" : "in_progress";
+    const answeredCount = await this.repo.countAnswered(existing.id);
+    return ok({
+      weekStart,
+      weekEnd,
+      status,
+      simulado: {
+        id: existing.id,
+        startedAt: existing.startedAt.toISOString(),
+        completedAt: existing.completedAt?.toISOString() ?? null,
+        questionsCount: existing.questionsCount,
+        answeredCount,
+        correctCount: existing.correctCount,
+      },
+      history,
+    });
+  }
+
+  async start(userId: string, now = new Date()): Promise<Result<SimuladoStartResponse, AppError>> {
+    if (!(await this.ultra.isUltra(userId))) return err(new ForbiddenError("ULTRA_REQUIRED"));
+    const { weekStart } = weekBoundsForSimulado(now);
+    const { simulado, questions } = await this.repo.startOrGetSimulado(userId, weekStart, SIMULADO_QUESTION_COUNT);
+    return ok({
+      simulado: { id: simulado.id, startedAt: simulado.startedAt.toISOString(), questionsCount: simulado.questionsCount },
+      questions: questions.map((q) => ({
+        position: q.position,
+        questionId: q.questionId,
+        content: q.content,
+        options: q.options,
+        subjectId: q.subjectId,
+        subtopicId: q.subtopicId,
+        requiresCalculation: q.requiresCalculation,
+      })),
+    });
+  }
+
+  // Intentionally NOT gated by ultra.isUltra — see spec §4 A9 (Ultra-lapse mid-simulado).
+  async getDetail(simuladoId: number, userId: string): Promise<Result<SimuladoDetailResponse, AppError>> {
+    const found = await this.repo.getOneForUser(simuladoId, userId);
+    if (!found) return err(new NotFoundError("Simulado not found"));
+    const completed = found.simulado.completedAt !== null;
+    return ok({
+      simulado: {
+        id: found.simulado.id,
+        weekStart: found.simulado.weekStartDate,
+        startedAt: found.simulado.startedAt.toISOString(),
+        completedAt: found.simulado.completedAt?.toISOString() ?? null,
+        questionsCount: found.simulado.questionsCount,
+        answeredCount: found.questions.filter((q) => q.selectedOptionIndex !== null).length,
+        correctCount: found.simulado.correctCount,
+        status: completed ? "completed" : "in_progress",
+      },
+      questions: this.sanitizeQuestions(found.questions, completed),
+    });
+  }
+
+  // Intentionally NOT gated by ultra.isUltra — see spec §4 A9.
+  async recordAnswer(simuladoId: number, userId: string, questionId: number, selectedOptionIndex: number): Promise<Result<SimuladoAnswerResponse, AppError>> {
+    const r = await this.repo.recordAnswer(simuladoId, userId, questionId, selectedOptionIndex);
+    switch (r.kind) {
+      case "not_found":
+        return err(new NotFoundError("Simulado not found"));
+      case "bad_question":
+        return err(new ValidationError("Question does not belong to this simulado"));
+      case "already_completed":
+        return err(new ConflictError("Simulado already completed"));
+      case "recorded":
+        return ok({
+          isCorrect: r.isCorrect,
+          correctOptionIndex: r.correctOptionIndex,
+          explanation: r.explanation,
+          answeredCount: r.answeredCount,
+          completed: r.completed,
+        });
+      case "already_answered":
+        return ok({
+          isCorrect: r.isCorrect,
+          correctOptionIndex: r.correctOptionIndex,
+          explanation: r.explanation,
+          answeredCount: r.answeredCount,
+          completed: r.completed,
+        });
+    }
+  }
+
+  // Intentionally NOT gated by ultra.isUltra — see spec §4 A9.
+  async forceComplete(simuladoId: number, userId: string): Promise<Result<{ id: number; completedAt: string }, AppError>> {
+    const r = await this.repo.forceComplete(simuladoId, userId);
+    if (r.kind === "not_found") return err(new NotFoundError("Simulado not found"));
+    return ok({ id: simuladoId, completedAt: r.completedAt.toISOString() });
+  }
+
+  // Intentionally NOT gated by ultra.isUltra — see spec §4 A9.
+  async getResults(simuladoId: number, userId: string, now = new Date()): Promise<Result<SimuladoResultsResponse, AppError>> {
+    const found = await this.repo.getOneForUser(simuladoId, userId);
+    if (!found) return err(new NotFoundError("Simulado not found"));
+    if (!found.simulado.completedAt) return err(new ValidationError("Simulado not yet completed"));
+    const agg = await this.repo.getResultsAggregate(simuladoId);
+    const history = await this.repo.listPriorCompletedSimulados(userId, found.simulado.weekStartDate, HISTORY_LIMIT);
+    return ok({
+      weekStart: found.simulado.weekStartDate,
+      correct: agg.correct,
+      total: agg.total,
+      perSubject: agg.perSubject,
+      history,
+    });
+  }
+}
+```
+
+Note: this uses `findByUserAndWeek` and `countAnswered` on the repo, which are not yet implemented. Add them to the repository:
+
+```ts
+  async findByUserAndWeek(userId: string, weekStart: string): Promise<SimuladoRow | null> {
+    const rows = await this.db
+      .select()
+      .from(weeklySimulado)
+      .where(and(eq(weeklySimulado.userId, userId), eq(weeklySimulado.weekStartDate, weekStart)))
+      .limit(1);
+    const r = rows[0];
+    return r ? this.toSimuladoRow(r) : null;
+  }
+
+  async countAnswered(simuladoId: number): Promise<number> {
+    const res = await this.db
+      .select({ value: count() })
+      .from(weeklySimuladoQuestion)
+      .where(and(eq(weeklySimuladoQuestion.simuladoId, simuladoId), sql`${weeklySimuladoQuestion.selectedOptionIndex} IS NOT NULL`));
+    return Number(res[0]!.value);
+  }
+```
+
+If `ConflictError` and `ForbiddenError` don't already exist in `utils/errors`, add them following the existing class pattern (extend `AppError` with statusCode 409 and 403 respectively).
+
+- [ ] **Step 6.3: Run, fix, commit**
+
+```bash
+cd apps/server && bun test src/features/simulados/
+git add apps/server/src/features/simulados/simulados.service.ts apps/server/src/features/simulados/simulados.service.test.ts apps/server/src/features/simulados/simulados.repository.ts
+git commit -m "feat(simulados): service — entitlement gating, lifecycle orchestration, ultra-lapse exemption per spec a9"
+```
+
+If `errors.ts` was modified, include it in the commit.
+
+---
+
+## Task 7 — Route: endpoints, schemas, cache, registration
+
+**Files:**
+- Create: `apps/server/src/features/simulados/simulados.route.ts`
+- Create: `apps/server/src/features/simulados/index.ts`
+- Modify: `apps/server/src/index.ts`
+
+- [ ] **Step 7.1: Implement the route module**
+
+Create `simulados.route.ts`:
+
+```ts
+import { z } from "zod";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import {
+  SimuladoAnswerBodySchema,
+  SimuladoAnswerResponseSchema,
+  SimuladoCurrentResponseSchema,
+  SimuladoDetailResponseSchema,
+  SimuladoResultsResponseSchema,
+  SimuladoStartResponseSchema,
+  type SimuladoCurrentResponse,
+} from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { successResponse, unwrapResult } from "../../types";
+import { SimuladosRepository } from "./simulados.repository";
+import { SimuladosService } from "./simulados.service";
+import { UltraRepository } from "../ultra/ultra.repository";
+import { UltraService } from "../ultra/ultra.service";
+
+const CURRENT_CACHE_TTL = 60;
+
+export const simuladosRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  const repo = new SimuladosRepository(db);
+  const ultra = new UltraService(new UltraRepository(db));
+  const service = new SimuladosService(repo, ultra, fastify.log);
+
+  fastify.get(
+    "/simulados/current",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: SimuladoCurrentResponseSchema }) } },
+    },
+    async (request) => {
+      const cacheKey = `simulado:current:${request.userId}`;
+      const cached = await fastify.cache.get<SimuladoCurrentResponse>(cacheKey);
+      if (cached) return successResponse(cached);
+      const data = unwrapResult(await service.getCurrent(request.userId)).data;
+      await fastify.cache.set(cacheKey, data, CURRENT_CACHE_TTL);
+      return successResponse(data);
+    },
+  );
+
+  fastify.post(
+    "/simulados/start",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: SimuladoStartResponseSchema }) } },
+    },
+    async (request) => {
+      const data = unwrapResult(await service.start(request.userId)).data;
+      await fastify.cache.del(`simulado:current:${request.userId}`);
+      return successResponse(data);
+    },
+  );
+
+  fastify.get(
+    "/simulados/:id",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ id: z.coerce.number().int() }),
+        response: { 200: z.object({ success: z.literal(true), data: SimuladoDetailResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const { id } = request.params;
+      const data = unwrapResult(await service.getDetail(id, request.userId)).data;
+      return successResponse(data);
+    },
+  );
+
+  fastify.post(
+    "/simulados/:id/answer",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ id: z.coerce.number().int() }),
+        body: SimuladoAnswerBodySchema,
+        response: { 200: z.object({ success: z.literal(true), data: SimuladoAnswerResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const { id } = request.params;
+      const { questionId, selectedOptionIndex } = request.body;
+      const data = unwrapResult(await service.recordAnswer(id, request.userId, questionId, selectedOptionIndex)).data;
+      await fastify.cache.del(`simulado:current:${request.userId}`);
+      return successResponse(data);
+    },
+  );
+
+  fastify.post(
+    "/simulados/:id/complete",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ id: z.coerce.number().int() }),
+        response: { 200: z.object({ success: z.literal(true), data: z.object({ id: z.number().int(), completedAt: z.string() }) }) },
+      },
+    },
+    async (request) => {
+      const { id } = request.params;
+      const data = unwrapResult(await service.forceComplete(id, request.userId)).data;
+      await fastify.cache.del(`simulado:current:${request.userId}`);
+      return successResponse(data);
+    },
+  );
+
+  fastify.get(
+    "/simulados/:id/results",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        params: z.object({ id: z.coerce.number().int() }),
+        response: { 200: z.object({ success: z.literal(true), data: SimuladoResultsResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const { id } = request.params;
+      const data = unwrapResult(await service.getResults(id, request.userId)).data;
+      return successResponse(data);
+    },
+  );
+};
+```
+
+Create `apps/server/src/features/simulados/index.ts`:
+
+```ts
+export { simuladosRoutes } from "./simulados.route";
+```
+
+- [ ] **Step 7.2: Register in the app**
+
+Modify `apps/server/src/index.ts`:
+
+- Add import: `import { simuladosRoutes } from "./features/simulados";`
+- Add registration after `shieldsRoutes`: `await app.register(simuladosRoutes);`
+
+- [ ] **Step 7.3: Run typecheck and full test suite**
+
+```bash
+cd apps/server && bun run typecheck && bun test
+```
+
+Expected: all green.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add apps/server/src/features/simulados/simulados.route.ts apps/server/src/features/simulados/index.ts apps/server/src/index.ts
+git commit -m "feat(simulados): routes — /simulados/{current,start,:id,:id/answer,:id/complete,:id/results} with 60s cache on /current"
+```
+
+---
+
+## Task 8 — Final cleanup, full typecheck, push, open PR
+
+- [ ] **Step 8.1: Run full project quality gates**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi
+bun run typecheck   # or whatever the root script is
+bun test
+```
+
+Fix anything red. If the lint/typecheck scripts have a different name (e.g., `pnpm`, `turbo`), use what's defined in the root `package.json`.
+
+- [ ] **Step 8.2: Verify all 13 acceptance criteria from spec §10**
+
+Walk through A1–A13. Note any that cannot be verified from the implementation alone (e.g., A12 cache TTL requires inspecting `simulados.route.ts` — confirm `CURRENT_CACHE_TTL = 60` and `cache.del` on each mutating endpoint).
+
+- [ ] **Step 8.3: Push and open PR**
+
+```bash
+git push -u origin feature/phase-2e3-simulado-semanal
+gh pr create --title "feat: phase 2e.3 — simulado semanal (ultra perk, race-safe lifecycle)" --body "$(cat <<'EOF'
+## Summary
+- Weekly mock exam for Ultra users: 35 questions, BRT Sunday-Sunday window
+- Per-subject results + up to 4 prior weeks of history
+- INSERT...ON CONFLICT for idempotent /start, SELECT FOR UPDATE for race-safe /answer
+- 60s cache on /current with explicit invalidation
+- Ultra entitlement enforced at /current and /start only (per spec A9: Ultra-lapse mid-simulado can still finish)
+- Spec: docs/superpowers/specs/2026-05-12-phase-2e3-simulado-semanal-design.md (v2 after Gate A)
+
+## Workflow gates
+- ✅ Gate A: spec self-review (6 blockers caught, fixed in v2)
+- ✅ Gate B: plan self-review
+- ✅ Gate C: per-task review (Opus 4.7) after every commit
+- ✅ Gate D: final spec-coverage review vs full diff
+
+## Test plan
+- [ ] Repository integration tests pass (PGlite): deterministic selection, start-or-get idempotency, race-safe recordAnswer, history queries
+- [ ] Service unit tests pass: entitlement gating, ultra-lapse exemption, error mapping
+- [ ] Manual: GET /simulados/current returns not_started for fresh Ultra user; POST /simulados/start returns 35 questions; answering all 35 auto-completes
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (run before dispatch)
+
+1. **Spec coverage:** every acceptance A1–A13 maps to at least one task. ✅ (A1 → T3/T6; A2 → T3/T4; A3 → T6/T7; A4 → T4/T6; A5 → T4; A6 → T4; A7 → T5/T6; A8 → T6; A9 → T6; A10 → T2; A11 → T2; A12 → T7; A13 → T6/T7.)
+2. **Placeholder scan:** no TBDs, no "similar to Task N". ✅
+3. **Type consistency:** `SimuladoRow.weekStartDate` is `string` everywhere. `SimuladoQuestionRow` has `correctOptionIndex` always set (read from join). Service strips it before returning to client. ✅
+4. **Migration safety:** `0009_*` is generated by drizzle-kit; manual SQL edits not required. ✅

--- a/docs/superpowers/plans/2026-05-12-phase-2e3-simulado-semanal.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e3-simulado-semanal.md
@@ -28,7 +28,7 @@ Create `packages/shared/src/time.ts`:
 export const BRT_OFFSET_MS = 3 * 60 * 60 * 1000;
 ```
 
-- [ ] **Step 1.2: Make `weekly.ts` import the shared constant**
+- [ ] **Step 1.2: Make `weekly.ts` AND `shields.ts` import the shared constant**
 
 Replace the top of `packages/shared/src/weekly.ts`:
 
@@ -45,6 +45,8 @@ export function startOfWeekBrt(now: Date): Date {
   return new Date(brt.getTime() + BRT_OFFSET_MS);
 }
 ```
+
+In `packages/shared/src/shields.ts`, change the `todayInBrt` helper to import `BRT_OFFSET_MS` from `./time` instead of inlining `3 * 60 * 60 * 1000`. Add `import { BRT_OFFSET_MS } from "./time";` at the top and replace the inline constant inside the function. No behavior change; this consolidates the BRT offset to a single source of truth (Gate B suggestion N2).
 
 - [ ] **Step 1.3: Create `simulado.ts` with constants, helper, and Zod schemas**
 
@@ -337,11 +339,28 @@ Verify the generated SQL contains:
 
 If the generator names the new file `0009_<word>.sql`, that's fine; note the filename. If the generator pulled in unrelated diffs (e.g., stale snapshot), STOP and ask — do not commit unrelated migration changes.
 
-- [ ] **Step 2.4: Commit**
+- [ ] **Step 2.4: Update `cleanupTestDb` TRUNCATE list**
+
+Modify `apps/server/src/test/db-helpers.ts` — the `cleanupTestDb` function. The current TRUNCATE list does NOT include the two new tables. Because `weekly_simulado_question.question_id` references `question(id) ON DELETE RESTRICT`, the existing `TRUNCATE ... question ... CASCADE` will FAIL when leftover `weekly_simulado_question` rows exist from a previous test (RESTRICT blocks the cascade). Even if it didn't, leftover rows would leak between test cases.
+
+Replace the SQL inside `cleanupTestDb` with:
+
+```ts
+await db.execute(sql`
+  TRUNCATE TABLE weekly_simulado_question, weekly_simulado,
+    push_token, review_log, daily_session, streak_shield_usage,
+    question, subtopic, topic, subject,
+    account, session, verification, "user" CASCADE
+`);
+```
+
+Order matters: child tables before parents. `streak_shield_usage` was likely added previously but missing — include it for safety; if it's already cascade-handled via `user`, this is a no-op redundancy.
+
+- [ ] **Step 2.5: Commit**
 
 ```bash
-git add packages/db/src/schema/weekly-simulado.ts packages/db/src/schema/index.ts packages/db/src/migrations/
-git commit -m "feat(db): weekly_simulado + weekly_simulado_question tables"
+git add packages/db/src/schema/weekly-simulado.ts packages/db/src/schema/index.ts packages/db/src/migrations/ apps/server/src/test/db-helpers.ts
+git commit -m "feat(db): weekly_simulado + weekly_simulado_question tables and test cleanup"
 ```
 
 ---
@@ -357,7 +376,7 @@ git commit -m "feat(db): weekly_simulado + weekly_simulado_question tables"
 Create `apps/server/src/features/simulados/simulados.repository.ts`:
 
 ```ts
-import { and, asc, count, desc, eq, isNull, lt, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, isNull, lt, sql } from "drizzle-orm";
 import type { db as DbClient } from "@pruvi/db";
 import { user } from "@pruvi/db/schema/auth";
 import { question } from "@pruvi/db/schema/questions";
@@ -403,6 +422,8 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { setupTestDb, cleanupTestDb, teardownTestDb, getTestDb } from "../../test/db-helpers";
 import { user } from "@pruvi/db/schema/auth";
 import { question } from "@pruvi/db/schema/questions";
+import { subject } from "@pruvi/db/schema/subjects";
+import { topic, subtopic } from "@pruvi/db/schema/topics";
 import { SimuladosRepository } from "./simulados.repository";
 
 describe("SimuladosRepository (integration)", () => {
@@ -425,18 +446,38 @@ describe("SimuladosRepository (integration)", () => {
     });
   }
 
-  async function seedQuestions(n: number, subjectId = 1) {
-    for (let i = 1; i <= n; i++) {
+  /** Sets up subject/topic/subtopic FK prereqs and inserts `n` questions distributed
+   *  across the requested number of subjects. Returns the created subject IDs. */
+  async function seedQuestions(n: number, subjectCount = 1): Promise<number[]> {
+    const subjects = await db
+      .insert(subject)
+      .values(Array.from({ length: subjectCount }, (_, i) => ({ name: `S${i + 1}`, slug: `s${i + 1}` })))
+      .returning();
+    const subtopicsBySubject = new Map<number, number>();
+    for (const s of subjects) {
+      const [t] = await db
+        .insert(topic)
+        .values({ subjectId: s.id, name: `T-${s.id}`, slug: `t-${s.id}`, displayOrder: 0 })
+        .returning();
+      const [st] = await db
+        .insert(subtopic)
+        .values({ topicId: t!.id, name: `ST-${s.id}`, slug: `st-${s.id}`, displayOrder: 0 })
+        .returning();
+      subtopicsBySubject.set(s.id, st!.id);
+    }
+    for (let i = 0; i < n; i++) {
+      const subj = subjects[i % subjects.length]!;
       await db.insert(question).values({
-        subjectId,
-        subtopicId: 1,
-        content: `Q${i}`,
+        subjectId: subj.id,
+        subtopicId: subtopicsBySubject.get(subj.id)!,
+        content: `Q${i + 1}`,
         options: ["a", "b", "c", "d"],
         correctOptionIndex: i % 4,
-        difficulty: 1,
+        difficulty: "easy" as const,
         requiresCalculation: false,
       });
     }
+    return subjects.map((s) => s.id);
   }
 
   describe("selectQuestionsForSimulado", () => {
@@ -592,7 +633,9 @@ Append:
         return { simulado: this.toSimuladoRow(simulado), questions, created: true };
       }
 
-      // Conflict path — re-read existing row + question set.
+      // Conflict path — re-read existing row + question set (inline; uses tx not this.db so
+      // it sees any uncommitted state in this transaction, though in practice the conflict
+      // means another committed transaction wrote it).
       const existing = await tx
         .select()
         .from(weeklySimulado)
@@ -600,7 +643,37 @@ Append:
         .limit(1);
       const simulado = existing[0];
       if (!simulado) throw new Error("startOrGetSimulado: conflict but no existing row");
-      const existingQs = await this.fetchQuestionsForSimulado(tx, simulado.id);
+      const rows = await tx
+        .select({
+          position: weeklySimuladoQuestion.position,
+          questionId: weeklySimuladoQuestion.questionId,
+          selectedOptionIndex: weeklySimuladoQuestion.selectedOptionIndex,
+          isCorrect: weeklySimuladoQuestion.isCorrect,
+          content: question.content,
+          options: question.options,
+          correctOptionIndex: question.correctOptionIndex,
+          explanation: question.explanation,
+          subjectId: question.subjectId,
+          subtopicId: question.subtopicId,
+          requiresCalculation: question.requiresCalculation,
+        })
+        .from(weeklySimuladoQuestion)
+        .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
+        .where(eq(weeklySimuladoQuestion.simuladoId, simulado.id))
+        .orderBy(asc(weeklySimuladoQuestion.position));
+      const existingQs: SimuladoQuestionRow[] = rows.map((r) => ({
+        position: r.position,
+        questionId: r.questionId,
+        content: r.content,
+        options: r.options as string[],
+        correctOptionIndex: r.correctOptionIndex,
+        explanation: r.explanation,
+        subjectId: r.subjectId,
+        subtopicId: r.subtopicId,
+        requiresCalculation: r.requiresCalculation,
+        selectedOptionIndex: r.selectedOptionIndex,
+        isCorrect: r.isCorrect,
+      }));
       return { simulado: this.toSimuladoRow(simulado), questions: existingQs, created: false };
     });
   }
@@ -617,8 +690,8 @@ Append:
     };
   }
 
-  private async fetchQuestionsForSimulado(tx: Db | Parameters<Db["transaction"]>[0] extends (tx: infer T) => unknown ? T : never, simuladoId: number): Promise<SimuladoQuestionRow[]> {
-    const rows = await (tx as Db)
+  private async fetchQuestionsForSimulado(simuladoId: number): Promise<SimuladoQuestionRow[]> {
+    const rows = await this.db
       .select({
         position: weeklySimuladoQuestion.position,
         questionId: weeklySimuladoQuestion.questionId,
@@ -816,14 +889,22 @@ Inside the class, add:
    */
   async recordAnswer(simuladoId: number, userId: string, questionId: number, selectedOptionIndex: number): Promise<RecordAnswerResult> {
     return await this.db.transaction(async (tx) => {
-      // 1. Lock parent row; check ownership and completion.
-      const locked = await tx.execute(sql`
-        SELECT id, user_id, completed_at, correct_count, questions_count
-        FROM weekly_simulado WHERE id = ${simuladoId} FOR UPDATE
-      `);
-      const parent = (locked.rows ?? locked)[0] as { id: number; user_id: string; completed_at: Date | null; correct_count: number; questions_count: number } | undefined;
-      if (!parent || parent.user_id !== userId) return { kind: "not_found" };
-      if (parent.completed_at !== null) return { kind: "already_completed" };
+      // 1. Lock parent row using Drizzle's typed .for("update"). Check ownership and completion.
+      const lockedRows = await tx
+        .select({
+          id: weeklySimulado.id,
+          userId: weeklySimulado.userId,
+          completedAt: weeklySimulado.completedAt,
+          correctCount: weeklySimulado.correctCount,
+          questionsCount: weeklySimulado.questionsCount,
+        })
+        .from(weeklySimulado)
+        .where(eq(weeklySimulado.id, simuladoId))
+        .for("update")
+        .limit(1);
+      const parent = lockedRows[0];
+      if (!parent || parent.userId !== userId) return { kind: "not_found" };
+      if (parent.completedAt !== null) return { kind: "already_completed" };
 
       // 2. Look up the question within this simulado.
       const qRow = await tx
@@ -894,7 +975,7 @@ Inside the class, add:
           .where(and(eq(weeklySimulado.id, simuladoId), isNull(weeklySimulado.completedAt)));
         completed = true;
       }
-      const answeredCount = parent.questions_count - remaining;
+      const answeredCount = parent.questionsCount - remaining;
       return { kind: "recorded", isCorrect, correctOptionIndex: correctOpt, explanation, answeredCount, completed };
     });
   }
@@ -918,24 +999,10 @@ Inside the class, add:
       .limit(1);
     const row = rows[0];
     if (!row) return null;
-    const questions = await this.fetchQuestionsForSimulado(this.db, row.id);
+    const questions = await this.fetchQuestionsForSimulado(row.id);
     return { simulado: this.toSimuladoRow(row), questions };
   }
 ```
-
-**Note on `tx.execute(sql\`... FOR UPDATE\`)`:** drizzle-orm's `.for("update")` is supported on `.select()`; prefer:
-
-```ts
-const lockedRows = await tx
-  .select({ id: weeklySimulado.id, userId: weeklySimulado.userId, completedAt: weeklySimulado.completedAt, correctCount: weeklySimulado.correctCount, questionsCount: weeklySimulado.questionsCount })
-  .from(weeklySimulado)
-  .where(eq(weeklySimulado.id, simuladoId))
-  .for("update")
-  .limit(1);
-const parent = lockedRows[0];
-```
-
-Use the typed `.for("update")` form rather than raw `sql\`SELECT ... FOR UPDATE\``. Adjust the implementation accordingly (the field names map to `parent.userId`, `parent.completedAt`, `parent.questionsCount`).
 
 - [ ] **Step 4.3: Run tests, fix, commit**
 
@@ -965,18 +1032,8 @@ Append to the integration test file:
   describe("listPriorCompletedSimulados", () => {
     it("returns up to N most recent COMPLETED prior simulados, oldest first, with per-subject breakdown", async () => {
       await insertUser("u-hist-1");
-      // Seed enough questions across 2 subjects
-      for (let i = 1; i <= 20; i++) {
-        await db.insert(question).values({
-          subjectId: i <= 10 ? 1 : 2,
-          subtopicId: 1,
-          content: `Q${i}`,
-          options: ["a","b","c","d"],
-          correctOptionIndex: 0,
-          difficulty: 1,
-          requiresCalculation: false,
-        });
-      }
+      // Seed 20 questions across 2 subjects (FK prereqs handled inside seedQuestions)
+      await seedQuestions(20, 2);
       const weeks = ["2026-04-05", "2026-04-12", "2026-04-19", "2026-04-26", "2026-05-03", "2026-05-10"];
       for (const w of weeks) {
         const { simulado, questions } = await repo.startOrGetSimulado("u-hist-1", w, 10);
@@ -997,9 +1054,7 @@ Append to the integration test file:
 
     it("excludes IN-PROGRESS simulados", async () => {
       await insertUser("u-hist-2");
-      for (let i = 1; i <= 5; i++) {
-        await db.insert(question).values({ subjectId: 1, subtopicId: 1, content: `Q${i}`, options: ["a","b","c","d"], correctOptionIndex: 0, difficulty: 1, requiresCalculation: false });
-      }
+      await seedQuestions(5, 1);
       const { simulado: prior, questions: pq } = await repo.startOrGetSimulado("u-hist-2", "2026-05-03", 5);
       for (const q of pq) await repo.recordAnswer(prior.id, "u-hist-2", q.questionId, q.correctOptionIndex);
       // Current week — started but not completed
@@ -1011,9 +1066,7 @@ Append to the integration test file:
 
     it("getResultsAggregate returns per-subject breakdown for one simulado", async () => {
       await insertUser("u-agg-1");
-      for (let i = 1; i <= 6; i++) {
-        await db.insert(question).values({ subjectId: i <= 3 ? 1 : 2, subtopicId: 1, content: `Q${i}`, options: ["a","b","c","d"], correctOptionIndex: 0, difficulty: 1, requiresCalculation: false });
-      }
+      await seedQuestions(6, 2); // 3 questions for each of 2 subjects
       const { simulado, questions } = await repo.startOrGetSimulado("u-agg-1", "2026-05-10", 6);
       // Answer first 4 correctly, last 2 wrong
       for (let i = 0; i < 4; i++) await repo.recordAnswer(simulado.id, "u-agg-1", questions[i]!.questionId, questions[i]!.correctOptionIndex);
@@ -1062,7 +1115,7 @@ Append to `simulados.repository.ts`:
       })
       .from(weeklySimuladoQuestion)
       .innerJoin(question, eq(weeklySimuladoQuestion.questionId, question.id))
-      .where(sql`${weeklySimuladoQuestion.simuladoId} IN (${sql.join(ids.map((id) => sql`${id}`), sql`, `)})`)
+      .where(inArray(weeklySimuladoQuestion.simuladoId, ids))
       .groupBy(weeklySimuladoQuestion.simuladoId, question.subjectId);
 
     const bySimulado = new Map<number, Array<{ subjectId: number; correct: number; total: number }>>();
@@ -1139,7 +1192,83 @@ Required test cases (skeleton; fill in full code following the project's mocking
 - `forceComplete`: non-Ultra → 403; not_found → 404; otherwise ok.
 - `getResults`: non-Ultra → 403; not owned → 404; in-progress → 400 (results not available until completed); completed → returns aggregate + history.
 
-For Ultra-lapse-after-start (acceptance A9): the service should NOT block `recordAnswer` / `forceComplete` / `getDetail` / `getResults` when `isUltra` is currently false but the simulado exists and is owned. **This means**: in `recordAnswer`, `forceComplete`, `getDetail`, `getResults`, we do NOT call `ultra.isUltra` — we only check Ultra at `getCurrent` and `start`. Document this in a comment on the methods that intentionally skip the Ultra check.
+For Ultra-lapse-after-start (acceptance A9): the service must NOT block `recordAnswer` / `forceComplete` / `getDetail` / `getResults` when `isUltra` is currently false but the simulado exists and is owned. We do NOT call `ultra.isUltra` in those methods at all. `getCurrent` defers the Ultra check until AFTER it determines no simulado exists for the current week; if one exists, it returns 200 regardless of Ultra state. Only `/start` enforces a strict Ultra check.
+
+**Required A9 test (fully fleshed-out — must not be left as a skeleton):**
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { SimuladosService } from "./simulados.service";
+import { ok } from "neverthrow";
+
+describe("SimuladosService — A9 Ultra-lapse exemption", () => {
+  function buildSut(opts: { isUltra: boolean; existingSimulado: unknown | null }) {
+    const ultra = { isUltra: vi.fn().mockResolvedValue(opts.isUltra) } as unknown as import("../ultra/ultra.service").UltraService;
+    const repo = {
+      findByUserAndWeek: vi.fn().mockResolvedValue(opts.existingSimulado),
+      listPriorCompletedSimulados: vi.fn().mockResolvedValue([]),
+      countAnswered: vi.fn().mockResolvedValue(0),
+      getOneForUser: vi.fn(),
+      recordAnswer: vi.fn(),
+      forceComplete: vi.fn(),
+      getResultsAggregate: vi.fn(),
+      startOrGetSimulado: vi.fn(),
+    } as unknown as import("./simulados.repository").SimuladosRepository;
+    return { service: new SimuladosService(repo, ultra), ultra, repo };
+  }
+
+  it("getCurrent: lapsed Ultra with existing in-progress simulado returns 200 (no 403)", async () => {
+    const existing = {
+      id: 42, userId: "u1", weekStartDate: "2026-05-10",
+      startedAt: new Date("2026-05-10T12:00:00Z"), completedAt: null,
+      questionsCount: 35, correctCount: 4,
+    };
+    const { service, ultra } = buildSut({ isUltra: false, existingSimulado: existing });
+    const r = await service.getCurrent("u1", new Date("2026-05-10T15:00:00Z"));
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.status).toBe("in_progress");
+      expect(r.value.simulado?.id).toBe(42);
+    }
+    // Critical: the Ultra check must NOT have been called when an existing simulado was found.
+    expect(ultra.isUltra).not.toHaveBeenCalled();
+  });
+
+  it("getCurrent: lapsed Ultra with NO simulado for the current week returns 403", async () => {
+    const { service } = buildSut({ isUltra: false, existingSimulado: null });
+    const r = await service.getCurrent("u1", new Date("2026-05-10T15:00:00Z"));
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.message).toContain("ULTRA_REQUIRED");
+  });
+
+  it("start: lapsed Ultra always returns 403, even if an old simulado exists", async () => {
+    const { service } = buildSut({ isUltra: false, existingSimulado: null });
+    const r = await service.start("u1", new Date("2026-05-10T15:00:00Z"));
+    expect(r.isErr()).toBe(true);
+  });
+
+  it("recordAnswer: lapsed Ultra with owned simulado succeeds (Ultra check skipped)", async () => {
+    const ultra = { isUltra: vi.fn().mockResolvedValue(false) } as unknown as import("../ultra/ultra.service").UltraService;
+    const repo = {
+      recordAnswer: vi.fn().mockResolvedValue({
+        kind: "recorded", isCorrect: true, correctOptionIndex: 0, explanation: null,
+        answeredCount: 1, completed: false,
+      }),
+    } as unknown as import("./simulados.repository").SimuladosRepository;
+    const service = new SimuladosService(repo, ultra);
+    const r = await service.recordAnswer(42, "u1", 100, 0);
+    expect(r.isOk()).toBe(true);
+    expect(ultra.isUltra).not.toHaveBeenCalled();
+  });
+});
+```
+
+The remaining service tests (entitlement gating on `/start`, error mapping for `recordAnswer` outcomes, etc.) can follow the same `buildSut` pattern. Cover at minimum:
+- `start`: non-Ultra → ForbiddenError; Ultra → repo.startOrGetSimulado called with `(userId, weekStart, SIMULADO_QUESTION_COUNT)` and response strips `correctOptionIndex` and `explanation` from each question.
+- `recordAnswer`: each repo result kind maps to the right Result<…, AppError>: not_found → NotFoundError, bad_question → ValidationError, already_completed → ConflictError, recorded → ok, already_answered → ok.
+- `getResults`: not_owned → NotFoundError; in_progress → ValidationError; completed → ok with aggregate + history.
+- `forceComplete`: not_found → NotFoundError; completed → ok.
+- `getDetail`: not_owned → NotFoundError; in-progress hides `correctOptionIndex`/`explanation` on unanswered questions but reveals them on answered questions; completed reveals all.
 
 - [ ] **Step 6.2: Implement the service**
 
@@ -1193,11 +1322,15 @@ export class SimuladosService {
   }
 
   async getCurrent(userId: string, now = new Date()): Promise<Result<SimuladoCurrentResponse, AppError>> {
-    if (!(await this.ultra.isUltra(userId))) return err(new ForbiddenError("ULTRA_REQUIRED"));
+    // Per spec §4 / A9: Ultra check is deferred. A user who started a simulado while Ultra
+    // was active retains read access even if Ultra has lapsed. We only enforce ULTRA_REQUIRED
+    // when there is NO simulado for the current week (i.e., they'd be requesting a `not_started`
+    // view that would normally lead to /start, which IS Ultra-gated).
     const { weekStart, weekEnd } = weekBoundsForSimulado(now);
     const existing = await this.repo.findByUserAndWeek(userId, weekStart);
     const history = await this.repo.listPriorCompletedSimulados(userId, weekStart, HISTORY_LIMIT);
     if (!existing) {
+      if (!(await this.ultra.isUltra(userId))) return err(new ForbiddenError("ULTRA_REQUIRED"));
       return ok({ weekStart, weekEnd, status: "not_started", simulado: null, history });
     }
     const status: SimuladoCurrentResponse["status"] = existing.completedAt ? "completed" : "in_progress";
@@ -1557,9 +1690,10 @@ EOF
 
 ---
 
-## Self-review checklist (run before dispatch)
+## Self-review checklist (post Gate B v2)
 
-1. **Spec coverage:** every acceptance A1–A13 maps to at least one task. ✅ (A1 → T3/T6; A2 → T3/T4; A3 → T6/T7; A4 → T4/T6; A5 → T4; A6 → T4; A7 → T5/T6; A8 → T6; A9 → T6; A10 → T2; A11 → T2; A12 → T7; A13 → T6/T7.)
+1. **Spec coverage:** every acceptance A1–A13 maps to at least one task. ✅ (A1 → T3/T6; A2 → T3/T4; A3 → T6/T7 (Ultra-lapse-aware); A4 → T4/T6; A5 → T4; A6 → T4; A7 → T5/T6; A8 → T6; A9 → T6 + dedicated test in 6.1; A10 → T2; A11 → T2; A12 → T7; A13 → T6/T7.)
 2. **Placeholder scan:** no TBDs, no "similar to Task N". ✅
 3. **Type consistency:** `SimuladoRow.weekStartDate` is `string` everywhere. `SimuladoQuestionRow` has `correctOptionIndex` always set (read from join). Service strips it before returning to client. ✅
 4. **Migration safety:** `0009_*` is generated by drizzle-kit; manual SQL edits not required. ✅
+5. **Gate B fixes applied:** cleanupTestDb truncate list updated for the two new tables (B1); typed `.for("update")` is the only `recordAnswer` lock form (B2); `difficulty` enum uses `"easy" as const` everywhere (B4); `getCurrent` defers Ultra check so Ultra-lapsed users with an in-progress simulado still see it (B6); FK prereqs (subject + topic + subtopic) seeded inside the `seedQuestions` helper before inserting questions; `shields.ts` migrated to shared `BRT_OFFSET_MS` (N2); `inArray` replaces `sql.join` (N3); `fetchQuestionsForSimulado` no longer threads `tx` (N1); fleshed-out A9 service test (N5). ✅

--- a/docs/superpowers/specs/2026-05-12-phase-2e3-simulado-semanal-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e3-simulado-semanal-design.md
@@ -1,6 +1,6 @@
 # Phase 2E.3 — Simulado Semanal (Design Spec)
 
-**Status:** v1
+**Status:** v2 (post Gate A self-review)
 **Date:** 2026-05-12
 **Branch:** `feature/phase-2e3-simulado-semanal`
 **Product source:** `pruvi-freatures.md` §5.2
@@ -27,11 +27,11 @@ Deliver a weekly mock exam ("simulado") to Ultra users: 35 questions, BRT-anchor
 - Questions are sampled deterministically from the user's perspective: for a given `(userId, weekStart)`, the same 35 questions are always returned. This lets users resume mid-simulado on a different device.
 - Answers are stored per-question with server-side `isCorrect`. Answering is idempotent per question (first answer wins; second attempt returns the recorded outcome).
 - Lifecycle: `not_started` → `in_progress` (POST /start) → `completed` (POST /complete OR auto-finalized when all 35 questions are answered).
-- After completion, results show per-subject correct/total and a 5-week history (current week + 4 prior, oldest first) for charting.
+- After completion, results show per-subject correct/total for the current simulado plus up to 4 prior completed weeks (oldest first). The current week is never duplicated inside the `history` array — clients combine the top-level current-week fields with `history` to render a 5-bar evolution chart.
 
 ## 4. Entitlement
 
-- Gated by `UltraService.isUltraActive(userId)` (existing, Phase 2E.1).
+- Gated by `UltraService.isUltra(userId)` (existing, Phase 2E.1 — note the method is named `isUltra`, not `isUltraActive`).
 - Non-Ultra requests return `403 ULTRA_REQUIRED` with the same envelope the lives feature uses for paywalls.
 - If Ultra lapses mid-simulado (`ultraExpiresAt` passes while a simulado is in progress), the user can still complete the simulado they started but cannot start a new one. **Rationale:** they paid for that simulado at start time; clawing it back creates support pain.
 
@@ -103,14 +103,20 @@ simulados/
 
 **Why this approach:** stateless, repeatable, and resumable. Doesn't touch `review_log` and doesn't require pre-storing the questions list before the user starts (we still store the assignment in `weekly_simulado_question` on `/start` so subsequent fetches don't re-query the seed; this also pins the set against future bank edits).
 
+**Bank smaller than `SIMULADO_QUESTION_COUNT`:** if the bank holds fewer than 35 questions (dev/seed environments), `selectQuestionsForSimulado` returns whatever the bank has (graceful degradation). `weekly_simulado.questions_count` records the actual count returned. Acceptance criterion A1 below states the 35-question guarantee conditionally on bank size.
+
 ### 6.3 Week boundaries
+
+`BRT_OFFSET_MS` must be defined once in `packages/shared/src/time.ts` (new file or existing time helper) and imported by both `packages/shared/src/weekly.ts` (Monday-anchored, ranking) and the new `packages/shared/src/simulado.ts` (Sunday-anchored, simulado). The existing inline constant in `weekly.ts` must be replaced by the import. Brazil does not observe DST (suspended 2019), so a fixed UTC-3 offset is correct; a single source of truth prevents future divergence.
 
 In `packages/shared/src/simulado.ts`:
 
 ```ts
-const BRT_OFFSET_MS = 3 * 60 * 60 * 1000;
+import { BRT_OFFSET_MS } from "./time";
 
-/** Sunday-anchored BRT week boundaries. Returns ISO date strings. */
+/** Sunday-anchored BRT week boundaries. Returns ISO date strings (YYYY-MM-DD)
+ *  representing BRT wall-clock dates, not UTC dates. The subtraction is
+ *  applied before truncation so the returned string is the BRT calendar date. */
 export function weekBoundsForSimulado(now: Date): {
   weekStart: string; // YYYY-MM-DD (Sunday in BRT)
   weekEnd: string;   // YYYY-MM-DD (next Sunday in BRT, exclusive)
@@ -147,7 +153,7 @@ All routes mount under `/api`; all require `fastify.authenticate`. All responses
 
 ### 7.1 `GET /simulados/current`
 
-Returns the current week's simulado state and 5-week history (current + 4 prior).
+Returns the current week's simulado state and up to 4 prior completed simulados (history).
 
 ```ts
 SimuladoCurrentResponseSchema = z.object({
@@ -171,7 +177,10 @@ SimuladoCurrentResponseSchema = z.object({
       correct: z.number().int(),
       total: z.number().int(),
     })),
-  })),                              // oldest first; up to 5 entries
+  })),                              // PRIOR completed weeks only, oldest first, up to 4 entries.
+                                    // The current week is represented by `status` + `simulado` above and
+                                    // is NEVER duplicated in `history`. Clients reconstruct the 5-bar
+                                    // chart by combining the top-level fields with `history`.
 });
 ```
 
@@ -179,7 +188,7 @@ Non-Ultra: `403 ULTRA_REQUIRED`.
 
 ### 7.2 `POST /simulados/start`
 
-Creates and returns the simulado for the current week. Idempotent: if one already exists for `(user, weekStart)`, returns the existing one.
+Creates and returns the simulado for the current week. Idempotent under concurrency: implemented as a single transaction using `INSERT ... ON CONFLICT (user_id, week_start_date) DO NOTHING RETURNING *`. If the conflict path is taken (zero rows returned), the same transaction re-reads the existing row by `(user_id, week_start_date)` and returns it. This pattern matches `shields.repository.ts`'s use of UNIQUE-conflict handling and avoids the TOCTOU race that a SELECT-then-INSERT would introduce. Question selection (deterministic, §6.2) and the bulk insert into `weekly_simulado_question` happen inside the same transaction so the simulado is never visible without its question set.
 
 ```ts
 // Request body: none
@@ -196,7 +205,7 @@ SimuladoStartResponseSchema = z.object({
     content: z.string(),
     options: z.array(z.string()),
     subjectId: z.number().int(),
-    subtopicId: z.number().int().nullable(),
+    subtopicId: z.number().int(),
     requiresCalculation: z.boolean(),
     // selectedOptionIndex/isCorrect/correctOptionIndex/explanation are NOT included here
   })),
@@ -229,12 +238,19 @@ SimuladoAnswerResponseSchema = z.object({
 ```
 
 **Semantics:**
-- Validates the question belongs to this simulado.
-- If the question already has a recorded answer: returns the recorded outcome unchanged (idempotent — first answer wins).
-- If not answered: records the answer, increments `correct_count` on the parent simulado if correct, and if this was the last unanswered question, sets `completed_at = now()` atomically (single transaction).
-- 404 if simulado not found or not owned.
+- 404 if simulado not found or not owned (return 404 instead of 403 to avoid leaking existence).
 - 400 if `questionId` doesn't belong to this simulado.
-- 409 if the simulado is already in state `completed` (no more answers allowed).
+- 409 if the simulado is already in state `completed` (no more answers allowed). Checked inside the transaction after acquiring the parent-row lock; a 409 must not retroactively expose the answer.
+
+**Transaction shape (mandatory — race-safe under Read Committed):**
+
+1. `SELECT * FROM weekly_simulado WHERE id = $id AND user_id = $userId FOR UPDATE`. This serializes concurrent answers on the same simulado, eliminating the auto-completion races (both-set or neither-set) that arise from racing conditional updates. Return 404 / 409 from this row.
+2. Conditional update on the question row: `UPDATE weekly_simulado_question SET selected_option_index = $opt, is_correct = $isCorrect, answered_at = now() WHERE simulado_id = $id AND question_id = $qId AND selected_option_index IS NULL RETURNING is_correct`. If zero rows updated, the question was already answered — re-read its recorded `is_correct` and return that outcome unchanged (first-answer-wins idempotency).
+3. If a new answer was recorded and `is_correct = true`: `UPDATE weekly_simulado SET correct_count = correct_count + 1 WHERE id = $id`.
+4. Re-count unanswered: `SELECT COUNT(*) FROM weekly_simulado_question WHERE simulado_id = $id AND is_correct IS NULL`. Because the parent row is locked, no concurrent transaction can have committed an answer between step 2 and step 4. If the count is 0: `UPDATE weekly_simulado SET completed_at = now() WHERE id = $id AND completed_at IS NULL`.
+5. Commit.
+
+`answeredCount` and `completed` in the response are computed from post-transaction state read inside the same transaction.
 
 ### 7.5 `POST /simulados/:id/complete`
 
@@ -263,7 +279,9 @@ SimuladoResultsResponseSchema = z.object({
       correct: z.number().int(),
       total: z.number().int(),
     })),
-  })),                              // includes the current simulado; oldest first
+  })),                              // PRIOR completed weeks only, oldest first, up to 4 entries.
+                                    // The current simulado's totals are in the top-level fields and are
+                                    // NEVER duplicated in `history`. Same convention as §7.1.
 });
 ```
 
@@ -299,13 +317,13 @@ No data backfill needed (greenfield tables).
 
 ## 10. Acceptance criteria
 
-A1. Ultra-active user can `POST /simulados/start` during the current BRT Sunday-Sunday window and receive 35 distinct questions.
+A1. Ultra-active user can `POST /simulados/start` during the current BRT Sunday-Sunday window and receive `min(SIMULADO_QUESTION_COUNT, total_bank_size)` distinct questions (35 in production; fewer in dev/seed environments where the bank is smaller, with `weekly_simulado.questions_count` reflecting the actual count).
 A2. The same Ultra user calling `/start` twice in the same week receives the same `simulado.id` and the same question set in the same order.
 A3. Non-Ultra user receives `403 ULTRA_REQUIRED` from `/start`, `/current`, `/:id`, `/:id/answer`, `/:id/complete`, `/:id/results`.
 A4. `POST /simulados/:id/answer` returns `{ isCorrect, correctOptionIndex, explanation }` based on the stored question and the submitted option.
 A5. Answering the same question twice on the same simulado returns the originally-recorded outcome; `correct_count` is incremented exactly once.
 A6. Answering the 35th unanswered question auto-completes the simulado (`completed_at` set, response `completed: true`).
-A7. `GET /simulados/current` returns `status`, current simulado (or null), and history with up to 5 weeks of per-subject breakdowns ordered oldest first.
+A7. `GET /simulados/current` returns `status`, current simulado (or null), and `history` containing up to 4 PRIOR completed simulados with per-subject breakdowns ordered oldest first. The current simulado's totals are never duplicated inside `history`.
 A8. `GET /simulados/:id/results` is only available when the simulado is `completed`; otherwise `400`.
 A9. A user whose Ultra lapses mid-simulado can still answer and complete the simulado they started, but cannot `/start` a new one.
 A10. `weekly_simulado` has a UNIQUE `(user_id, week_start_date)` constraint enforced at the DB layer.

--- a/docs/superpowers/specs/2026-05-12-phase-2e3-simulado-semanal-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e3-simulado-semanal-design.md
@@ -1,6 +1,6 @@
 # Phase 2E.3 — Simulado Semanal (Design Spec)
 
-**Status:** v2 (post Gate A self-review)
+**Status:** v3 (post Gate B plan review — resolves Ultra-lapse `/current` UX)
 **Date:** 2026-05-12
 **Branch:** `feature/phase-2e3-simulado-semanal`
 **Product source:** `pruvi-freatures.md` §5.2
@@ -32,8 +32,10 @@ Deliver a weekly mock exam ("simulado") to Ultra users: 35 questions, BRT-anchor
 ## 4. Entitlement
 
 - Gated by `UltraService.isUltra(userId)` (existing, Phase 2E.1 — note the method is named `isUltra`, not `isUltraActive`).
-- Non-Ultra requests return `403 ULTRA_REQUIRED` with the same envelope the lives feature uses for paywalls.
+- Non-Ultra requests return `403 ULTRA_REQUIRED` from `POST /simulados/start` unconditionally (no new simulado for non-Ultra).
+- `GET /simulados/current`, `GET /simulados/:id`, `POST /simulados/:id/answer`, `POST /simulados/:id/complete`, and `GET /simulados/:id/results` return `403 ULTRA_REQUIRED` ONLY when the user is non-Ultra AND has no existing simulado for the relevant week (`/current`) or the requested simulado is not theirs (`/:id` endpoints — these use 404 anyway). The mid-simulado escape hatch (spec A9) is preserved: a user whose Ultra lapsed while a simulado is in progress can still see it via `/current`, fetch its detail, answer remaining questions, and finalize it.
 - If Ultra lapses mid-simulado (`ultraExpiresAt` passes while a simulado is in progress), the user can still complete the simulado they started but cannot start a new one. **Rationale:** they paid for that simulado at start time; clawing it back creates support pain.
+- **Implementation rule:** `getCurrent` and `getDetail`/`recordAnswer`/`forceComplete`/`getResults` do NOT call `ultra.isUltra` unconditionally. Instead: `getCurrent` calls `ultra.isUltra` only after determining no simulado exists for the current week (so a lapsed user with an in-progress simulado still gets a 200 response). `getDetail`/`recordAnswer`/`forceComplete`/`getResults` rely on ownership (returning 404 if not owned) and do not check Ultra at all, because the simulado's existence is itself proof of past entitlement at start time.
 
 ## 5. Data model
 
@@ -184,7 +186,7 @@ SimuladoCurrentResponseSchema = z.object({
 });
 ```
 
-Non-Ultra: `403 ULTRA_REQUIRED`.
+Non-Ultra with NO simulado for the current week: `403 ULTRA_REQUIRED`. Non-Ultra with an existing simulado for the current week (Ultra-lapsed mid-simulado): `200` with that simulado's state. See §4 for the entitlement rule.
 
 ### 7.2 `POST /simulados/start`
 
@@ -319,7 +321,7 @@ No data backfill needed (greenfield tables).
 
 A1. Ultra-active user can `POST /simulados/start` during the current BRT Sunday-Sunday window and receive `min(SIMULADO_QUESTION_COUNT, total_bank_size)` distinct questions (35 in production; fewer in dev/seed environments where the bank is smaller, with `weekly_simulado.questions_count` reflecting the actual count).
 A2. The same Ultra user calling `/start` twice in the same week receives the same `simulado.id` and the same question set in the same order.
-A3. Non-Ultra user receives `403 ULTRA_REQUIRED` from `/start`, `/current`, `/:id`, `/:id/answer`, `/:id/complete`, `/:id/results`.
+A3. Non-Ultra user with NO simulado for the current week receives `403 ULTRA_REQUIRED` from `POST /simulados/start` and `GET /simulados/current`. Non-Ultra user who started a simulado while Ultra was active (now lapsed) gets a `200` from `/current` showing their in-progress simulado and can still call `/:id`, `/:id/answer`, `/:id/complete`, `/:id/results` for it. Non-owners of a simulado get `404` from the `/:id*` endpoints (not 403) to avoid leaking existence.
 A4. `POST /simulados/:id/answer` returns `{ isCorrect, correctOptionIndex, explanation }` based on the stored question and the submitted option.
 A5. Answering the same question twice on the same simulado returns the originally-recorded outcome; `correct_count` is incremented exactly once.
 A6. Answering the 35th unanswered question auto-completes the simulado (`completed_at` set, response `completed: true`).

--- a/docs/superpowers/specs/2026-05-12-phase-2e3-simulado-semanal-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e3-simulado-semanal-design.md
@@ -1,0 +1,330 @@
+# Phase 2E.3 — Simulado Semanal (Design Spec)
+
+**Status:** v1
+**Date:** 2026-05-12
+**Branch:** `feature/phase-2e3-simulado-semanal`
+**Product source:** `pruvi-freatures.md` §5.2
+
+---
+
+## 1. Goal
+
+Deliver a weekly mock exam ("simulado") to Ultra users: 35 questions, BRT-anchored Sunday-to-Sunday window, per-subject performance results, and a 5-week history for visualizing progress.
+
+## 2. Non-goals
+
+- Banca-specific question filtering by exam board (`user.selectedExam`). The `question.source` field is unstructured; mapping it to bancas is out of scope for v1. v1 samples from the entire question bank. Banca filtering is deferred.
+- Timer enforcement. The client decides whether to show a countdown; the server only records `startedAt`/`completedAt`.
+- Coupling the simulado to SM-2 review state, XP, lives, or streak. Simulado is an isolated, monetization-facing flow. Answers do NOT update `review_log` or grant XP.
+- Free-tier purchase or trial of individual simulados.
+- Real-time multiplayer or proctoring.
+
+## 3. Mechanic
+
+- A new simulado week starts at **Sunday 00:00 BRT** and runs through the following Sunday 00:00 BRT (exclusive).
+- One simulado per `(user_id, week_start_date)`. Ultra users can start it any time within the window.
+- 35 questions per simulado (configurable constant `SIMULADO_QUESTION_COUNT = 35`, within the product range 30–40).
+- Questions are sampled deterministically from the user's perspective: for a given `(userId, weekStart)`, the same 35 questions are always returned. This lets users resume mid-simulado on a different device.
+- Answers are stored per-question with server-side `isCorrect`. Answering is idempotent per question (first answer wins; second attempt returns the recorded outcome).
+- Lifecycle: `not_started` → `in_progress` (POST /start) → `completed` (POST /complete OR auto-finalized when all 35 questions are answered).
+- After completion, results show per-subject correct/total and a 5-week history (current week + 4 prior, oldest first) for charting.
+
+## 4. Entitlement
+
+- Gated by `UltraService.isUltraActive(userId)` (existing, Phase 2E.1).
+- Non-Ultra requests return `403 ULTRA_REQUIRED` with the same envelope the lives feature uses for paywalls.
+- If Ultra lapses mid-simulado (`ultraExpiresAt` passes while a simulado is in progress), the user can still complete the simulado they started but cannot start a new one. **Rationale:** they paid for that simulado at start time; clawing it back creates support pain.
+
+## 5. Data model
+
+### 5.1 `weekly_simulado`
+
+```sql
+CREATE TABLE weekly_simulado (
+  id              SERIAL PRIMARY KEY,
+  user_id         TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  week_start_date DATE NOT NULL,                    -- BRT Sunday
+  started_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  completed_at    TIMESTAMP WITH TIME ZONE,         -- NULL while in_progress
+  questions_count INTEGER NOT NULL,                 -- snapshot of SIMULADO_QUESTION_COUNT at start
+  correct_count   INTEGER NOT NULL DEFAULT 0,
+  CONSTRAINT weekly_simulado_unique UNIQUE (user_id, week_start_date)
+);
+CREATE INDEX weekly_simulado_user_week_idx
+  ON weekly_simulado (user_id, week_start_date DESC);
+```
+
+### 5.2 `weekly_simulado_question`
+
+```sql
+CREATE TABLE weekly_simulado_question (
+  simulado_id            INTEGER NOT NULL REFERENCES weekly_simulado(id) ON DELETE CASCADE,
+  position               INTEGER NOT NULL,           -- 0..N-1, stable order
+  question_id            INTEGER NOT NULL REFERENCES question(id) ON DELETE RESTRICT,
+  selected_option_index  INTEGER,                    -- NULL until answered
+  is_correct             BOOLEAN,                    -- NULL until answered
+  answered_at            TIMESTAMP WITH TIME ZONE,   -- NULL until answered
+  PRIMARY KEY (simulado_id, position),
+  CONSTRAINT simulado_question_unique UNIQUE (simulado_id, question_id)
+);
+CREATE INDEX simulado_question_simulado_idx
+  ON weekly_simulado_question (simulado_id);
+```
+
+**Note on `ON DELETE RESTRICT` for `question_id`:** prevents losing simulado history when a question is deleted from the bank. If a question must be removed, the admin must first migrate or accept the simulado history is also archived.
+
+## 6. Architecture
+
+New module: `apps/server/src/features/simulados/`
+
+```
+simulados/
+├── simulados.repository.ts
+├── simulados.repository.integration.test.ts
+├── simulados.service.ts
+├── simulados.service.test.ts
+├── simulados.route.ts
+└── index.ts
+```
+
+### 6.1 Layering
+
+- **Route** parses input, dispatches to service, formats response envelope. Auth via `fastify.authenticate`.
+- **Service** orchestrates: checks Ultra entitlement, computes week boundaries via `weekBoundsForSimulado(now)` helper (new, in `packages/shared/src/simulado.ts`), composes question selection + persistence, builds result payloads.
+- **Repository** wraps Drizzle calls. All multi-statement writes use `db.transaction`.
+
+### 6.2 Question selection
+
+`SimuladosRepository.selectQuestionsForSimulado(userId, weekStart, count)`:
+
+1. Deterministic seed: `seed = hash(userId || weekStart)` using a stable string hash (e.g., `bun:crypto` SHA-256 → take first 8 bytes as bigint → modulo). The seed itself is not stored; selection is repeatable because the inputs are stable.
+2. Query `count` questions from the full bank using `ORDER BY md5(id::text || $seedString) LIMIT $count` to get a deterministic pseudo-random sample without holding the full bank in memory.
+3. Return the rows in the resulting order; `position` is the row index.
+
+**Why this approach:** stateless, repeatable, and resumable. Doesn't touch `review_log` and doesn't require pre-storing the questions list before the user starts (we still store the assignment in `weekly_simulado_question` on `/start` so subsequent fetches don't re-query the seed; this also pins the set against future bank edits).
+
+### 6.3 Week boundaries
+
+In `packages/shared/src/simulado.ts`:
+
+```ts
+const BRT_OFFSET_MS = 3 * 60 * 60 * 1000;
+
+/** Sunday-anchored BRT week boundaries. Returns ISO date strings. */
+export function weekBoundsForSimulado(now: Date): {
+  weekStart: string; // YYYY-MM-DD (Sunday in BRT)
+  weekEnd: string;   // YYYY-MM-DD (next Sunday in BRT, exclusive)
+} {
+  const brtMs = now.getTime() - BRT_OFFSET_MS;
+  const brt = new Date(brtMs);
+  const dow = brt.getUTCDay(); // 0=Sun..6=Sat
+  brt.setUTCDate(brt.getUTCDate() - dow);
+  brt.setUTCHours(0, 0, 0, 0);
+  const start = new Date(brt);
+  const end = new Date(brt);
+  end.setUTCDate(end.getUTCDate() + 7);
+  return {
+    weekStart: start.toISOString().slice(0, 10),
+    weekEnd: end.toISOString().slice(0, 10),
+  };
+}
+```
+
+**Why a new helper instead of reusing `startOfWeekBrt`:** the existing helper is Monday-anchored (used by ranking). Simulado is Sunday-anchored per product. Different concept, different helper.
+
+### 6.4 Service-level caching
+
+- `GET /simulados/current` payload cached at `simulado:current:{userId}` with TTL 60s.
+- Invalidated on: `/start`, `/answer`, `/complete`. (Cheap `cache.del`; safe to call when key doesn't exist.)
+
+### 6.5 Logging
+
+All service errors flow through `fastify.log` (structured), matching the post-2E.2 logger pattern in `sessions.service.ts`. No `console.error`.
+
+## 7. API surface
+
+All routes mount under `/api`; all require `fastify.authenticate`. All responses use the existing `successResponse` envelope.
+
+### 7.1 `GET /simulados/current`
+
+Returns the current week's simulado state and 5-week history (current + 4 prior).
+
+```ts
+SimuladoCurrentResponseSchema = z.object({
+  weekStart: z.string(),           // YYYY-MM-DD (BRT Sunday)
+  weekEnd: z.string(),
+  status: z.enum(["not_started", "in_progress", "completed"]),
+  simulado: z.object({
+    id: z.number().int(),
+    startedAt: z.string(),
+    completedAt: z.string().nullable(),
+    questionsCount: z.number().int(),
+    answeredCount: z.number().int(),
+    correctCount: z.number().int(),
+  }).nullable(),
+  history: z.array(z.object({
+    weekStart: z.string(),
+    correct: z.number().int(),
+    total: z.number().int(),
+    perSubject: z.array(z.object({
+      subjectId: z.number().int(),
+      correct: z.number().int(),
+      total: z.number().int(),
+    })),
+  })),                              // oldest first; up to 5 entries
+});
+```
+
+Non-Ultra: `403 ULTRA_REQUIRED`.
+
+### 7.2 `POST /simulados/start`
+
+Creates and returns the simulado for the current week. Idempotent: if one already exists for `(user, weekStart)`, returns the existing one.
+
+```ts
+// Request body: none
+// Response data:
+SimuladoStartResponseSchema = z.object({
+  simulado: z.object({
+    id: z.number().int(),
+    startedAt: z.string(),
+    questionsCount: z.number().int(),
+  }),
+  questions: z.array(z.object({
+    position: z.number().int(),
+    questionId: z.number().int(),
+    content: z.string(),
+    options: z.array(z.string()),
+    subjectId: z.number().int(),
+    subtopicId: z.number().int().nullable(),
+    requiresCalculation: z.boolean(),
+    // selectedOptionIndex/isCorrect/correctOptionIndex/explanation are NOT included here
+  })),
+});
+```
+
+Non-Ultra: `403 ULTRA_REQUIRED`.
+
+### 7.3 `GET /simulados/:id`
+
+Returns the in-progress simulado state (questions + already-recorded answers). For answered questions, includes `selectedOptionIndex` and `isCorrect`; `correctOptionIndex` and `explanation` are only included when the simulado is `completed` OR for the specific answered question (so the client can show post-answer feedback). For unanswered questions, none of the answer fields are included.
+
+**Auth:** must be the simulado owner; otherwise `404`. Use `404` (not `403`) to avoid leaking existence.
+
+### 7.4 `POST /simulados/:id/answer`
+
+```ts
+SimuladoAnswerBodySchema = z.object({
+  questionId: z.number().int(),
+  selectedOptionIndex: z.number().int().min(0).max(3),
+});
+
+SimuladoAnswerResponseSchema = z.object({
+  isCorrect: z.boolean(),
+  correctOptionIndex: z.number().int(),
+  explanation: z.string().nullable(),
+  answeredCount: z.number().int(),
+  completed: z.boolean(),          // true if this answer was the 35th
+});
+```
+
+**Semantics:**
+- Validates the question belongs to this simulado.
+- If the question already has a recorded answer: returns the recorded outcome unchanged (idempotent — first answer wins).
+- If not answered: records the answer, increments `correct_count` on the parent simulado if correct, and if this was the last unanswered question, sets `completed_at = now()` atomically (single transaction).
+- 404 if simulado not found or not owned.
+- 400 if `questionId` doesn't belong to this simulado.
+- 409 if the simulado is already in state `completed` (no more answers allowed).
+
+### 7.5 `POST /simulados/:id/complete`
+
+Force-finalize a simulado even if not all questions are answered. Sets `completed_at = now()` if NULL. Idempotent. Unanswered questions remain NULL — they count toward `total` but not toward `correct`.
+
+### 7.6 `GET /simulados/:id/results`
+
+Returns the same per-subject breakdown the `current` endpoint embeds in history, but for an arbitrary owned simulado. Only valid when `status = completed`; otherwise `400`.
+
+```ts
+SimuladoResultsResponseSchema = z.object({
+  weekStart: z.string(),
+  correct: z.number().int(),
+  total: z.number().int(),
+  perSubject: z.array(z.object({
+    subjectId: z.number().int(),
+    correct: z.number().int(),
+    total: z.number().int(),
+  })),
+  history: z.array(z.object({
+    weekStart: z.string(),
+    correct: z.number().int(),
+    total: z.number().int(),
+    perSubject: z.array(z.object({
+      subjectId: z.number().int(),
+      correct: z.number().int(),
+      total: z.number().int(),
+    })),
+  })),                              // includes the current simulado; oldest first
+});
+```
+
+## 8. Migration
+
+`packages/db/src/migrations/0009_<name>.sql` (drizzle-kit will generate the suffix):
+
+- Create `weekly_simulado` and `weekly_simulado_question` per §5.
+- Add the `(user_id, week_start_date)` UNIQUE constraint inline.
+- Add `(simulado_id, question_id)` UNIQUE constraint inline.
+
+No data backfill needed (greenfield tables).
+
+## 9. Testing strategy
+
+**Unit (`*.service.test.ts`)**, using existing PGlite test client pattern:
+- Ultra entitlement gating: non-Ultra → 403, Ultra-active → proceeds, Ultra-expired (`ultraExpiresAt` past) → 403 for start, but can still answer/complete an existing simulado.
+- `weekBoundsForSimulado` BRT edge cases: Saturday 23:59 BRT, Sunday 00:00 BRT, Sunday 23:59 BRT, week containing DST-style (N/A in BRT but verify no surprise).
+- `POST /start` idempotency: second call returns same `simulado.id`.
+- `POST /answer` idempotency: re-answering with a different option returns the originally-recorded outcome.
+- Auto-completion: answering the 35th question sets `completed_at` and returns `completed: true`.
+- `correct_count` increments only on correct, only on first answer for that question.
+
+**Integration (`*.repository.integration.test.ts`)**, real DB via existing helpers:
+- `selectQuestionsForSimulado` determinism: same `(userId, weekStart)` returns the same set in the same order.
+- `selectQuestionsForSimulado` distinctness: returns `count` distinct questions.
+- History query: for a user with 6 prior simulados, returns the most recent 4 + current = 5 entries, ordered oldest first, with correct per-subject breakdown.
+- Cascade: deleting a `weekly_simulado` deletes its `weekly_simulado_question` rows (ON DELETE CASCADE).
+- UNIQUE constraints reject duplicate `(user, weekStart)` and duplicate `(simulado, question)`.
+
+**Shared (`packages/shared/src/simulado.test.ts`)**:
+- `weekBoundsForSimulado` returns Sunday-anchored boundaries for inputs across the BRT week.
+
+## 10. Acceptance criteria
+
+A1. Ultra-active user can `POST /simulados/start` during the current BRT Sunday-Sunday window and receive 35 distinct questions.
+A2. The same Ultra user calling `/start` twice in the same week receives the same `simulado.id` and the same question set in the same order.
+A3. Non-Ultra user receives `403 ULTRA_REQUIRED` from `/start`, `/current`, `/:id`, `/:id/answer`, `/:id/complete`, `/:id/results`.
+A4. `POST /simulados/:id/answer` returns `{ isCorrect, correctOptionIndex, explanation }` based on the stored question and the submitted option.
+A5. Answering the same question twice on the same simulado returns the originally-recorded outcome; `correct_count` is incremented exactly once.
+A6. Answering the 35th unanswered question auto-completes the simulado (`completed_at` set, response `completed: true`).
+A7. `GET /simulados/current` returns `status`, current simulado (or null), and history with up to 5 weeks of per-subject breakdowns ordered oldest first.
+A8. `GET /simulados/:id/results` is only available when the simulado is `completed`; otherwise `400`.
+A9. A user whose Ultra lapses mid-simulado can still answer and complete the simulado they started, but cannot `/start` a new one.
+A10. `weekly_simulado` has a UNIQUE `(user_id, week_start_date)` constraint enforced at the DB layer.
+A11. `weekly_simulado_question` has a UNIQUE `(simulado_id, question_id)` constraint enforced at the DB layer.
+A12. The `GET /simulados/current` response is cached at `simulado:current:{userId}` with TTL 60s and invalidated on `/start`, `/answer`, `/complete`.
+A13. All service errors are logged via `fastify.log` (structured); no `console.error` calls in production paths.
+
+## 11. Deferred items
+
+- Banca-specific question filtering (requires `question.examBoard` field and source→banca mapping).
+- Push notification on Sunday morning ("Seu simulado da semana está pronto").
+- Comparative analytics ("você melhorou X% em Matemática vs semana passada") — basic data is exposed; aggregation UI is client-side.
+- Simulado-specific question quality curation (handcrafted vs sampled).
+- Free-tier per-simulado purchase.
+
+## 12. Open questions resolved during design
+
+- **Question count fixed vs. user-chosen:** Fixed at 35 (mid-range). YAGNI: no current UX need for per-user customization.
+- **Re-answering policy:** First answer wins. **Why:** matches "real exam" feel and avoids gaming `correct_count`. The product doc doesn't mandate either way.
+- **Simulado vs review_log coupling:** Decoupled. **Why:** simulado is monetization-driven and shouldn't double-count for spaced repetition (would distort the SM-2 schedule).
+- **XP/streak coupling:** Decoupled. **Why:** simulado is a separate flow; product doesn't request it; coupling would create cross-feature regressions.
+- **Question ordering display:** Stored `position` is canonical. Client renders in that order.

--- a/packages/db/src/migrations/0009_marvelous_johnny_blaze.sql
+++ b/packages/db/src/migrations/0009_marvelous_johnny_blaze.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "weekly_simulado" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"week_start_date" date NOT NULL,
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"completed_at" timestamp with time zone,
+	"questions_count" integer NOT NULL,
+	"correct_count" integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "weekly_simulado_question" (
+	"simulado_id" integer NOT NULL,
+	"position" integer NOT NULL,
+	"question_id" integer NOT NULL,
+	"selected_option_index" integer,
+	"is_correct" boolean,
+	"answered_at" timestamp with time zone,
+	CONSTRAINT "weekly_simulado_question_simulado_id_position_pk" PRIMARY KEY("simulado_id","position")
+);
+--> statement-breakpoint
+ALTER TABLE "weekly_simulado" ADD CONSTRAINT "weekly_simulado_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "weekly_simulado_question" ADD CONSTRAINT "weekly_simulado_question_simulado_id_weekly_simulado_id_fk" FOREIGN KEY ("simulado_id") REFERENCES "public"."weekly_simulado"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "weekly_simulado_question" ADD CONSTRAINT "weekly_simulado_question_question_id_question_id_fk" FOREIGN KEY ("question_id") REFERENCES "public"."question"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "weekly_simulado_user_week_uq" ON "weekly_simulado" USING btree ("user_id","week_start_date");--> statement-breakpoint
+CREATE INDEX "weekly_simulado_user_week_idx" ON "weekly_simulado" USING btree ("user_id","week_start_date");--> statement-breakpoint
+CREATE UNIQUE INDEX "weekly_simulado_question_simulado_question_uq" ON "weekly_simulado_question" USING btree ("simulado_id","question_id");--> statement-breakpoint
+CREATE INDEX "weekly_simulado_question_simulado_idx" ON "weekly_simulado_question" USING btree ("simulado_id");

--- a/packages/db/src/migrations/meta/0009_snapshot.json
+++ b/packages/db/src/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1756 @@
+{
+  "id": "5c37fefc-7ff7-43c6-84c7-74ab678ede71",
+  "prevId": "05b75080-524e-4f84-b73e-25e5f3da9816",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives": {
+          "name": "lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lives_last_regen_at": {
+          "name": "lives_last_regen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "selected_exam": {
+          "name": "selected_exam",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulties": {
+          "name": "difficulties",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "daily_study_time_minutes": {
+          "name": "daily_study_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ultra": {
+          "name": "is_ultra",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ultra_expires_at": {
+          "name": "ultra_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)"
+        },
+        "notification_hour": {
+          "name": "notification_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 19
+        },
+        "streak_reminders_enabled": {
+          "name": "streak_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "achievement_notifications_enabled": {
+          "name": "achievement_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "streak_shields_available": {
+          "name": "streak_shields_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_shield_grant_at": {
+          "name": "last_shield_grant_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_session": {
+      "name": "daily_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_correct": {
+          "name": "questions_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastery_snapshot": {
+          "name": "mastery_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_session_user_created_idx": {
+          "name": "daily_session_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_session_user_id_user_id_fk": {
+          "name": "daily_session_user_id_user_id_fk",
+          "tableFrom": "daily_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "friendship_requester_idx": {
+          "name": "friendship_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendship_recipient_idx": {
+          "name": "friendship_recipient_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendship_requester_id_user_id_fk": {
+          "name": "friendship_requester_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_recipient_id_user_id_fk": {
+          "name": "friendship_recipient_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subject_name_unique": {
+          "name": "subject_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "subject_slug_unique": {
+          "name": "subject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopic": {
+      "name": "subtopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtopic_topic_order_idx": {
+          "name": "subtopic_topic_order_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopic_topic_id_topic_id_fk": {
+          "name": "subtopic_topic_id_topic_id_fk",
+          "tableFrom": "subtopic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtopic_topic_slug_uniq": {
+          "name": "subtopic_topic_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topic_subject_order_idx": {
+          "name": "topic_subject_order_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_subject_id_subject_id_fk": {
+          "name": "topic_subject_id_subject_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_subject_slug_uniq": {
+          "name": "topic_subject_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_option_index": {
+          "name": "correct_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_calculation": {
+          "name": "requires_calculation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtopic_id": {
+          "name": "subtopic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_subject_difficulty_idx": {
+          "name": "question_subject_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_subtopic_difficulty_idx": {
+          "name": "question_subtopic_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_subject_id_subject_id_fk": {
+          "name": "question_subject_id_subject_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_subtopic_id_subtopic_id_fk": {
+          "name": "question_subtopic_id_subtopic_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subtopic",
+          "columnsFrom": [
+            "subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_log": {
+      "name": "review_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "easiness_factor": {
+          "name": "easiness_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_log_user_next_review_idx": {
+          "name": "review_log_user_next_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_log_user_question_idx": {
+          "name": "review_log_user_question_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_log_user_id_user_id_fk": {
+          "name": "review_log_user_id_user_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_log_question_id_question_id_fk": {
+          "name": "review_log_question_id_question_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_token": {
+      "name": "push_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_token_user_idx": {
+          "name": "push_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_token_user_id_user_id_fk": {
+          "name": "push_token_user_id_user_id_fk",
+          "tableFrom": "push_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_token_token_unique": {
+          "name": "push_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_acceptance": {
+      "name": "invitation_acceptance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_acceptance_inviter_idx": {
+          "name": "invitation_acceptance_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_acceptance_inviter_id_user_id_fk": {
+          "name": "invitation_acceptance_inviter_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_acceptance_invitee_id_user_id_fk": {
+          "name": "invitation_acceptance_invitee_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invitee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_acceptance_invitee_id_unique": {
+          "name": "invitation_acceptance_invitee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_shield_usage": {
+      "name": "streak_shield_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protected_date": {
+          "name": "protected_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "streak_shield_usage_user_date_idx": {
+          "name": "streak_shield_usage_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protected_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "streak_shield_usage_user_idx": {
+          "name": "streak_shield_usage_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "streak_shield_usage_user_id_user_id_fk": {
+          "name": "streak_shield_usage_user_id_user_id_fk",
+          "tableFrom": "streak_shield_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_simulado": {
+      "name": "weekly_simulado",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start_date": {
+          "name": "week_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions_count": {
+          "name": "questions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weekly_simulado_user_week_uq": {
+          "name": "weekly_simulado_user_week_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_simulado_user_week_idx": {
+          "name": "weekly_simulado_user_week_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_simulado_user_id_user_id_fk": {
+          "name": "weekly_simulado_user_id_user_id_fk",
+          "tableFrom": "weekly_simulado",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_simulado_question": {
+      "name": "weekly_simulado_question",
+      "schema": "",
+      "columns": {
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_index": {
+          "name": "selected_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "weekly_simulado_question_simulado_question_uq": {
+          "name": "weekly_simulado_question_simulado_question_uq",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_simulado_question_simulado_idx": {
+          "name": "weekly_simulado_question_simulado_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_simulado_question_simulado_id_weekly_simulado_id_fk": {
+          "name": "weekly_simulado_question_simulado_id_weekly_simulado_id_fk",
+          "tableFrom": "weekly_simulado_question",
+          "tableTo": "weekly_simulado",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weekly_simulado_question_question_id_question_id_fk": {
+          "name": "weekly_simulado_question_question_id_question_id_fk",
+          "tableFrom": "weekly_simulado_question",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "weekly_simulado_question_simulado_id_position_pk": {
+          "name": "weekly_simulado_question_simulado_id_position_pk",
+          "columns": [
+            "simulado_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1778547463046,
       "tag": "0008_known_lockjaw",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1778584840941,
+      "tag": "0009_marvelous_johnny_blaze",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -8,3 +8,4 @@ export * from "./push-tokens";
 export * from "./friendship";
 export * from "./invitation-acceptance";
 export * from "./streak-shield-usage";
+export * from "./weekly-simulado";

--- a/packages/db/src/schema/weekly-simulado.ts
+++ b/packages/db/src/schema/weekly-simulado.ts
@@ -1,0 +1,48 @@
+import { relations } from "drizzle-orm";
+import { boolean, date, index, integer, pgTable, primaryKey, serial, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+import { question } from "./questions";
+
+export const weeklySimulado = pgTable(
+  "weekly_simulado",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+    weekStartDate: date("week_start_date").notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true }).defaultNow().notNull(),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    questionsCount: integer("questions_count").notNull(),
+    correctCount: integer("correct_count").notNull().default(0),
+  },
+  (t) => [
+    uniqueIndex("weekly_simulado_user_week_uq").on(t.userId, t.weekStartDate),
+    index("weekly_simulado_user_week_idx").on(t.userId, t.weekStartDate),
+  ],
+);
+
+export const weeklySimuladoQuestion = pgTable(
+  "weekly_simulado_question",
+  {
+    simuladoId: integer("simulado_id").notNull().references(() => weeklySimulado.id, { onDelete: "cascade" }),
+    position: integer("position").notNull(),
+    questionId: integer("question_id").notNull().references(() => question.id, { onDelete: "restrict" }),
+    selectedOptionIndex: integer("selected_option_index"),
+    isCorrect: boolean("is_correct"),
+    answeredAt: timestamp("answered_at", { withTimezone: true }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.simuladoId, t.position] }),
+    uniqueIndex("weekly_simulado_question_simulado_question_uq").on(t.simuladoId, t.questionId),
+    index("weekly_simulado_question_simulado_idx").on(t.simuladoId),
+  ],
+);
+
+export const weeklySimuladoRelations = relations(weeklySimulado, ({ many, one }) => ({
+  user: one(user, { fields: [weeklySimulado.userId], references: [user.id] }),
+  questions: many(weeklySimuladoQuestion),
+}));
+
+export const weeklySimuladoQuestionRelations = relations(weeklySimuladoQuestion, ({ one }) => ({
+  simulado: one(weeklySimulado, { fields: [weeklySimuladoQuestion.simuladoId], references: [weeklySimulado.id] }),
+  question: one(question, { fields: [weeklySimuladoQuestion.questionId], references: [question.id] }),
+}));

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,3 +16,5 @@ export * from "./social";
 export * from "./weekly";
 export * from "./ultra";
 export * from "./shields";
+export * from "./time";
+export * from "./simulado";

--- a/packages/shared/src/shields.ts
+++ b/packages/shared/src/shields.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { BRT_OFFSET_MS } from "./time";
 
 export const MAX_STREAK_SHIELDS = 1;
 /** BRT = UTC-3, no DST (Brazil dropped DST in 2019). */
@@ -19,6 +20,6 @@ export type ShieldUseResult = z.infer<typeof ShieldUseResultSchema>;
 
 /** Returns the BRT-local YYYY-MM-DD for a given instant. */
 export function todayInBrt(now: Date): string {
-  const brtMs = now.getTime() - 3 * 60 * 60 * 1000;
+  const brtMs = now.getTime() - BRT_OFFSET_MS;
   return new Date(brtMs).toISOString().slice(0, 10);
 }

--- a/packages/shared/src/simulado.test.ts
+++ b/packages/shared/src/simulado.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { weekBoundsForSimulado, SIMULADO_QUESTION_COUNT } from "./simulado";
+
+describe("SIMULADO_QUESTION_COUNT", () => {
+  it("is 35 (mid-range of product spec 30-40)", () => {
+    expect(SIMULADO_QUESTION_COUNT).toBe(35);
+  });
+});
+
+describe("weekBoundsForSimulado", () => {
+  it("for Sunday 12:00 BRT (15:00 UTC), weekStart is that same Sunday's BRT date", () => {
+    // 2026-05-10 (Sunday) 15:00 UTC == 12:00 BRT
+    const now = new Date("2026-05-10T15:00:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-10");
+    expect(weekEnd).toBe("2026-05-17");
+  });
+
+  it("for Saturday 23:00 BRT (2026-05-09 23:00 BRT == 2026-05-10 02:00 UTC), weekStart is the PREVIOUS Sunday", () => {
+    const now = new Date("2026-05-10T02:00:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-03");
+    expect(weekEnd).toBe("2026-05-10");
+  });
+
+  it("for Sunday 02:00 BRT (Sun 05:00 UTC), weekStart is THAT Sunday's BRT date", () => {
+    const now = new Date("2026-05-10T05:00:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-10");
+    expect(weekEnd).toBe("2026-05-17");
+  });
+
+  it("for Sunday 01:00 UTC (Saturday 22:00 BRT), weekStart is the PREVIOUS Sunday", () => {
+    const now = new Date("2026-05-10T01:00:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-03");
+    expect(weekEnd).toBe("2026-05-10");
+  });
+});

--- a/packages/shared/src/simulado.test.ts
+++ b/packages/shared/src/simulado.test.ts
@@ -36,4 +36,18 @@ describe("weekBoundsForSimulado", () => {
     expect(weekStart).toBe("2026-05-03");
     expect(weekEnd).toBe("2026-05-10");
   });
+
+  it("for Sunday 00:00 BRT exactly (Sunday 03:00 UTC), weekStart is THAT Sunday", () => {
+    const now = new Date("2026-05-10T03:00:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-10");
+    expect(weekEnd).toBe("2026-05-17");
+  });
+
+  it("for Sunday 23:59 BRT (Monday 02:59 UTC), weekStart is THAT Sunday", () => {
+    const now = new Date("2026-05-11T02:59:00Z");
+    const { weekStart, weekEnd } = weekBoundsForSimulado(now);
+    expect(weekStart).toBe("2026-05-10");
+    expect(weekEnd).toBe("2026-05-17");
+  });
 });

--- a/packages/shared/src/simulado.ts
+++ b/packages/shared/src/simulado.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import { BRT_OFFSET_MS } from "./time";
+
+export const SIMULADO_QUESTION_COUNT = 35;
+
+/** Sunday-anchored BRT week bounds. Returns BRT calendar dates as YYYY-MM-DD.
+ *  Subtraction is applied before truncation so the returned string is the BRT
+ *  calendar date, not the UTC calendar date. */
+export function weekBoundsForSimulado(now: Date): { weekStart: string; weekEnd: string } {
+  const brtMs = now.getTime() - BRT_OFFSET_MS;
+  const brt = new Date(brtMs);
+  const dow = brt.getUTCDay(); // 0=Sun..6=Sat
+  brt.setUTCDate(brt.getUTCDate() - dow);
+  brt.setUTCHours(0, 0, 0, 0);
+  const start = new Date(brt);
+  const end = new Date(brt);
+  end.setUTCDate(end.getUTCDate() + 7);
+  return {
+    weekStart: start.toISOString().slice(0, 10),
+    weekEnd: end.toISOString().slice(0, 10),
+  };
+}
+
+const PerSubjectSchema = z.object({
+  subjectId: z.number().int(),
+  correct: z.number().int(),
+  total: z.number().int(),
+});
+
+const HistoryEntrySchema = z.object({
+  weekStart: z.string(),
+  correct: z.number().int(),
+  total: z.number().int(),
+  perSubject: z.array(PerSubjectSchema),
+});
+
+export const SimuladoCurrentResponseSchema = z.object({
+  weekStart: z.string(),
+  weekEnd: z.string(),
+  status: z.enum(["not_started", "in_progress", "completed"]),
+  simulado: z
+    .object({
+      id: z.number().int(),
+      startedAt: z.string(),
+      completedAt: z.string().nullable(),
+      questionsCount: z.number().int(),
+      answeredCount: z.number().int(),
+      correctCount: z.number().int(),
+    })
+    .nullable(),
+  history: z.array(HistoryEntrySchema),
+});
+export type SimuladoCurrentResponse = z.infer<typeof SimuladoCurrentResponseSchema>;
+
+export const SimuladoQuestionSchema = z.object({
+  position: z.number().int(),
+  questionId: z.number().int(),
+  content: z.string(),
+  options: z.array(z.string()),
+  subjectId: z.number().int(),
+  subtopicId: z.number().int(),
+  requiresCalculation: z.boolean(),
+});
+export type SimuladoQuestion = z.infer<typeof SimuladoQuestionSchema>;
+
+export const SimuladoStartResponseSchema = z.object({
+  simulado: z.object({
+    id: z.number().int(),
+    startedAt: z.string(),
+    questionsCount: z.number().int(),
+  }),
+  questions: z.array(SimuladoQuestionSchema),
+});
+export type SimuladoStartResponse = z.infer<typeof SimuladoStartResponseSchema>;
+
+export const SimuladoAnsweredQuestionSchema = SimuladoQuestionSchema.extend({
+  selectedOptionIndex: z.number().int().nullable(),
+  isCorrect: z.boolean().nullable(),
+  correctOptionIndex: z.number().int().nullable(),
+  explanation: z.string().nullable(),
+});
+export type SimuladoAnsweredQuestion = z.infer<typeof SimuladoAnsweredQuestionSchema>;
+
+export const SimuladoDetailResponseSchema = z.object({
+  simulado: z.object({
+    id: z.number().int(),
+    weekStart: z.string(),
+    startedAt: z.string(),
+    completedAt: z.string().nullable(),
+    questionsCount: z.number().int(),
+    answeredCount: z.number().int(),
+    correctCount: z.number().int(),
+    status: z.enum(["in_progress", "completed"]),
+  }),
+  questions: z.array(SimuladoAnsweredQuestionSchema),
+});
+export type SimuladoDetailResponse = z.infer<typeof SimuladoDetailResponseSchema>;
+
+export const SimuladoAnswerBodySchema = z.object({
+  questionId: z.number().int(),
+  selectedOptionIndex: z.number().int().min(0).max(3),
+});
+export type SimuladoAnswerBody = z.infer<typeof SimuladoAnswerBodySchema>;
+
+export const SimuladoAnswerResponseSchema = z.object({
+  isCorrect: z.boolean(),
+  correctOptionIndex: z.number().int(),
+  explanation: z.string().nullable(),
+  answeredCount: z.number().int(),
+  completed: z.boolean(),
+});
+export type SimuladoAnswerResponse = z.infer<typeof SimuladoAnswerResponseSchema>;
+
+export const SimuladoResultsResponseSchema = z.object({
+  weekStart: z.string(),
+  correct: z.number().int(),
+  total: z.number().int(),
+  perSubject: z.array(PerSubjectSchema),
+  history: z.array(HistoryEntrySchema),
+});
+export type SimuladoResultsResponse = z.infer<typeof SimuladoResultsResponseSchema>;

--- a/packages/shared/src/time.ts
+++ b/packages/shared/src/time.ts
@@ -1,0 +1,2 @@
+/** Brazil time offset: UTC-3, no DST (Brazil suspended DST in 2019). */
+export const BRT_OFFSET_MS = 3 * 60 * 60 * 1000;

--- a/packages/shared/src/weekly.ts
+++ b/packages/shared/src/weekly.ts
@@ -1,4 +1,4 @@
-const BRT_OFFSET_MS = 3 * 60 * 60 * 1000;
+import { BRT_OFFSET_MS } from "./time";
 
 export function startOfWeekBrt(now: Date): Date {
   const brtMs = now.getTime() - BRT_OFFSET_MS;


### PR DESCRIPTION
## Summary
- Weekly mock exam for Ultra users: 35 questions, BRT Sunday-Sunday window
- Per-subject results + up to 4 prior weeks history (current week never duplicated)
- INSERT...ON CONFLICT for idempotent `/start`, `SELECT ... FOR UPDATE` for race-safe `/answer`
- Auto-completion when the last unanswered question is answered; `forceComplete` (POST `/:id/complete`) as a manual finalizer
- 60s cache on `/current` with explicit invalidation on `/start`, `/answer`, `/complete`
- Ultra entitlement: strict on `/start`; deferred on `/current` so a user whose Ultra lapsed mid-simulado can still see their in-progress simulado; not checked at all on `/:id`, `/:id/answer`, `/:id/complete`, `/:id/results` (ownership-only) per spec A9
- Decoupled from `review_log`, XP, lives, streak

## Workflow gates
- ✅ Gate A — spec self-review (Opus 4.7): 6 blockers caught (entitlement method name, /start race, /answer race, BRT constant duplication, history shape, subtopicId nullable). Spec → v2.
- ✅ Gate B — plan self-review (Opus 4.7): 4 blockers caught (cleanupTestDb truncate list, raw-SQL FOR UPDATE, difficulty enum mismatch, /current Ultra-lapse UX). Spec → v3, plan → v2.
- ✅ Gate C — per-task review (Opus 4.7) after each of 7 implementer tasks. Caught: `isNotNull` vs raw `sql`, hardcoded `completed: false` in idempotent re-answer, missing `getOneForUser` tests.
- ✅ Gate D — final spec-coverage review (Opus 4.7) vs full diff. All 13 acceptance criteria covered; non-goals respected; deferred items not silently shipped. Two spec §9 test gaps closed in commit 78c5bcc (BRT Sunday boundary unit tests + DB cascade/UNIQUE integration tests).

## Test plan
- [x] Shared package: `bun test packages/shared/src/simulado.test.ts` — 7/7 pass
- [x] Server unit (service mocked): `bun test apps/server/src/features/simulados/simulados.service.test.ts` — 27/27 pass
- [ ] Server integration (real Postgres via Docker): `bun test apps/server/src/features/simulados/simulados.repository.integration.test.ts` — 22 tests; verify CI green
- [ ] Manual: GET `/simulados/current` returns `not_started` for fresh Ultra user; POST `/simulados/start` returns 35 questions; answering all 35 auto-completes; GET `/simulados/:id/results` returns per-subject breakdown
- [ ] Manual: Lapsed-Ultra user with in-progress simulado: GET `/simulados/current` returns 200; non-owner: GET `/simulados/:id` returns 404; non-Ultra fresh user: POST `/simulados/start` returns 403

## Spec & plan
- Spec v3: docs/superpowers/specs/2026-05-12-phase-2e3-simulado-semanal-design.md
- Plan v2: docs/superpowers/plans/2026-05-12-phase-2e3-simulado-semanal.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced weekly mock exam feature for Ultra users with Sunday-to-Sunday scheduling
  * Questions are deterministically selected and assigned per user per week
  * Added exam workflow endpoints: start, view current status, answer questions, force complete, and view results
  * Implemented caching for exam status with automatic invalidation on user actions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CeCamillo/pruvi/pull/24)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->