### PR TITLE
feat: phase 2e.4 — google play billing webhooks (ultra entitlement)

### DIFF
--- a/apps/server/src/features/billing/billing.repository.integration.test.ts
+++ b/apps/server/src/features/billing/billing.repository.integration.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { setupTestDb, cleanupTestDb, teardownTestDb, getTestDb } from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { BillingRepository } from "./billing.repository";
+
+describe("BillingRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new BillingRepository(db);
+
+  beforeAll(async () => setupTestDb());
+  beforeEach(async () => cleanupTestDb());
+  afterAll(async () => teardownTestDb());
+
+  async function insertUser(id: string) {
+    await db.insert(user).values({
+      id, name: `U ${id}`, email: `${id}@e.com`, emailVerified: false,
+      inviteCode: `c${id.replace(/-/g, "").slice(0, 8)}`, username: null, updatedAt: new Date(),
+    });
+  }
+
+  it("insertEvent dedup: same (provider, message_id) returns null on second insert", async () => {
+    const a = await repo.insertEvent(db, { provider: "google_play", messageId: "m1", eventType: "PURCHASED", purchaseToken: "t1", payload: { x: 1 } });
+    const b = await repo.insertEvent(db, { provider: "google_play", messageId: "m1", eventType: "PURCHASED", purchaseToken: "t1", payload: { x: 2 } });
+    expect(a).not.toBeNull();
+    expect(b).toBeNull();
+  });
+
+  it("createOrphanSubscription is idempotent on conflict", async () => {
+    const a = await repo.createOrphanSubscription(db, "google_play", "t-orph");
+    const b = await repo.createOrphanSubscription(db, "google_play", "t-orph");
+    expect(b.id).toBe(a.id);
+    expect(b.userId).toBeNull();
+  });
+
+  it("upsertLinkedSubscription creates with linked_at set; second call by same user returns existing", async () => {
+    await insertUser("u-link-1");
+    const r1 = await repo.upsertLinkedSubscription(db, { userId: "u-link-1", provider: "google_play", productId: "p1", token: "t-link-1" });
+    expect(r1.created).toBe(true);
+    expect(r1.subscription.linkedAt).toBeInstanceOf(Date);
+    const r2 = await repo.upsertLinkedSubscription(db, { userId: "u-link-1", provider: "google_play", productId: "p1", token: "t-link-1" });
+    expect(r2.created).toBe(false);
+    expect(r2.subscription.id).toBe(r1.subscription.id);
+  });
+
+  it("claimOrphanSubscription sets user_id, product_id, linked_at", async () => {
+    await insertUser("u-claim-1");
+    const orph = await repo.createOrphanSubscription(db, "google_play", "t-claim-1");
+    const claimed = await repo.claimOrphanSubscription(db, orph.id, "u-claim-1", "pruvi_ultra_monthly");
+    expect(claimed.userId).toBe("u-claim-1");
+    expect(claimed.productId).toBe("pruvi_ultra_monthly");
+    expect(claimed.linkedAt).toBeInstanceOf(Date);
+  });
+
+  it("claimOrphanSubscription rejects already-claimed", async () => {
+    await insertUser("u-claim-2a");
+    await insertUser("u-claim-2b");
+    const orph = await repo.createOrphanSubscription(db, "google_play", "t-claim-2");
+    await repo.claimOrphanSubscription(db, orph.id, "u-claim-2a", "p");
+    await expect(repo.claimOrphanSubscription(db, orph.id, "u-claim-2b", "p")).rejects.toThrow();
+  });
+
+  it("hasOtherActiveSubscription detects sibling active row", async () => {
+    await insertUser("u-multi-1");
+    const a = await repo.upsertLinkedSubscription(db, { userId: "u-multi-1", provider: "google_play", productId: "p", token: "t-A" });
+    await repo.updateSubscriptionState(db, a.subscription.id, { status: "active", currentPeriodEnd: new Date(Date.now() + 86400000) });
+    const b = await repo.upsertLinkedSubscription(db, { userId: "u-multi-1", provider: "google_play", productId: "p", token: "t-B" });
+    expect(await repo.hasOtherActiveSubscription(db, "u-multi-1", b.subscription.id)).toBe(true);
+  });
+
+  it("hasOtherActiveSubscription returns false when only this subscription is active", async () => {
+    await insertUser("u-multi-2");
+    const a = await repo.upsertLinkedSubscription(db, { userId: "u-multi-2", provider: "google_play", productId: "p", token: "t-only" });
+    await repo.updateSubscriptionState(db, a.subscription.id, { status: "active" });
+    expect(await repo.hasOtherActiveSubscription(db, "u-multi-2", a.subscription.id)).toBe(false);
+  });
+
+  it("listUnprocessedEventsForToken returns rows oldest-first, processed rows excluded", async () => {
+    await repo.insertEvent(db, { provider: "google_play", messageId: "m-a", eventType: "PURCHASED", purchaseToken: "t-X", payload: {} });
+    await new Promise((r) => setTimeout(r, 10));
+    const ev2 = await repo.insertEvent(db, { provider: "google_play", messageId: "m-b", eventType: "RENEWED", purchaseToken: "t-X", payload: {} });
+    await repo.markEventProcessed(db, ev2!.id);
+    const unprocessed = await repo.listUnprocessedEventsForToken(db, "google_play", "t-X");
+    expect(unprocessed).toHaveLength(1);
+    expect(unprocessed[0]!.messageId).toBe("m-a");
+  });
+});

--- a/apps/server/src/features/billing/billing.repository.integration.test.ts
+++ b/apps/server/src/features/billing/billing.repository.integration.test.ts
@@ -5,7 +5,7 @@ import { BillingRepository } from "./billing.repository";
 
 describe("BillingRepository (integration)", () => {
   const db = getTestDb();
-  const repo = new BillingRepository(db);
+  const repo = new BillingRepository();
 
   beforeAll(async () => setupTestDb());
   beforeEach(async () => cleanupTestDb());

--- a/apps/server/src/features/billing/billing.repository.integration.test.ts
+++ b/apps/server/src/features/billing/billing.repository.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { setupTestDb, cleanupTestDb, teardownTestDb, getTestDb } from "../../test/db-helpers";
 import { user } from "@pruvi/db/schema/auth";
+import { eq } from "drizzle-orm";
 import { BillingRepository } from "./billing.repository";
 
 describe("BillingRepository (integration)", () => {
@@ -82,5 +83,40 @@ describe("BillingRepository (integration)", () => {
     const unprocessed = await repo.listUnprocessedEventsForToken(db, "google_play", "t-X");
     expect(unprocessed).toHaveLength(1);
     expect(unprocessed[0]!.messageId).toBe("m-a");
+  });
+
+  it("getMaxOtherActivePeriodEnd returns the LATER end across other active subs", async () => {
+    await insertUser("u-max-1");
+    const future30 = new Date(Date.now() + 30 * 86400000);
+    const future365 = new Date(Date.now() + 365 * 86400000);
+    // Create subscription A with 30-day end
+    const a = await repo.upsertLinkedSubscription(db, { userId: "u-max-1", provider: "google_play", productId: "p", token: "t-A" });
+    await repo.updateSubscriptionState(db, a.subscription.id, { status: "active", currentPeriodEnd: future30 });
+    // Create subscription B with 365-day end
+    const b = await repo.upsertLinkedSubscription(db, { userId: "u-max-1", provider: "google_play", productId: "p", token: "t-B" });
+    await repo.updateSubscriptionState(db, b.subscription.id, { status: "active", currentPeriodEnd: future365 });
+    // When excluding A, the max-other should be B's (365 days)
+    const maxOther = await repo.getMaxOtherActivePeriodEnd(db, "u-max-1", a.subscription.id);
+    expect(maxOther).not.toBeNull();
+    expect(Math.abs(maxOther!.getTime() - future365.getTime())).toBeLessThan(1000);
+  });
+
+  it("getMaxOtherActivePeriodEnd returns null when only this sub is active", async () => {
+    await insertUser("u-max-2");
+    const a = await repo.upsertLinkedSubscription(db, { userId: "u-max-2", provider: "google_play", productId: "p", token: "t-solo" });
+    await repo.updateSubscriptionState(db, a.subscription.id, { status: "active", currentPeriodEnd: new Date(Date.now() + 86400000) });
+    expect(await repo.getMaxOtherActivePeriodEnd(db, "u-max-2", a.subscription.id)).toBeNull();
+  });
+
+  it("ON DELETE SET NULL: deleting a user with linked subscriptions sets user_id to NULL", async () => {
+    await insertUser("u-cascade-1");
+    const a = await repo.upsertLinkedSubscription(db, { userId: "u-cascade-1", provider: "google_play", productId: "p", token: "t-casc" });
+    expect(a.subscription.userId).toBe("u-cascade-1");
+    // Delete the user
+    await db.delete(user).where(eq(user.id, "u-cascade-1"));
+    // Subscription row must still exist with userId = NULL
+    const after = await repo.findSubscriptionByToken(db, "google_play", "t-casc");
+    expect(after).not.toBeNull();
+    expect(after!.userId).toBeNull();
   });
 });

--- a/apps/server/src/features/billing/billing.repository.ts
+++ b/apps/server/src/features/billing/billing.repository.ts
@@ -31,7 +31,7 @@ export type BillingEventRow = {
 };
 
 export class BillingRepository {
-  constructor(private db: Db) {}
+  constructor() {}
 
   /** Insert audit row with ON CONFLICT DO NOTHING. Returns the row if newly inserted, null on dup. */
   async insertEvent(

--- a/apps/server/src/features/billing/billing.repository.ts
+++ b/apps/server/src/features/billing/billing.repository.ts
@@ -1,0 +1,241 @@
+import { and, asc, eq, isNull, ne, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { subscription, billingEvent } from "@pruvi/db/schema/billing";
+import type { BillingProvider, SubscriptionStatus } from "@pruvi/shared";
+
+type Db = typeof DbClient;
+export type Tx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+export type DbOrTx = Db | Tx;
+
+export type SubscriptionRow = {
+  id: number;
+  userId: string | null;
+  provider: BillingProvider;
+  productId: string;
+  purchaseToken: string;
+  status: SubscriptionStatus;
+  currentPeriodEnd: Date | null;
+  linkedAt: Date | null;
+};
+
+export type BillingEventRow = {
+  id: number;
+  provider: BillingProvider;
+  messageId: string;
+  eventType: string;
+  purchaseToken: string | null;
+  payload: Record<string, unknown>;
+  receivedAt: Date;
+  processedAt: Date | null;
+  processingError: string | null;
+};
+
+export class BillingRepository {
+  constructor(private db: Db) {}
+
+  /** Insert audit row with ON CONFLICT DO NOTHING. Returns the row if newly inserted, null on dup. */
+  async insertEvent(
+    tx: DbOrTx,
+    args: { provider: BillingProvider; messageId: string; eventType: string; purchaseToken: string | null; payload: Record<string, unknown> },
+  ): Promise<BillingEventRow | null> {
+    const inserted = await tx
+      .insert(billingEvent)
+      .values({
+        provider: args.provider,
+        messageId: args.messageId,
+        eventType: args.eventType,
+        purchaseToken: args.purchaseToken,
+        payload: args.payload,
+      })
+      .onConflictDoNothing({ target: [billingEvent.provider, billingEvent.messageId] })
+      .returning();
+    const row = inserted[0];
+    return row ? this.toEvent(row) : null;
+  }
+
+  async findSubscriptionByToken(
+    tx: DbOrTx,
+    provider: BillingProvider,
+    token: string,
+  ): Promise<SubscriptionRow | null> {
+    const rows = await tx
+      .select()
+      .from(subscription)
+      .where(and(eq(subscription.provider, provider), eq(subscription.purchaseToken, token)))
+      .limit(1);
+    const r = rows[0];
+    return r ? this.toSubscription(r) : null;
+  }
+
+  /** Create a webhook-orphaned subscription row (user_id null, product_id empty placeholder). */
+  async createOrphanSubscription(
+    tx: DbOrTx,
+    provider: BillingProvider,
+    token: string,
+  ): Promise<SubscriptionRow> {
+    const inserted = await tx
+      .insert(subscription)
+      .values({ provider, purchaseToken: token, productId: "", status: "pending", userId: null })
+      .onConflictDoNothing({ target: [subscription.provider, subscription.purchaseToken] })
+      .returning();
+    if (inserted[0]) return this.toSubscription(inserted[0]);
+    const existing = await this.findSubscriptionByToken(tx, provider, token);
+    if (!existing) throw new Error("createOrphanSubscription: conflict but no existing row");
+    return existing;
+  }
+
+  async upsertLinkedSubscription(
+    tx: DbOrTx,
+    args: { userId: string; provider: BillingProvider; productId: string; token: string },
+  ): Promise<{ subscription: SubscriptionRow; created: boolean }> {
+    const now = new Date();
+    const inserted = await tx
+      .insert(subscription)
+      .values({
+        provider: args.provider,
+        purchaseToken: args.token,
+        productId: args.productId,
+        status: "pending",
+        userId: args.userId,
+        linkedAt: now,
+      })
+      .onConflictDoNothing({ target: [subscription.provider, subscription.purchaseToken] })
+      .returning();
+    if (inserted[0]) return { subscription: this.toSubscription(inserted[0]), created: true };
+
+    const existing = await this.findSubscriptionByToken(tx, args.provider, args.token);
+    if (!existing) throw new Error("upsertLinkedSubscription: conflict but no existing row");
+    return { subscription: existing, created: false };
+  }
+
+  async claimOrphanSubscription(
+    tx: DbOrTx,
+    subscriptionId: number,
+    userId: string,
+    productId: string,
+  ): Promise<SubscriptionRow> {
+    const now = new Date();
+    const updated = await tx
+      .update(subscription)
+      .set({ userId, productId, linkedAt: now, updatedAt: now })
+      .where(and(eq(subscription.id, subscriptionId), isNull(subscription.userId)))
+      .returning();
+    const row = updated[0];
+    if (!row) throw new Error("claimOrphanSubscription: row not found or already claimed");
+    return this.toSubscription(row);
+  }
+
+  async updateSubscriptionState(
+    tx: DbOrTx,
+    subscriptionId: number,
+    args: { status: SubscriptionStatus; currentPeriodEnd?: Date | null },
+  ): Promise<SubscriptionRow> {
+    const now = new Date();
+    const updates: Record<string, unknown> = { status: args.status, updatedAt: now };
+    if (args.currentPeriodEnd !== undefined) updates.currentPeriodEnd = args.currentPeriodEnd;
+    const rows = await tx
+      .update(subscription)
+      .set(updates)
+      .where(eq(subscription.id, subscriptionId))
+      .returning();
+    const r = rows[0];
+    if (!r) throw new Error("updateSubscriptionState: not found");
+    return this.toSubscription(r);
+  }
+
+  async markEventProcessed(
+    tx: DbOrTx,
+    eventId: number,
+    processingError?: string | null,
+  ): Promise<void> {
+    await tx
+      .update(billingEvent)
+      .set({ processedAt: new Date(), processingError: processingError ?? null })
+      .where(eq(billingEvent.id, eventId));
+  }
+
+  async listUnprocessedEventsForToken(
+    tx: DbOrTx,
+    provider: BillingProvider,
+    token: string,
+  ): Promise<BillingEventRow[]> {
+    const rows = await tx
+      .select()
+      .from(billingEvent)
+      .where(and(eq(billingEvent.provider, provider), eq(billingEvent.purchaseToken, token), isNull(billingEvent.processedAt)))
+      .orderBy(asc(billingEvent.receivedAt));
+    return rows.map((r) => this.toEvent(r));
+  }
+
+  /** True if the user has any OTHER subscription row (excluding this one) in active or in_grace status. */
+  async hasOtherActiveSubscription(
+    tx: DbOrTx,
+    userId: string,
+    excludeSubscriptionId: number,
+  ): Promise<boolean> {
+    const rows = await tx
+      .select({ id: subscription.id })
+      .from(subscription)
+      .where(
+        and(
+          eq(subscription.userId, userId),
+          ne(subscription.id, excludeSubscriptionId),
+          sql`${subscription.status} IN ('active','in_grace')`,
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  /** Returns the maximum `current_period_end` across all OTHER active/in_grace subscriptions for this user.
+   *  Used by the multi-subscription GRANT guard (spec §7.2): when granting Ultra, we must use
+   *  MAX(allActive.currentPeriodEnd) so a short renewal doesn't truncate a longer active plan. */
+  async getMaxOtherActivePeriodEnd(
+    tx: DbOrTx,
+    userId: string,
+    excludeSubscriptionId: number,
+  ): Promise<Date | null> {
+    const rows = await tx
+      .select({ end: subscription.currentPeriodEnd })
+      .from(subscription)
+      .where(
+        and(
+          eq(subscription.userId, userId),
+          ne(subscription.id, excludeSubscriptionId),
+          sql`${subscription.status} IN ('active','in_grace')`,
+        ),
+      );
+    let max: Date | null = null;
+    for (const r of rows) {
+      if (r.end && (!max || r.end > max)) max = r.end;
+    }
+    return max;
+  }
+
+  private toSubscription(r: typeof subscription.$inferSelect): SubscriptionRow {
+    return {
+      id: r.id,
+      userId: r.userId,
+      provider: r.provider as BillingProvider,
+      productId: r.productId,
+      purchaseToken: r.purchaseToken,
+      status: r.status as SubscriptionStatus,
+      currentPeriodEnd: r.currentPeriodEnd,
+      linkedAt: r.linkedAt,
+    };
+  }
+
+  private toEvent(r: typeof billingEvent.$inferSelect): BillingEventRow {
+    return {
+      id: r.id,
+      provider: r.provider as BillingProvider,
+      messageId: r.messageId,
+      eventType: r.eventType,
+      purchaseToken: r.purchaseToken,
+      payload: r.payload as Record<string, unknown>,
+      receivedAt: r.receivedAt,
+      processedAt: r.processedAt,
+      processingError: r.processingError,
+    };
+  }
+}

--- a/apps/server/src/features/billing/billing.route.ts
+++ b/apps/server/src/features/billing/billing.route.ts
@@ -12,7 +12,7 @@ import { BillingService } from "./billing.service";
 import { UltraRepository } from "../ultra/ultra.repository";
 import { UltraService } from "../ultra/ultra.service";
 
-const repo = new BillingRepository(db);
+const repo = new BillingRepository();
 const ultra = new UltraService(new UltraRepository(db));
 const service = new BillingService(db, repo, ultra);
 

--- a/apps/server/src/features/billing/billing.route.ts
+++ b/apps/server/src/features/billing/billing.route.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import { timingSafeEqual } from "node:crypto";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import type { FastifyRequest, FastifyReply } from "fastify";
+import { GooglePlayLinkBodySchema, GooglePlayLinkResponseSchema } from "@pruvi/shared";
+import { env } from "@pruvi/env/server";
+import { db } from "@pruvi/db";
+import { successResponse, unwrapResult } from "../../types";
+import { AppError, UnauthorizedError } from "../../utils/errors";
+import { BillingRepository } from "./billing.repository";
+import { BillingService } from "./billing.service";
+import { UltraRepository } from "../ultra/ultra.repository";
+import { UltraService } from "../ultra/ultra.service";
+
+const repo = new BillingRepository(db);
+const ultra = new UltraService(new UltraRepository(db));
+const service = new BillingService(db, repo, ultra);
+
+// IMPORTANT: throw AppError subclasses so the project's error handler maps statusCode correctly.
+// Plain `throw new Error(...)` would fall through to the 500 branch regardless of reply.code().
+async function webhookGuard(request: FastifyRequest, _reply: FastifyReply) {
+  if (!env.GOOGLE_PLAY_WEBHOOK_TOKEN) {
+    throw new AppError("WEBHOOK_DISABLED", 503, "WEBHOOK_DISABLED");
+  }
+  const provided = request.headers["x-pruvi-webhook-token"];
+  if (typeof provided !== "string") {
+    throw new UnauthorizedError("UNAUTHORIZED");
+  }
+  const a = Buffer.from(provided);
+  const b = Buffer.from(env.GOOGLE_PLAY_WEBHOOK_TOKEN);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    throw new UnauthorizedError("UNAUTHORIZED");
+  }
+}
+
+export const billingRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.post(
+    "/webhooks/google-play",
+    {
+      schema: {
+        body: z.unknown(),
+        response: {
+          200: z.object({
+            success: z.literal(true),
+            data: z.object({ received: z.boolean(), messageId: z.string().optional(), kind: z.string().optional(), error: z.string().optional() }),
+          }),
+        },
+      },
+      preHandler: [webhookGuard],
+    },
+    async (request) => {
+      const result = await service.processWebhookEnvelope(request.body);
+      if (result.isErr()) {
+        const error = result.error;
+        // For MALFORMED_ENVELOPE we still return 200 so Pub/Sub stops retrying.
+        if (error.code === "MALFORMED_ENVELOPE") {
+          fastify.log.warn({ err: error.message }, "google-play webhook malformed envelope");
+          return successResponse({ received: false, error: "MALFORMED_ENVELOPE" });
+        }
+        fastify.log.error({ err: error.message }, "google-play webhook processing failed");
+        return successResponse({ received: false, error: "PROCESSING_FAILED" });
+      }
+      return successResponse({ received: true, messageId: result.value.messageId, kind: result.value.kind });
+    },
+  );
+
+  fastify.post(
+    "/billing/google-play/link",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        body: GooglePlayLinkBodySchema,
+        response: { 200: z.object({ success: z.literal(true), data: GooglePlayLinkResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const data = unwrapResult(await service.linkGooglePlayPurchase(request.userId, request.body)).data;
+      return successResponse(data);
+    },
+  );
+};

--- a/apps/server/src/features/billing/billing.service.test.ts
+++ b/apps/server/src/features/billing/billing.service.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BillingService } from "./billing.service";
+import type { BillingRepository, SubscriptionRow, BillingEventRow } from "./billing.repository";
+import type { UltraService } from "../ultra/ultra.service";
+import type { db as DbClient } from "@pruvi/db";
+
+type Mocked<T> = { [K in keyof T]: T[K] extends (...a: infer A) => infer R ? ReturnType<typeof vi.fn<(...a: A) => R>> : T[K] };
+
+function buildSut(opts: {
+  insertEvent?: BillingEventRow | null;
+  findSubscription?: SubscriptionRow | null;
+  createOrphan?: SubscriptionRow;
+  updateState?: SubscriptionRow;
+  listUnprocessed?: BillingEventRow[];
+  hasOtherActive?: boolean;
+  maxOtherEnd?: Date | null;
+  upsertLinked?: { subscription: SubscriptionRow; created: boolean };
+  claimOrphan?: SubscriptionRow;
+} = {}) {
+  const repo = {
+    insertEvent: vi.fn().mockResolvedValue(opts.insertEvent ?? { id: 1, provider: "google_play", messageId: "m1", eventType: "PURCHASED", purchaseToken: "tok", payload: {}, receivedAt: new Date(), processedAt: null, processingError: null }),
+    findSubscriptionByToken: vi.fn().mockResolvedValue(opts.findSubscription ?? null),
+    createOrphanSubscription: vi.fn().mockResolvedValue(opts.createOrphan ?? { id: 10, userId: null, provider: "google_play", productId: "", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: null }),
+    upsertLinkedSubscription: vi.fn().mockResolvedValue(opts.upsertLinked ?? { subscription: { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() }, created: true }),
+    claimOrphanSubscription: vi.fn().mockResolvedValue(opts.claimOrphan ?? { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() }),
+    updateSubscriptionState: vi.fn().mockResolvedValue(opts.updateState ?? { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(Date.now() + 30 * 86400000), linkedAt: new Date() }),
+    markEventProcessed: vi.fn().mockResolvedValue(undefined),
+    listUnprocessedEventsForToken: vi.fn().mockResolvedValue(opts.listUnprocessed ?? []),
+    hasOtherActiveSubscription: vi.fn().mockResolvedValue(opts.hasOtherActive ?? false),
+    getMaxOtherActivePeriodEnd: vi.fn().mockResolvedValue(opts.maxOtherEnd ?? null),
+  } as unknown as Mocked<BillingRepository>;
+  const ultra = {
+    grant: vi.fn().mockResolvedValue(undefined),
+    revoke: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Mocked<UltraService>;
+  const db = {
+    transaction: vi.fn(async (cb: (tx: any) => Promise<any>) => cb(repo)),
+  } as unknown as typeof DbClient;
+  const service = new BillingService(db, repo as unknown as BillingRepository, ultra as unknown as UltraService);
+  return { service, repo, ultra, db };
+}
+
+function buildEnvelope(notificationType: number, purchaseToken = "tok", messageId = "msg-1") {
+  const inner = { packageName: "com.pruvi.app", subscriptionNotification: { notificationType, purchaseToken, version: "1.0" } };
+  return { message: { messageId, publishTime: "2026-05-12T10:00:00Z", data: Buffer.from(JSON.stringify(inner)).toString("base64") } };
+}
+
+describe("BillingService", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Case 1
+  it("PURCHASED on linked subscription: active + grant called with ~now+30d", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    const r = await service.processWebhookEnvelope(buildEnvelope(4));
+    expect(r.isOk()).toBe(true);
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "active" }));
+    expect(ultra.grant).toHaveBeenCalledTimes(1);
+    const grantedExpiry = ultra.grant.mock.calls[0]![1] as Date;
+    const expected = Date.now() + 30 * 86400000;
+    expect(Math.abs(grantedExpiry.getTime() - expected)).toBeLessThan(60_000);
+  });
+
+  // Case 2
+  it("PURCHASED with NO existing subscription: orphan created, NO grant", async () => {
+    const { service, ultra, repo } = buildSut({ findSubscription: null });
+    await service.processWebhookEnvelope(buildEnvelope(4));
+    expect(repo.createOrphanSubscription).toHaveBeenCalled();
+    expect(ultra.grant).not.toHaveBeenCalled();
+  });
+
+  // Case 3
+  it("EXPIRED with no other active subs: revoke called", async () => {
+    const active: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra } = buildSut({ findSubscription: active, hasOtherActive: false });
+    await service.processWebhookEnvelope(buildEnvelope(13));
+    expect(ultra.revoke).toHaveBeenCalledWith("u1");
+  });
+
+  // Case 4 — MULTI-SUB REVOKE GUARD (critical)
+  it("EXPIRED with another active subscription: revoke NOT called (multi-sub guard)", async () => {
+    const active: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: active, hasOtherActive: true });
+    await service.processWebhookEnvelope(buildEnvelope(13));
+    expect(repo.hasOtherActiveSubscription).toHaveBeenCalledWith(expect.anything(), "u1", 10);
+    expect(ultra.revoke).not.toHaveBeenCalled();
+  });
+
+  // Bonus: MULTI-SUB GRANT GUARD (also critical)
+  it("PURCHASED with another active sub having LATER period end: grant uses MAX expiry, not now+30d", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() };
+    const farFuture = new Date(Date.now() + 365 * 86400000); // 1 year out
+    const { service, ultra } = buildSut({ findSubscription: linked, maxOtherEnd: farFuture });
+    await service.processWebhookEnvelope(buildEnvelope(4));
+    expect(ultra.grant).toHaveBeenCalledWith("u1", farFuture);
+  });
+
+  // Case 5
+  it("CANCELED: state=canceled, no Ultra change", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    await service.processWebhookEnvelope(buildEnvelope(3));
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "canceled" }));
+    expect(ultra.grant).not.toHaveBeenCalled();
+    expect(ultra.revoke).not.toHaveBeenCalled();
+  });
+
+  // Case 6
+  it("Duplicate messageId: second call no-op (insertEvent returns null)", async () => {
+    const { service, ultra } = buildSut({ insertEvent: null });
+    await service.processWebhookEnvelope(buildEnvelope(4));
+    expect(ultra.grant).not.toHaveBeenCalled();
+  });
+
+  // Case 7
+  it("Unknown notificationType: UNKNOWN_99 event recorded, no state mutation", async () => {
+    const { service, ultra, repo } = buildSut();
+    await service.processWebhookEnvelope(buildEnvelope(99));
+    expect(repo.insertEvent).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: "UNKNOWN_99" }));
+    expect(repo.updateSubscriptionState).not.toHaveBeenCalled();
+    expect(ultra.grant).not.toHaveBeenCalled();
+  });
+
+  // Case 8
+  it("link: same user re-call returns existing subscription, no error", async () => {
+    const existing: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service } = buildSut({ findSubscription: existing });
+    const r = await service.linkGooglePlayPurchase("u1", { purchaseToken: "tok", productId: "p" });
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value.subscription.id).toBe(10);
+  });
+
+  // Case 9
+  it("link: token owned by other user throws ConflictError", async () => {
+    const owned: SubscriptionRow = { id: 10, userId: "OTHER", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service } = buildSut({ findSubscription: owned });
+    await expect(service.linkGooglePlayPurchase("u1", { purchaseToken: "tok", productId: "p" })).rejects.toThrow(/PURCHASE_TOKEN_OWNED/);
+  });
+
+  // Case 10 — LINK-TIME REPLAY (critical)
+  it("link after pre-link webhook: claims orphan, replays parked PURCHASED, ultra.grant called", async () => {
+    const orphan: SubscriptionRow = { id: 10, userId: null, provider: "google_play", productId: "", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: null };
+    const claimed: SubscriptionRow = { ...orphan, userId: "u1", productId: "p", linkedAt: new Date() };
+    const parkedEvent: BillingEventRow = {
+      id: 5,
+      provider: "google_play",
+      messageId: "m-parked",
+      eventType: "PURCHASED",
+      purchaseToken: "tok",
+      payload: { kind: "subscription", messageId: "m-parked", notificationType: 4, notificationTypeName: "PURCHASED", purchaseToken: "tok", publishTime: "", packageName: "", eventTimeMillis: "" } as unknown as Record<string, unknown>,
+      receivedAt: new Date(Date.now() - 60_000),
+      processedAt: null,
+      processingError: null,
+    };
+    const afterUpdate: SubscriptionRow = { ...claimed, status: "active", currentPeriodEnd: new Date(Date.now() + 30 * 86400000) };
+
+    const { service, repo, ultra } = buildSut({ findSubscription: orphan, claimOrphan: claimed, listUnprocessed: [parkedEvent], updateState: afterUpdate });
+    // After claim, findSubscriptionByToken inside the replay loop should return the claimed row.
+    (repo.findSubscriptionByToken as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(orphan)     // first call: pre-claim
+      .mockResolvedValueOnce(claimed)    // inside replay loop: post-claim, before applyDecoded
+      .mockResolvedValueOnce(afterUpdate); // final read at end of transaction
+
+    const r = await service.linkGooglePlayPurchase("u1", { purchaseToken: "tok", productId: "p" });
+    expect(r.isOk()).toBe(true);
+    expect(repo.claimOrphanSubscription).toHaveBeenCalledWith(expect.anything(), 10, "u1", "p");
+    expect(repo.markEventProcessed).toHaveBeenCalledWith(expect.anything(), 5);
+    expect(ultra.grant).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/server/src/features/billing/billing.service.ts
+++ b/apps/server/src/features/billing/billing.service.ts
@@ -1,0 +1,220 @@
+import { ok, err, type Result } from "neverthrow";
+import { AppError, ConflictError } from "../../utils/errors";
+import { DEFAULT_SUBSCRIPTION_PERIOD_MS, type GooglePlayLinkResponse, type SubscriptionStatus } from "@pruvi/shared";
+import type { BillingRepository, DbOrTx, SubscriptionRow } from "./billing.repository";
+import type { UltraService } from "../ultra/ultra.service";
+import type { DecodedGooglePlayEvent } from "./google-play.decoder";
+import { decodeGooglePlayPubSubEnvelope } from "./google-play.decoder";
+import type { db as DbClient } from "@pruvi/db";
+
+type Db = typeof DbClient;
+
+/** Effect to apply AFTER the transaction commits (two-phase pattern per spec §7.6).
+ *  Both `grant` and `revoke` variants carry `excludeSubscriptionId` so the post-commit
+ *  step can consult OTHER active subscriptions (the multi-sub guards from §7.2):
+ *   - grant: final expiry = MAX(effect.expiresAt, otherActive.currentPeriodEnd) — never truncates a longer plan.
+ *   - revoke: revoke only if no other active subscription exists. */
+type PostCommitUltraEffect =
+  | { kind: "grant"; userId: string; expiresAt: Date; excludeSubscriptionId: number }
+  | { kind: "revoke_if_no_other_active"; userId: string; excludeSubscriptionId: number }
+  | { kind: "none" };
+
+export class BillingService {
+  constructor(
+    private db: Db,
+    private repo: BillingRepository,
+    private ultra: UltraService,
+  ) {}
+
+  /** Webhook entry point. Returns the response payload; always 200 on accepted shapes.
+   *  Auth + envelope-shape validation happens in the route. */
+  async processWebhookEnvelope(envelope: unknown): Promise<Result<{ messageId: string; kind: string }, AppError>> {
+    let decoded: DecodedGooglePlayEvent;
+    try {
+      decoded = decodeGooglePlayPubSubEnvelope(envelope);
+    } catch (e) {
+      return err(new AppError(`MALFORMED_ENVELOPE: ${(e as Error).message}`, 200, "MALFORMED_ENVELOPE"));
+    }
+
+    if (decoded.kind === "test") {
+      // Record audit row with no purchase token; idempotent on messageId.
+      await this.repo.insertEvent(this.db, {
+        provider: "google_play",
+        messageId: decoded.messageId,
+        eventType: "TEST",
+        purchaseToken: null,
+        payload: { kind: "test" },
+      });
+      return ok({ messageId: decoded.messageId, kind: "test" });
+    }
+
+    const effect = await this.db.transaction(async (tx) => {
+      const eventType =
+        decoded.kind === "subscription" ? decoded.notificationTypeName : `UNKNOWN_${decoded.notificationType}`;
+      const inserted = await this.repo.insertEvent(tx, {
+        provider: "google_play",
+        messageId: decoded.messageId,
+        eventType,
+        purchaseToken: decoded.purchaseToken,
+        payload: decoded as unknown as Record<string, unknown>,
+      });
+      if (!inserted) {
+        // Duplicate delivery — already processed (or processed previously). No-op.
+        return { kind: "none" } as PostCommitUltraEffect;
+      }
+
+      if (decoded.kind === "unknown") {
+        await this.repo.markEventProcessed(tx, inserted.id);
+        return { kind: "none" };
+      }
+
+      // Find or create subscription row.
+      let sub = await this.repo.findSubscriptionByToken(tx, "google_play", decoded.purchaseToken);
+      if (!sub) {
+        sub = await this.repo.createOrphanSubscription(tx, "google_play", decoded.purchaseToken);
+      }
+
+      const { newStatus, newPeriodEnd, ultraEffect } = this.applyDecodedEvent(decoded, sub);
+      await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
+
+      // If subscription has no user yet, leave processed_at = NULL so link can replay.
+      if (sub.userId === null) {
+        return { kind: "none" };
+      }
+
+      await this.repo.markEventProcessed(tx, inserted.id);
+      return ultraEffect;
+    });
+
+    await this.applyUltraEffect(effect);
+    return ok({ messageId: decoded.messageId, kind: decoded.kind });
+  }
+
+  /** Link entry point: associates a purchase token with the authenticated user and replays parked events. */
+  async linkGooglePlayPurchase(
+    userId: string,
+    body: { purchaseToken: string; productId: string },
+  ): Promise<Result<GooglePlayLinkResponse, AppError>> {
+    const effects: PostCommitUltraEffect[] = [];
+    const finalRow = await this.db.transaction(async (tx) => {
+      const existing = await this.repo.findSubscriptionByToken(tx, "google_play", body.purchaseToken);
+      let sub: SubscriptionRow;
+      if (!existing) {
+        const created = await this.repo.upsertLinkedSubscription(tx, {
+          userId, provider: "google_play", productId: body.productId, token: body.purchaseToken,
+        });
+        sub = created.subscription;
+      } else if (existing.userId !== null && existing.userId !== userId) {
+        throw new ConflictError("PURCHASE_TOKEN_OWNED_BY_OTHER_USER");
+      } else if (existing.userId === userId) {
+        sub = existing;
+      } else {
+        // Orphan claim
+        sub = await this.repo.claimOrphanSubscription(tx, existing.id, userId, body.productId);
+      }
+
+      // Replay parked events for this token (only if we just claimed an orphan or first-link).
+      const parked = await this.repo.listUnprocessedEventsForToken(tx, "google_play", body.purchaseToken);
+      for (const event of parked) {
+        // Reconstruct the decoded event from the audit payload.
+        const decoded = event.payload as unknown as DecodedGooglePlayEvent;
+        if (decoded.kind !== "subscription") {
+          await this.repo.markEventProcessed(tx, event.id);
+          continue;
+        }
+        const fresh = await this.repo.findSubscriptionByToken(tx, "google_play", body.purchaseToken);
+        if (!fresh) throw new Error("replay: subscription disappeared mid-transaction");
+        sub = fresh;
+        const { newStatus, newPeriodEnd, ultraEffect } = this.applyDecodedEvent(decoded, sub);
+        await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
+        await this.repo.markEventProcessed(tx, event.id);
+        effects.push(ultraEffect);
+      }
+      const final = await this.repo.findSubscriptionByToken(tx, "google_play", body.purchaseToken);
+      if (!final) throw new Error("link: subscription disappeared mid-transaction");
+      return final;
+    }).catch((e) => {
+      if (e instanceof ConflictError) throw e;
+      throw e;
+    });
+
+    for (const e of effects) await this.applyUltraEffect(e);
+
+    return ok({
+      subscription: {
+        id: finalRow.id,
+        status: finalRow.status,
+        productId: finalRow.productId,
+        currentPeriodEnd: finalRow.currentPeriodEnd?.toISOString() ?? null,
+      },
+    });
+  }
+
+  /** Pure state-machine: maps (event, current subscription) → next state + ultra effect. NO DB writes. */
+  applyDecodedEvent(
+    decoded: DecodedGooglePlayEvent,
+    sub: SubscriptionRow,
+  ): { newStatus: SubscriptionStatus; newPeriodEnd: Date | null; ultraEffect: PostCommitUltraEffect } {
+    if (decoded.kind !== "subscription") {
+      return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+    }
+    const now = new Date();
+    const defaultEnd = new Date(now.getTime() + DEFAULT_SUBSCRIPTION_PERIOD_MS);
+    const name = decoded.notificationTypeName;
+    const grant = (end: Date): PostCommitUltraEffect =>
+      sub.userId !== null
+        ? { kind: "grant", userId: sub.userId, expiresAt: end, excludeSubscriptionId: sub.id }
+        : { kind: "none" };
+    const revoke = (): PostCommitUltraEffect =>
+      sub.userId !== null
+        ? { kind: "revoke_if_no_other_active", userId: sub.userId, excludeSubscriptionId: sub.id }
+        : { kind: "none" };
+
+    switch (name) {
+      case "PURCHASED":
+      case "RENEWED":
+      case "RECOVERED":
+      case "RESTARTED":
+        return { newStatus: "active", newPeriodEnd: defaultEnd, ultraEffect: grant(defaultEnd) };
+      case "IN_GRACE_PERIOD":
+        return { newStatus: "in_grace", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+      case "CANCELED":
+        return { newStatus: "canceled", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+      case "ON_HOLD":
+        return { newStatus: "on_hold", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "PAUSED":
+        return { newStatus: "paused", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "EXPIRED":
+        return { newStatus: "expired", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "REVOKED":
+        return { newStatus: "revoked", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "PRICE_CHANGE_CONFIRMED":
+      case "DEFERRED":
+      case "PAUSE_SCHEDULE_CHANGED":
+      case "ITEMS_CHANGED":
+      case "CANCELLATION_SCHEDULED":
+      case "PRICE_CHANGE_UPDATED":
+      case "PENDING_PURCHASE_CANCELED":
+      case "PRICE_STEP_UP_CONSENT_UPDATED":
+        return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+    }
+  }
+
+  private async applyUltraEffect(effect: PostCommitUltraEffect): Promise<void> {
+    if (effect.kind === "grant") {
+      // Multi-sub GRANT guard (spec §7.2): the final expiry must be the MAX across this
+      // subscription's expiry and the currentPeriodEnd of any other active/in_grace subscriptions
+      // for the same user. A renewal of a short plan must NEVER truncate a long active plan.
+      const otherMax = await this.repo.getMaxOtherActivePeriodEnd(
+        this.db, effect.userId, effect.excludeSubscriptionId,
+      );
+      const finalEnd = otherMax && otherMax > effect.expiresAt ? otherMax : effect.expiresAt;
+      await this.ultra.grant(effect.userId, finalEnd);
+    } else if (effect.kind === "revoke_if_no_other_active") {
+      const hasOther = await this.repo.hasOtherActiveSubscription(
+        this.db, effect.userId, effect.excludeSubscriptionId,
+      );
+      if (!hasOther) await this.ultra.revoke(effect.userId);
+    }
+  }
+}

--- a/apps/server/src/features/billing/billing.service.ts
+++ b/apps/server/src/features/billing/billing.service.ts
@@ -1,7 +1,7 @@
 import { ok, err, type Result } from "neverthrow";
 import { AppError, ConflictError } from "../../utils/errors";
 import { DEFAULT_SUBSCRIPTION_PERIOD_MS, type GooglePlayLinkResponse, type SubscriptionStatus } from "@pruvi/shared";
-import type { BillingRepository, DbOrTx, SubscriptionRow } from "./billing.repository";
+import type { BillingRepository, SubscriptionRow } from "./billing.repository";
 import type { UltraService } from "../ultra/ultra.service";
 import type { DecodedGooglePlayEvent } from "./google-play.decoder";
 import { decodeGooglePlayPubSubEnvelope } from "./google-play.decoder";
@@ -65,7 +65,7 @@ export class BillingService {
 
       if (decoded.kind === "unknown") {
         await this.repo.markEventProcessed(tx, inserted.id);
-        return { kind: "none" };
+        return { kind: "none" } as PostCommitUltraEffect;
       }
 
       // Find or create subscription row.
@@ -79,7 +79,7 @@ export class BillingService {
 
       // If subscription has no user yet, leave processed_at = NULL so link can replay.
       if (sub.userId === null) {
-        return { kind: "none" };
+        return { kind: "none" } as PostCommitUltraEffect;
       }
 
       await this.repo.markEventProcessed(tx, inserted.id);

--- a/apps/server/src/features/billing/google-play.decoder.test.ts
+++ b/apps/server/src/features/billing/google-play.decoder.test.ts
@@ -89,4 +89,9 @@ describe("decodeGooglePlayPubSubEnvelope", () => {
     const env = buildEnvelope({ packageName: "x" });
     expect(() => decodeGooglePlayPubSubEnvelope(env)).toThrow(DecoderError);
   });
+
+  it("throws on malformed subscriptionNotification (missing purchaseToken)", () => {
+    const env = buildEnvelope({ subscriptionNotification: { notificationType: 4 } });
+    expect(() => decodeGooglePlayPubSubEnvelope(env)).toThrow(DecoderError);
+  });
 });

--- a/apps/server/src/features/billing/google-play.decoder.test.ts
+++ b/apps/server/src/features/billing/google-play.decoder.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { decodeGooglePlayPubSubEnvelope, DecoderError } from "./google-play.decoder";
+
+function buildEnvelope(inner: object, messageId = "msg-1") {
+  return {
+    message: {
+      messageId,
+      publishTime: "2026-05-12T10:00:00Z",
+      data: Buffer.from(JSON.stringify(inner)).toString("base64"),
+    },
+  };
+}
+
+describe("decodeGooglePlayPubSubEnvelope", () => {
+  it("decodes PURCHASED (type 4)", () => {
+    const env = buildEnvelope({
+      version: "1.0",
+      packageName: "com.pruvi.app",
+      eventTimeMillis: "1747044000000",
+      subscriptionNotification: { version: "1.0", notificationType: 4, purchaseToken: "tok-A" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind).toBe("subscription");
+    if (decoded.kind === "subscription") {
+      expect(decoded.notificationType).toBe(4);
+      expect(decoded.notificationTypeName).toBe("PURCHASED");
+      expect(decoded.purchaseToken).toBe("tok-A");
+      expect(decoded.messageId).toBe("msg-1");
+    }
+  });
+
+  it("decodes RENEWED (type 2)", () => {
+    const env = buildEnvelope({
+      subscriptionNotification: { notificationType: 2, purchaseToken: "tok-B" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind === "subscription" && decoded.notificationTypeName).toBe("RENEWED");
+  });
+
+  it("decodes EXPIRED (type 13)", () => {
+    const env = buildEnvelope({
+      subscriptionNotification: { notificationType: 13, purchaseToken: "tok-C" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind === "subscription" && decoded.notificationTypeName).toBe("EXPIRED");
+  });
+
+  it("decodes CANCELLATION_SCHEDULED (type 18)", () => {
+    const env = buildEnvelope({
+      subscriptionNotification: { notificationType: 18, purchaseToken: "tok-D" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind === "subscription" && decoded.notificationTypeName).toBe("CANCELLATION_SCHEDULED");
+  });
+
+  it("returns kind=unknown for unrecognized notificationType", () => {
+    const env = buildEnvelope({
+      subscriptionNotification: { notificationType: 99, purchaseToken: "tok-E" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind).toBe("unknown");
+    if (decoded.kind === "unknown") {
+      expect(decoded.notificationType).toBe(99);
+      expect(decoded.purchaseToken).toBe("tok-E");
+    }
+  });
+
+  it("returns kind=test for testNotification envelopes", () => {
+    const env = buildEnvelope({ testNotification: { version: "1.0" } });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind).toBe("test");
+  });
+
+  it("throws on missing messageId", () => {
+    expect(() =>
+      decodeGooglePlayPubSubEnvelope({ message: { data: Buffer.from("{}").toString("base64") } }),
+    ).toThrow(DecoderError);
+  });
+
+  it("throws on missing message.data", () => {
+    expect(() => decodeGooglePlayPubSubEnvelope({ message: { messageId: "x" } })).toThrow(DecoderError);
+  });
+
+  it("throws on malformed base64", () => {
+    expect(() => decodeGooglePlayPubSubEnvelope({ message: { messageId: "x", data: "!!!notbase64!!!" } })).toThrow(DecoderError);
+  });
+
+  it("throws on missing subscriptionNotification", () => {
+    const env = buildEnvelope({ packageName: "x" });
+    expect(() => decodeGooglePlayPubSubEnvelope(env)).toThrow(DecoderError);
+  });
+});

--- a/apps/server/src/features/billing/google-play.decoder.test.ts
+++ b/apps/server/src/features/billing/google-play.decoder.test.ts
@@ -94,4 +94,21 @@ describe("decodeGooglePlayPubSubEnvelope", () => {
     const env = buildEnvelope({ subscriptionNotification: { notificationType: 4 } });
     expect(() => decodeGooglePlayPubSubEnvelope(env)).toThrow(DecoderError);
   });
+
+  it("decodes ALL 13 core notification types (1-13)", () => {
+    const expected: Array<[number, string]> = [
+      [1, "RECOVERED"], [2, "RENEWED"], [3, "CANCELED"], [4, "PURCHASED"],
+      [5, "ON_HOLD"], [6, "IN_GRACE_PERIOD"], [7, "RESTARTED"], [8, "PRICE_CHANGE_CONFIRMED"],
+      [9, "DEFERRED"], [10, "PAUSED"], [11, "PAUSE_SCHEDULE_CHANGED"], [12, "REVOKED"], [13, "EXPIRED"],
+    ];
+    for (const [ntype, name] of expected) {
+      const env = buildEnvelope({ subscriptionNotification: { notificationType: ntype, purchaseToken: `t-${ntype}` } });
+      const decoded = decodeGooglePlayPubSubEnvelope(env);
+      expect(decoded.kind).toBe("subscription");
+      if (decoded.kind === "subscription") {
+        expect(decoded.notificationType).toBe(ntype);
+        expect(decoded.notificationTypeName).toBe(name);
+      }
+    }
+  });
 });

--- a/apps/server/src/features/billing/google-play.decoder.ts
+++ b/apps/server/src/features/billing/google-play.decoder.ts
@@ -1,0 +1,95 @@
+import { GOOGLE_PLAY_NOTIFICATION_TYPES, type GooglePlayNotificationTypeName } from "@pruvi/shared";
+
+export type DecodedGooglePlayEvent =
+  | {
+      kind: "subscription";
+      messageId: string;
+      publishTime: string;
+      packageName: string;
+      eventTimeMillis: string;
+      notificationType: number;
+      notificationTypeName: GooglePlayNotificationTypeName;
+      purchaseToken: string;
+    }
+  | { kind: "test"; messageId: string }
+  | { kind: "unknown"; messageId: string; notificationType: number; purchaseToken: string };
+
+export class DecoderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DecoderError";
+  }
+}
+
+type PubSubMessage = {
+  message?: {
+    messageId?: string;
+    publishTime?: string;
+    data?: string;
+  };
+};
+
+/** Pure decoder: throws DecoderError on unparseable input. */
+export function decodeGooglePlayPubSubEnvelope(raw: unknown): DecodedGooglePlayEvent {
+  if (!raw || typeof raw !== "object") {
+    throw new DecoderError("Envelope is not an object");
+  }
+  const env = raw as PubSubMessage;
+  const msg = env.message;
+  if (!msg || typeof msg !== "object") {
+    throw new DecoderError("Missing message field");
+  }
+  const messageId = msg.messageId;
+  if (!messageId || typeof messageId !== "string") {
+    throw new DecoderError("Missing message.messageId");
+  }
+  if (!msg.data || typeof msg.data !== "string") {
+    throw new DecoderError("Missing message.data");
+  }
+  let inner: unknown;
+  try {
+    const decoded = Buffer.from(msg.data, "base64").toString("utf-8");
+    inner = JSON.parse(decoded);
+  } catch (_e) {
+    throw new DecoderError("message.data is not valid base64+JSON");
+  }
+  if (!inner || typeof inner !== "object") {
+    throw new DecoderError("Decoded payload is not an object");
+  }
+
+  const obj = inner as {
+    packageName?: string;
+    eventTimeMillis?: string;
+    testNotification?: unknown;
+    subscriptionNotification?: { notificationType?: number; purchaseToken?: string };
+  };
+
+  if (obj.testNotification) {
+    return { kind: "test", messageId };
+  }
+
+  const sub = obj.subscriptionNotification;
+  if (!sub || typeof sub !== "object") {
+    throw new DecoderError("Missing subscriptionNotification");
+  }
+  const ntype = sub.notificationType;
+  const token = sub.purchaseToken;
+  if (typeof ntype !== "number" || !token || typeof token !== "string") {
+    throw new DecoderError("Malformed subscriptionNotification");
+  }
+
+  const name = GOOGLE_PLAY_NOTIFICATION_TYPES[ntype as keyof typeof GOOGLE_PLAY_NOTIFICATION_TYPES];
+  if (!name) {
+    return { kind: "unknown", messageId, notificationType: ntype, purchaseToken: token };
+  }
+  return {
+    kind: "subscription",
+    messageId,
+    publishTime: msg.publishTime ?? "",
+    packageName: obj.packageName ?? "",
+    eventTimeMillis: obj.eventTimeMillis ?? "",
+    notificationType: ntype,
+    notificationTypeName: name,
+    purchaseToken: token,
+  };
+}

--- a/apps/server/src/features/billing/index.ts
+++ b/apps/server/src/features/billing/index.ts
@@ -1,0 +1,1 @@
+export { billingRoutes } from "./billing.route";

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,6 +14,7 @@ import { invitationsRoutes, friendshipsRoutes, rankingRoutes } from "./features/
 import { ultraRoutes } from "./features/ultra/ultra.route";
 import { shieldsRoutes } from "./features/shields/shields.route";
 import { simuladosRoutes } from "./features/simulados";
+import { billingRoutes } from "./features/billing";
 import { livesRoutes } from "./features/lives";
 import { onboardingRoutes } from "./features/onboarding";
 import { progressRoutes } from "./features/progress";
@@ -90,6 +91,7 @@ export async function buildApp() {
   await app.register(ultraRoutes);
   await app.register(shieldsRoutes);
   await app.register(simuladosRoutes);
+  await app.register(billingRoutes);
 
   // Health check — verifies DB connectivity for ALB
   app.get("/health", async (_request, reply) => {

--- a/apps/server/src/test/db-helpers.ts
+++ b/apps/server/src/test/db-helpers.ts
@@ -63,7 +63,8 @@ export async function setupTestDb() {
 export async function cleanupTestDb() {
   const db = getTestDb();
   await db.execute(sql`
-    TRUNCATE TABLE weekly_simulado_question, weekly_simulado,
+    TRUNCATE TABLE billing_event, subscription,
+      weekly_simulado_question, weekly_simulado,
       push_token, review_log, daily_session, streak_shield_usage,
       question, subtopic, topic, subject,
       account, session, verification, "user" CASCADE

--- a/docs/superpowers/plans/2026-05-12-phase-2e4-billing-webhooks.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e4-billing-webhooks.md
@@ -1,0 +1,1250 @@
+# Phase 2E.4 — Google Play Billing Webhooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Each task gets Gate C (Opus 4.7 per-task review). Final Gate D before PR.
+
+**Goal:** Wire Google Play Real-Time Developer Notifications into the existing Ultra entitlement so subscription purchases, renewals, and revocations grant/revoke Ultra automatically. Includes parked-event replay for the pre-link race.
+
+**Architecture:** New `billing` feature module under `apps/server/src/features/`. Two new tables (`subscription`, `billing_event`). Pure decoder + repository + service split. Shared `applyDecodedEvent(decoded, subscription, tx)` state-machine function used by both the webhook handler and the link-time replay loop. Multi-subscription revoke guard before calling `UltraService.revoke`. New optional env var `GOOGLE_PLAY_WEBHOOK_TOKEN`.
+
+**Tech Stack:** Drizzle ORM + drizzle-kit, Fastify 5 + fastify-type-provider-zod on Bun, neverthrow Result, real Postgres for integration tests.
+
+**Authoritative spec:** `docs/superpowers/specs/2026-05-12-phase-2e4-billing-webhooks-design.md` (v2 post Gate A).
+
+---
+
+## Task 1 — Env, shared schemas, notification-type enum
+
+**Files:**
+- Modify: `packages/env/src/server.ts`
+- Create: `packages/shared/src/billing.ts`
+- Create: `packages/shared/src/billing.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] **Step 1.1: Add `GOOGLE_PLAY_WEBHOOK_TOKEN` to env**
+
+In `packages/env/src/server.ts`, add inside the `server: {...}` block after `ADMIN_API_TOKEN`:
+
+```ts
+    GOOGLE_PLAY_WEBHOOK_TOKEN: z.string().min(16).optional(),
+```
+
+- [ ] **Step 1.2: Create the shared billing module**
+
+Create `packages/shared/src/billing.ts`:
+
+```ts
+import { z } from "zod";
+
+export const BILLING_PROVIDERS = ["google_play", "app_store"] as const;
+export type BillingProvider = (typeof BILLING_PROVIDERS)[number];
+
+export const SUBSCRIPTION_STATUSES = [
+  "pending",
+  "active",
+  "in_grace",
+  "on_hold",
+  "paused",
+  "canceled",
+  "expired",
+  "revoked",
+] as const;
+export type SubscriptionStatus = (typeof SUBSCRIPTION_STATUSES)[number];
+
+/** Conservative default expiry when the webhook payload doesn't carry expiryTimeMillis. */
+export const DEFAULT_SUBSCRIPTION_PERIOD_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Mapping from Google Play RTDN notificationType integer → name. Values not listed
+ *  are decoded as { kind: "unknown" } and result in no state mutation. */
+export const GOOGLE_PLAY_NOTIFICATION_TYPES = {
+  1: "RECOVERED",
+  2: "RENEWED",
+  3: "CANCELED",
+  4: "PURCHASED",
+  5: "ON_HOLD",
+  6: "IN_GRACE_PERIOD",
+  7: "RESTARTED",
+  8: "PRICE_CHANGE_CONFIRMED",
+  9: "DEFERRED",
+  10: "PAUSED",
+  11: "PAUSE_SCHEDULE_CHANGED",
+  12: "REVOKED",
+  13: "EXPIRED",
+  17: "ITEMS_CHANGED",
+  18: "CANCELLATION_SCHEDULED",
+  19: "PRICE_CHANGE_UPDATED",
+  20: "PENDING_PURCHASE_CANCELED",
+  22: "PRICE_STEP_UP_CONSENT_UPDATED",
+} as const;
+export type GooglePlayNotificationTypeName =
+  (typeof GOOGLE_PLAY_NOTIFICATION_TYPES)[keyof typeof GOOGLE_PLAY_NOTIFICATION_TYPES];
+
+export const GooglePlayLinkBodySchema = z.object({
+  purchaseToken: z.string().min(1),
+  productId: z.string().min(1),
+});
+export type GooglePlayLinkBody = z.infer<typeof GooglePlayLinkBodySchema>;
+
+export const GooglePlayLinkResponseSchema = z.object({
+  subscription: z.object({
+    id: z.number().int(),
+    status: z.enum(SUBSCRIPTION_STATUSES),
+    productId: z.string(),
+    currentPeriodEnd: z.string().nullable(),
+  }),
+});
+export type GooglePlayLinkResponse = z.infer<typeof GooglePlayLinkResponseSchema>;
+```
+
+- [ ] **Step 1.3: Failing tests**
+
+Create `packages/shared/src/billing.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  BILLING_PROVIDERS,
+  SUBSCRIPTION_STATUSES,
+  GOOGLE_PLAY_NOTIFICATION_TYPES,
+  GooglePlayLinkBodySchema,
+  DEFAULT_SUBSCRIPTION_PERIOD_MS,
+} from "./billing";
+
+describe("billing shared module", () => {
+  it("declares the v1 providers", () => {
+    expect(BILLING_PROVIDERS).toEqual(["google_play", "app_store"]);
+  });
+
+  it("declares all 8 subscription statuses", () => {
+    expect(SUBSCRIPTION_STATUSES).toHaveLength(8);
+    expect(SUBSCRIPTION_STATUSES).toContain("pending");
+    expect(SUBSCRIPTION_STATUSES).toContain("active");
+    expect(SUBSCRIPTION_STATUSES).toContain("expired");
+  });
+
+  it("maps Google Play notificationType integers to enum names", () => {
+    expect(GOOGLE_PLAY_NOTIFICATION_TYPES[4]).toBe("PURCHASED");
+    expect(GOOGLE_PLAY_NOTIFICATION_TYPES[13]).toBe("EXPIRED");
+    expect(GOOGLE_PLAY_NOTIFICATION_TYPES[18]).toBe("CANCELLATION_SCHEDULED");
+  });
+
+  it("DEFAULT_SUBSCRIPTION_PERIOD_MS is 30 days", () => {
+    expect(DEFAULT_SUBSCRIPTION_PERIOD_MS).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("validates link body shape", () => {
+    expect(GooglePlayLinkBodySchema.safeParse({ purchaseToken: "t", productId: "pruvi_ultra_monthly" }).success).toBe(true);
+    expect(GooglePlayLinkBodySchema.safeParse({ purchaseToken: "", productId: "x" }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 1.4: Re-export**
+
+In `packages/shared/src/index.ts`, append:
+```ts
+export * from "./billing";
+```
+
+- [ ] **Step 1.5: Run tests, commit**
+
+```bash
+cd packages/shared && bun test src/billing.test.ts
+```
+Expected: 5 pass.
+
+```bash
+git add packages/env/src/server.ts packages/shared/src/billing.ts packages/shared/src/billing.test.ts packages/shared/src/index.ts
+git commit -m "feat(shared,env): billing module — providers, statuses, google play notification types, link schemas"
+```
+
+---
+
+## Task 2 — DB schema + migration + test cleanup
+
+**Files:**
+- Create: `packages/db/src/schema/billing.ts`
+- Modify: `packages/db/src/schema/index.ts`
+- Create: `packages/db/src/migrations/0010_<generated>.sql` (auto-named)
+- Create: `packages/db/src/migrations/meta/0010_snapshot.json`
+- Modify: `packages/db/src/migrations/meta/_journal.json`
+- Modify: `apps/server/src/test/db-helpers.ts`
+
+- [ ] **Step 2.1: Define schema**
+
+Create `packages/db/src/schema/billing.ts`:
+
+```ts
+import { relations } from "drizzle-orm";
+import { index, integer, jsonb, pgTable, serial, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const subscription = pgTable(
+  "subscription",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id").references(() => user.id, { onDelete: "set null" }),
+    provider: text("provider", { enum: ["google_play", "app_store"] }).notNull(),
+    productId: text("product_id").notNull(),
+    purchaseToken: text("purchase_token").notNull(),
+    status: text("status", {
+      enum: ["pending", "active", "in_grace", "on_hold", "paused", "canceled", "expired", "revoked"],
+    }).notNull(),
+    currentPeriodEnd: timestamp("current_period_end", { withTimezone: true }),
+    linkedAt: timestamp("linked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => [
+    uniqueIndex("subscription_provider_token_uq").on(t.provider, t.purchaseToken),
+    index("subscription_user_idx").on(t.userId),
+    index("subscription_status_idx").on(t.status),
+  ],
+);
+
+export const billingEvent = pgTable(
+  "billing_event",
+  {
+    id: serial("id").primaryKey(),
+    provider: text("provider", { enum: ["google_play", "app_store"] }).notNull(),
+    messageId: text("message_id").notNull(),
+    eventType: text("event_type").notNull(),
+    purchaseToken: text("purchase_token"),
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    receivedAt: timestamp("received_at", { withTimezone: true }).defaultNow().notNull(),
+    processedAt: timestamp("processed_at", { withTimezone: true }),
+    processingError: text("processing_error"),
+  },
+  (t) => [
+    uniqueIndex("billing_event_provider_message_uq").on(t.provider, t.messageId),
+    index("billing_event_token_idx").on(t.purchaseToken),
+  ],
+);
+
+export const subscriptionRelations = relations(subscription, ({ one }) => ({
+  user: one(user, { fields: [subscription.userId], references: [user.id] }),
+}));
+```
+
+- [ ] **Step 2.2: Register in schema index**
+
+In `packages/db/src/schema/index.ts`, add:
+```ts
+export * from "./billing";
+```
+
+- [ ] **Step 2.3: Generate migration**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi && pnpm -F db db:generate
+```
+
+(If the package script name differs, check `packages/db/package.json`.) Verify the generated `0010_*.sql` contains both tables with the expected constraints (CHECK for provider + status enums, UNIQUE indexes, ON DELETE SET NULL for user_id). If unrelated diffs appear, STOP and report BLOCKED.
+
+- [ ] **Step 2.4: Update `cleanupTestDb`**
+
+In `apps/server/src/test/db-helpers.ts`, modify the `cleanupTestDb` TRUNCATE list to include the new tables. The current list (after Phase 2E.3) is:
+```sql
+TRUNCATE TABLE weekly_simulado_question, weekly_simulado, push_token, review_log, daily_session,
+  streak_shield_usage, question, subtopic, topic, subject,
+  account, session, verification, "user" CASCADE
+```
+
+Add `billing_event, subscription,` at the front (children-first ordering; both have CASCADE/SET NULL but explicit listing prevents UNIQUE pollution):
+
+```sql
+TRUNCATE TABLE billing_event, subscription,
+  weekly_simulado_question, weekly_simulado, push_token, review_log, daily_session,
+  streak_shield_usage, question, subtopic, topic, subject,
+  account, session, verification, "user" CASCADE
+```
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add packages/db/src/schema/billing.ts packages/db/src/schema/index.ts packages/db/src/migrations/ apps/server/src/test/db-helpers.ts
+git commit -m "feat(db): subscription + billing_event tables and test cleanup"
+```
+
+---
+
+## Task 3 — Pure Google Play decoder
+
+**Files:**
+- Create: `apps/server/src/features/billing/google-play.decoder.ts`
+- Create: `apps/server/src/features/billing/google-play.decoder.test.ts`
+
+- [ ] **Step 3.1: Implement the decoder**
+
+Create `apps/server/src/features/billing/google-play.decoder.ts`:
+
+```ts
+import { GOOGLE_PLAY_NOTIFICATION_TYPES, type GooglePlayNotificationTypeName } from "@pruvi/shared";
+
+export type DecodedGooglePlayEvent =
+  | {
+      kind: "subscription";
+      messageId: string;
+      publishTime: string;
+      packageName: string;
+      eventTimeMillis: string;
+      notificationType: number;
+      notificationTypeName: GooglePlayNotificationTypeName;
+      purchaseToken: string;
+    }
+  | { kind: "test"; messageId: string }
+  | { kind: "unknown"; messageId: string; notificationType: number; purchaseToken: string };
+
+export class DecoderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DecoderError";
+  }
+}
+
+type PubSubMessage = {
+  message?: {
+    messageId?: string;
+    publishTime?: string;
+    data?: string;
+  };
+};
+
+/** Pure decoder: throws DecoderError on unparseable input. */
+export function decodeGooglePlayPubSubEnvelope(raw: unknown): DecodedGooglePlayEvent {
+  if (!raw || typeof raw !== "object") {
+    throw new DecoderError("Envelope is not an object");
+  }
+  const env = raw as PubSubMessage;
+  const msg = env.message;
+  if (!msg || typeof msg !== "object") {
+    throw new DecoderError("Missing message field");
+  }
+  const messageId = msg.messageId;
+  if (!messageId || typeof messageId !== "string") {
+    throw new DecoderError("Missing message.messageId");
+  }
+  if (!msg.data || typeof msg.data !== "string") {
+    throw new DecoderError("Missing message.data");
+  }
+  let inner: unknown;
+  try {
+    const decoded = Buffer.from(msg.data, "base64").toString("utf-8");
+    inner = JSON.parse(decoded);
+  } catch (_e) {
+    throw new DecoderError("message.data is not valid base64+JSON");
+  }
+  if (!inner || typeof inner !== "object") {
+    throw new DecoderError("Decoded payload is not an object");
+  }
+
+  const obj = inner as {
+    packageName?: string;
+    eventTimeMillis?: string;
+    testNotification?: unknown;
+    subscriptionNotification?: { notificationType?: number; purchaseToken?: string };
+  };
+
+  if (obj.testNotification) {
+    return { kind: "test", messageId };
+  }
+
+  const sub = obj.subscriptionNotification;
+  if (!sub || typeof sub !== "object") {
+    throw new DecoderError("Missing subscriptionNotification");
+  }
+  const ntype = sub.notificationType;
+  const token = sub.purchaseToken;
+  if (typeof ntype !== "number" || !token || typeof token !== "string") {
+    throw new DecoderError("Malformed subscriptionNotification");
+  }
+
+  const name = GOOGLE_PLAY_NOTIFICATION_TYPES[ntype as keyof typeof GOOGLE_PLAY_NOTIFICATION_TYPES];
+  if (!name) {
+    return { kind: "unknown", messageId, notificationType: ntype, purchaseToken: token };
+  }
+  return {
+    kind: "subscription",
+    messageId,
+    publishTime: msg.publishTime ?? "",
+    packageName: obj.packageName ?? "",
+    eventTimeMillis: obj.eventTimeMillis ?? "",
+    notificationType: ntype,
+    notificationTypeName: name,
+    purchaseToken: token,
+  };
+}
+```
+
+- [ ] **Step 3.2: Failing tests**
+
+Create `apps/server/src/features/billing/google-play.decoder.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { decodeGooglePlayPubSubEnvelope, DecoderError } from "./google-play.decoder";
+
+function buildEnvelope(inner: object, messageId = "msg-1") {
+  return {
+    message: {
+      messageId,
+      publishTime: "2026-05-12T10:00:00Z",
+      data: Buffer.from(JSON.stringify(inner)).toString("base64"),
+    },
+  };
+}
+
+describe("decodeGooglePlayPubSubEnvelope", () => {
+  it("decodes PURCHASED (type 4)", () => {
+    const env = buildEnvelope({
+      version: "1.0",
+      packageName: "com.pruvi.app",
+      eventTimeMillis: "1747044000000",
+      subscriptionNotification: { version: "1.0", notificationType: 4, purchaseToken: "tok-A" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind).toBe("subscription");
+    if (decoded.kind === "subscription") {
+      expect(decoded.notificationType).toBe(4);
+      expect(decoded.notificationTypeName).toBe("PURCHASED");
+      expect(decoded.purchaseToken).toBe("tok-A");
+      expect(decoded.messageId).toBe("msg-1");
+    }
+  });
+
+  it("decodes RENEWED (type 2)", () => {
+    const env = buildEnvelope({
+      subscriptionNotification: { notificationType: 2, purchaseToken: "tok-B" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind === "subscription" && decoded.notificationTypeName).toBe("RENEWED");
+  });
+
+  it("decodes EXPIRED (type 13)", () => {
+    const env = buildEnvelope({
+      subscriptionNotification: { notificationType: 13, purchaseToken: "tok-C" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind === "subscription" && decoded.notificationTypeName).toBe("EXPIRED");
+  });
+
+  it("decodes CANCELLATION_SCHEDULED (type 18)", () => {
+    const env = buildEnvelope({
+      subscriptionNotification: { notificationType: 18, purchaseToken: "tok-D" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind === "subscription" && decoded.notificationTypeName).toBe("CANCELLATION_SCHEDULED");
+  });
+
+  it("returns kind=unknown for unrecognized notificationType", () => {
+    const env = buildEnvelope({
+      subscriptionNotification: { notificationType: 99, purchaseToken: "tok-E" },
+    });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind).toBe("unknown");
+    if (decoded.kind === "unknown") {
+      expect(decoded.notificationType).toBe(99);
+      expect(decoded.purchaseToken).toBe("tok-E");
+    }
+  });
+
+  it("returns kind=test for testNotification envelopes", () => {
+    const env = buildEnvelope({ testNotification: { version: "1.0" } });
+    const decoded = decodeGooglePlayPubSubEnvelope(env);
+    expect(decoded.kind).toBe("test");
+  });
+
+  it("throws on missing messageId", () => {
+    expect(() =>
+      decodeGooglePlayPubSubEnvelope({ message: { data: Buffer.from("{}").toString("base64") } }),
+    ).toThrow(DecoderError);
+  });
+
+  it("throws on missing message.data", () => {
+    expect(() => decodeGooglePlayPubSubEnvelope({ message: { messageId: "x" } })).toThrow(DecoderError);
+  });
+
+  it("throws on malformed base64", () => {
+    expect(() => decodeGooglePlayPubSubEnvelope({ message: { messageId: "x", data: "!!!notbase64!!!" } })).toThrow(DecoderError);
+  });
+
+  it("throws on missing subscriptionNotification", () => {
+    const env = buildEnvelope({ packageName: "x" });
+    expect(() => decodeGooglePlayPubSubEnvelope(env)).toThrow(DecoderError);
+  });
+});
+```
+
+- [ ] **Step 3.3: Run tests, commit**
+
+```bash
+cd apps/server && bun test src/features/billing/google-play.decoder.test.ts
+```
+Expected: 10 pass.
+
+```bash
+git add apps/server/src/features/billing/google-play.decoder.ts apps/server/src/features/billing/google-play.decoder.test.ts
+git commit -m "feat(billing): google play rtdn decoder — pure pubsub envelope parser"
+```
+
+---
+
+## Task 4 — Billing repository (subscription + event storage)
+
+**Files:**
+- Create: `apps/server/src/features/billing/billing.repository.ts`
+- Create: `apps/server/src/features/billing/billing.repository.integration.test.ts`
+
+- [ ] **Step 4.1: Implement the repository**
+
+Create `apps/server/src/features/billing/billing.repository.ts`:
+
+```ts
+import { and, asc, eq, isNull, ne, sql } from "drizzle-orm";
+import type { db as DbClient } from "@pruvi/db";
+import { subscription, billingEvent } from "@pruvi/db/schema/billing";
+import type { BillingProvider, SubscriptionStatus } from "@pruvi/shared";
+
+type Db = typeof DbClient;
+export type Tx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+export type DbOrTx = Db | Tx;
+
+export type SubscriptionRow = {
+  id: number;
+  userId: string | null;
+  provider: BillingProvider;
+  productId: string;
+  purchaseToken: string;
+  status: SubscriptionStatus;
+  currentPeriodEnd: Date | null;
+  linkedAt: Date | null;
+};
+
+export type BillingEventRow = {
+  id: number;
+  provider: BillingProvider;
+  messageId: string;
+  eventType: string;
+  purchaseToken: string | null;
+  payload: Record<string, unknown>;
+  receivedAt: Date;
+  processedAt: Date | null;
+  processingError: string | null;
+};
+
+export class BillingRepository {
+  constructor(private db: Db) {}
+
+  /** Insert audit row with ON CONFLICT DO NOTHING. Returns the row if newly inserted, null on dup. */
+  async insertEvent(
+    tx: DbOrTx,
+    args: { provider: BillingProvider; messageId: string; eventType: string; purchaseToken: string | null; payload: Record<string, unknown> },
+  ): Promise<BillingEventRow | null> {
+    const inserted = await tx
+      .insert(billingEvent)
+      .values({
+        provider: args.provider,
+        messageId: args.messageId,
+        eventType: args.eventType,
+        purchaseToken: args.purchaseToken,
+        payload: args.payload,
+      })
+      .onConflictDoNothing({ target: [billingEvent.provider, billingEvent.messageId] })
+      .returning();
+    const row = inserted[0];
+    return row ? this.toEvent(row) : null;
+  }
+
+  async findSubscriptionByToken(
+    tx: DbOrTx,
+    provider: BillingProvider,
+    token: string,
+  ): Promise<SubscriptionRow | null> {
+    const rows = await tx
+      .select()
+      .from(subscription)
+      .where(and(eq(subscription.provider, provider), eq(subscription.purchaseToken, token)))
+      .limit(1);
+    const r = rows[0];
+    return r ? this.toSubscription(r) : null;
+  }
+
+  /** Create a webhook-orphaned subscription row (user_id null, product_id empty placeholder). */
+  async createOrphanSubscription(
+    tx: DbOrTx,
+    provider: BillingProvider,
+    token: string,
+  ): Promise<SubscriptionRow> {
+    const inserted = await tx
+      .insert(subscription)
+      .values({ provider, purchaseToken: token, productId: "", status: "pending", userId: null })
+      .onConflictDoNothing({ target: [subscription.provider, subscription.purchaseToken] })
+      .returning();
+    if (inserted[0]) return this.toSubscription(inserted[0]);
+    const existing = await this.findSubscriptionByToken(tx, provider, token);
+    if (!existing) throw new Error("createOrphanSubscription: conflict but no existing row");
+    return existing;
+  }
+
+  async upsertLinkedSubscription(
+    tx: DbOrTx,
+    args: { userId: string; provider: BillingProvider; productId: string; token: string },
+  ): Promise<{ subscription: SubscriptionRow; created: boolean }> {
+    const now = new Date();
+    const inserted = await tx
+      .insert(subscription)
+      .values({
+        provider: args.provider,
+        purchaseToken: args.token,
+        productId: args.productId,
+        status: "pending",
+        userId: args.userId,
+        linkedAt: now,
+      })
+      .onConflictDoNothing({ target: [subscription.provider, subscription.purchaseToken] })
+      .returning();
+    if (inserted[0]) return { subscription: this.toSubscription(inserted[0]), created: true };
+
+    const existing = await this.findSubscriptionByToken(tx, args.provider, args.token);
+    if (!existing) throw new Error("upsertLinkedSubscription: conflict but no existing row");
+    return { subscription: existing, created: false };
+  }
+
+  async claimOrphanSubscription(
+    tx: DbOrTx,
+    subscriptionId: number,
+    userId: string,
+    productId: string,
+  ): Promise<SubscriptionRow> {
+    const now = new Date();
+    const updated = await tx
+      .update(subscription)
+      .set({ userId, productId, linkedAt: now, updatedAt: now })
+      .where(and(eq(subscription.id, subscriptionId), isNull(subscription.userId)))
+      .returning();
+    const row = updated[0];
+    if (!row) throw new Error("claimOrphanSubscription: row not found or already claimed");
+    return this.toSubscription(row);
+  }
+
+  async updateSubscriptionState(
+    tx: DbOrTx,
+    subscriptionId: number,
+    args: { status: SubscriptionStatus; currentPeriodEnd?: Date | null },
+  ): Promise<SubscriptionRow> {
+    const now = new Date();
+    const updates: Record<string, unknown> = { status: args.status, updatedAt: now };
+    if (args.currentPeriodEnd !== undefined) updates.currentPeriodEnd = args.currentPeriodEnd;
+    const rows = await tx
+      .update(subscription)
+      .set(updates)
+      .where(eq(subscription.id, subscriptionId))
+      .returning();
+    const r = rows[0];
+    if (!r) throw new Error("updateSubscriptionState: not found");
+    return this.toSubscription(r);
+  }
+
+  async markEventProcessed(
+    tx: DbOrTx,
+    eventId: number,
+    processingError?: string | null,
+  ): Promise<void> {
+    await tx
+      .update(billingEvent)
+      .set({ processedAt: new Date(), processingError: processingError ?? null })
+      .where(eq(billingEvent.id, eventId));
+  }
+
+  async listUnprocessedEventsForToken(
+    tx: DbOrTx,
+    provider: BillingProvider,
+    token: string,
+  ): Promise<BillingEventRow[]> {
+    const rows = await tx
+      .select()
+      .from(billingEvent)
+      .where(and(eq(billingEvent.provider, provider), eq(billingEvent.purchaseToken, token), isNull(billingEvent.processedAt)))
+      .orderBy(asc(billingEvent.receivedAt));
+    return rows.map((r) => this.toEvent(r));
+  }
+
+  /** True if the user has any OTHER subscription row (excluding this one) in active or in_grace status. */
+  async hasOtherActiveSubscription(
+    tx: DbOrTx,
+    userId: string,
+    excludeSubscriptionId: number,
+  ): Promise<boolean> {
+    const rows = await tx
+      .select({ id: subscription.id })
+      .from(subscription)
+      .where(
+        and(
+          eq(subscription.userId, userId),
+          ne(subscription.id, excludeSubscriptionId),
+          sql`${subscription.status} IN ('active','in_grace')`,
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  private toSubscription(r: typeof subscription.$inferSelect): SubscriptionRow {
+    return {
+      id: r.id,
+      userId: r.userId,
+      provider: r.provider as BillingProvider,
+      productId: r.productId,
+      purchaseToken: r.purchaseToken,
+      status: r.status as SubscriptionStatus,
+      currentPeriodEnd: r.currentPeriodEnd,
+      linkedAt: r.linkedAt,
+    };
+  }
+  private toEvent(r: typeof billingEvent.$inferSelect): BillingEventRow {
+    return {
+      id: r.id,
+      provider: r.provider as BillingProvider,
+      messageId: r.messageId,
+      eventType: r.eventType,
+      purchaseToken: r.purchaseToken,
+      payload: r.payload as Record<string, unknown>,
+      receivedAt: r.receivedAt,
+      processedAt: r.processedAt,
+      processingError: r.processingError,
+    };
+  }
+}
+```
+
+- [ ] **Step 4.2: Failing integration tests**
+
+Create `apps/server/src/features/billing/billing.repository.integration.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { setupTestDb, cleanupTestDb, teardownTestDb, getTestDb } from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { BillingRepository } from "./billing.repository";
+
+describe("BillingRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new BillingRepository(db);
+
+  beforeAll(async () => setupTestDb());
+  beforeEach(async () => cleanupTestDb());
+  afterAll(async () => teardownTestDb());
+
+  async function insertUser(id: string) {
+    await db.insert(user).values({
+      id, name: `U ${id}`, email: `${id}@e.com`, emailVerified: false,
+      inviteCode: `c${id.replace(/-/g, "").slice(0, 8)}`, username: null, updatedAt: new Date(),
+    });
+  }
+
+  it("insertEvent dedup: same (provider, message_id) returns null on second insert", async () => {
+    const a = await repo.insertEvent(db, { provider: "google_play", messageId: "m1", eventType: "PURCHASED", purchaseToken: "t1", payload: { x: 1 } });
+    const b = await repo.insertEvent(db, { provider: "google_play", messageId: "m1", eventType: "PURCHASED", purchaseToken: "t1", payload: { x: 2 } });
+    expect(a).not.toBeNull();
+    expect(b).toBeNull();
+  });
+
+  it("createOrphanSubscription is idempotent on conflict", async () => {
+    const a = await repo.createOrphanSubscription(db, "google_play", "t-orph");
+    const b = await repo.createOrphanSubscription(db, "google_play", "t-orph");
+    expect(b.id).toBe(a.id);
+    expect(b.userId).toBeNull();
+  });
+
+  it("upsertLinkedSubscription creates with linked_at set; second call by same user returns existing", async () => {
+    await insertUser("u-link-1");
+    const r1 = await repo.upsertLinkedSubscription(db, { userId: "u-link-1", provider: "google_play", productId: "p1", token: "t-link-1" });
+    expect(r1.created).toBe(true);
+    expect(r1.subscription.linkedAt).toBeInstanceOf(Date);
+    const r2 = await repo.upsertLinkedSubscription(db, { userId: "u-link-1", provider: "google_play", productId: "p1", token: "t-link-1" });
+    expect(r2.created).toBe(false);
+    expect(r2.subscription.id).toBe(r1.subscription.id);
+  });
+
+  it("claimOrphanSubscription sets user_id, product_id, linked_at", async () => {
+    await insertUser("u-claim-1");
+    const orph = await repo.createOrphanSubscription(db, "google_play", "t-claim-1");
+    const claimed = await repo.claimOrphanSubscription(db, orph.id, "u-claim-1", "pruvi_ultra_monthly");
+    expect(claimed.userId).toBe("u-claim-1");
+    expect(claimed.productId).toBe("pruvi_ultra_monthly");
+    expect(claimed.linkedAt).toBeInstanceOf(Date);
+  });
+
+  it("claimOrphanSubscription rejects already-claimed", async () => {
+    await insertUser("u-claim-2a");
+    await insertUser("u-claim-2b");
+    const orph = await repo.createOrphanSubscription(db, "google_play", "t-claim-2");
+    await repo.claimOrphanSubscription(db, orph.id, "u-claim-2a", "p");
+    await expect(repo.claimOrphanSubscription(db, orph.id, "u-claim-2b", "p")).rejects.toThrow();
+  });
+
+  it("hasOtherActiveSubscription detects sibling active row", async () => {
+    await insertUser("u-multi-1");
+    const a = await repo.upsertLinkedSubscription(db, { userId: "u-multi-1", provider: "google_play", productId: "p", token: "t-A" });
+    await repo.updateSubscriptionState(db, a.subscription.id, { status: "active", currentPeriodEnd: new Date(Date.now() + 86400000) });
+    const b = await repo.upsertLinkedSubscription(db, { userId: "u-multi-1", provider: "google_play", productId: "p", token: "t-B" });
+    expect(await repo.hasOtherActiveSubscription(db, "u-multi-1", b.subscription.id)).toBe(true);
+  });
+
+  it("hasOtherActiveSubscription returns false when only this subscription is active", async () => {
+    await insertUser("u-multi-2");
+    const a = await repo.upsertLinkedSubscription(db, { userId: "u-multi-2", provider: "google_play", productId: "p", token: "t-only" });
+    await repo.updateSubscriptionState(db, a.subscription.id, { status: "active" });
+    expect(await repo.hasOtherActiveSubscription(db, "u-multi-2", a.subscription.id)).toBe(false);
+  });
+
+  it("listUnprocessedEventsForToken returns rows oldest-first, processed rows excluded", async () => {
+    await repo.insertEvent(db, { provider: "google_play", messageId: "m-a", eventType: "PURCHASED", purchaseToken: "t-X", payload: {} });
+    await new Promise((r) => setTimeout(r, 10));
+    const ev2 = await repo.insertEvent(db, { provider: "google_play", messageId: "m-b", eventType: "RENEWED", purchaseToken: "t-X", payload: {} });
+    await repo.markEventProcessed(db, ev2!.id);
+    const unprocessed = await repo.listUnprocessedEventsForToken(db, "google_play", "t-X");
+    expect(unprocessed).toHaveLength(1);
+    expect(unprocessed[0]!.messageId).toBe("m-a");
+  });
+});
+```
+
+- [ ] **Step 4.3: Run tests, commit**
+
+```bash
+cd apps/server && bun test src/features/billing/billing.repository.integration.test.ts
+```
+Expected: 8 pass.
+
+```bash
+git add apps/server/src/features/billing/billing.repository.ts apps/server/src/features/billing/billing.repository.integration.test.ts
+git commit -m "feat(billing): repository — event dedup, subscription upsert, orphan claim, multi-sub guard"
+```
+
+---
+
+## Task 5 — Service with `applyDecodedEvent` shared state machine
+
+**Files:**
+- Create: `apps/server/src/features/billing/billing.service.ts`
+- Create: `apps/server/src/features/billing/billing.service.test.ts`
+
+- [ ] **Step 5.1: Implement service**
+
+Create `apps/server/src/features/billing/billing.service.ts`:
+
+```ts
+import { ok, err, type Result } from "neverthrow";
+import { AppError, ConflictError } from "../../utils/errors";
+import { DEFAULT_SUBSCRIPTION_PERIOD_MS, type GooglePlayLinkResponse, type SubscriptionStatus } from "@pruvi/shared";
+import type { BillingRepository, DbOrTx, SubscriptionRow } from "./billing.repository";
+import type { UltraService } from "../ultra/ultra.service";
+import type { DecodedGooglePlayEvent } from "./google-play.decoder";
+import { decodeGooglePlayPubSubEnvelope } from "./google-play.decoder";
+import type { db as DbClient } from "@pruvi/db";
+
+type Db = typeof DbClient;
+
+/** Effect to apply AFTER the transaction commits (two-phase pattern per spec §7.6). */
+type PostCommitUltraEffect =
+  | { kind: "grant"; userId: string; expiresAt: Date }
+  | { kind: "revoke_if_no_other_active"; userId: string; excludeSubscriptionId: number }
+  | { kind: "none" };
+
+export class BillingService {
+  constructor(
+    private db: Db,
+    private repo: BillingRepository,
+    private ultra: UltraService,
+  ) {}
+
+  /** Webhook entry point. Returns the response payload; always 200 on accepted shapes.
+   *  Auth + envelope-shape validation happens in the route. */
+  async processWebhookEnvelope(envelope: unknown): Promise<Result<{ messageId: string; kind: string }, AppError>> {
+    let decoded: DecodedGooglePlayEvent;
+    try {
+      decoded = decodeGooglePlayPubSubEnvelope(envelope);
+    } catch (e) {
+      return err(new AppError(`MALFORMED_ENVELOPE: ${(e as Error).message}`, 200, "MALFORMED_ENVELOPE"));
+    }
+
+    if (decoded.kind === "test") {
+      // Record audit row with no purchase token; idempotent on messageId.
+      await this.repo.insertEvent(this.db, {
+        provider: "google_play",
+        messageId: decoded.messageId,
+        eventType: "TEST",
+        purchaseToken: null,
+        payload: { kind: "test" },
+      });
+      return ok({ messageId: decoded.messageId, kind: "test" });
+    }
+
+    const effect = await this.db.transaction(async (tx) => {
+      const eventType =
+        decoded.kind === "subscription" ? decoded.notificationTypeName : `UNKNOWN_${decoded.notificationType}`;
+      const inserted = await this.repo.insertEvent(tx, {
+        provider: "google_play",
+        messageId: decoded.messageId,
+        eventType,
+        purchaseToken: decoded.purchaseToken,
+        payload: decoded as unknown as Record<string, unknown>,
+      });
+      if (!inserted) {
+        // Duplicate delivery — already processed (or processed previously). No-op.
+        return { kind: "none" } as PostCommitUltraEffect;
+      }
+
+      if (decoded.kind === "unknown") {
+        await this.repo.markEventProcessed(tx, inserted.id);
+        return { kind: "none" };
+      }
+
+      // Find or create subscription row.
+      let sub = await this.repo.findSubscriptionByToken(tx, "google_play", decoded.purchaseToken);
+      if (!sub) {
+        sub = await this.repo.createOrphanSubscription(tx, "google_play", decoded.purchaseToken);
+      }
+
+      const { newStatus, newPeriodEnd, ultraEffect } = this.applyDecodedEvent(decoded, sub);
+      await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
+
+      // If subscription has no user yet, leave processed_at = NULL so link can replay.
+      if (sub.userId === null) {
+        return { kind: "none" };
+      }
+
+      await this.repo.markEventProcessed(tx, inserted.id);
+      return ultraEffect;
+    });
+
+    await this.applyUltraEffect(effect);
+    return ok({ messageId: decoded.messageId, kind: decoded.kind });
+  }
+
+  /** Link entry point: associates a purchase token with the authenticated user and replays parked events. */
+  async linkGooglePlayPurchase(
+    userId: string,
+    body: { purchaseToken: string; productId: string },
+  ): Promise<Result<GooglePlayLinkResponse, AppError>> {
+    const effects: PostCommitUltraEffect[] = [];
+    const finalRow = await this.db.transaction(async (tx) => {
+      const existing = await this.repo.findSubscriptionByToken(tx, "google_play", body.purchaseToken);
+      let sub: SubscriptionRow;
+      if (!existing) {
+        const created = await this.repo.upsertLinkedSubscription(tx, {
+          userId, provider: "google_play", productId: body.productId, token: body.purchaseToken,
+        });
+        sub = created.subscription;
+      } else if (existing.userId !== null && existing.userId !== userId) {
+        throw new ConflictError("PURCHASE_TOKEN_OWNED_BY_OTHER_USER");
+      } else if (existing.userId === userId) {
+        sub = existing;
+      } else {
+        // Orphan claim
+        sub = await this.repo.claimOrphanSubscription(tx, existing.id, userId, body.productId);
+      }
+
+      // Replay parked events for this token (only if we just claimed an orphan or first-link).
+      const parked = await this.repo.listUnprocessedEventsForToken(tx, "google_play", body.purchaseToken);
+      for (const event of parked) {
+        // Reconstruct the decoded event from the audit payload.
+        const decoded = event.payload as unknown as DecodedGooglePlayEvent;
+        if (decoded.kind !== "subscription") {
+          await this.repo.markEventProcessed(tx, event.id);
+          continue;
+        }
+        const fresh = await this.repo.findSubscriptionByToken(tx, "google_play", body.purchaseToken);
+        if (!fresh) throw new Error("replay: subscription disappeared mid-transaction");
+        sub = fresh;
+        const { newStatus, newPeriodEnd, ultraEffect } = this.applyDecodedEvent(decoded, sub);
+        await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
+        await this.repo.markEventProcessed(tx, event.id);
+        effects.push(ultraEffect);
+      }
+      const final = await this.repo.findSubscriptionByToken(tx, "google_play", body.purchaseToken);
+      if (!final) throw new Error("link: subscription disappeared mid-transaction");
+      return final;
+    }).catch((e) => {
+      if (e instanceof ConflictError) throw e;
+      throw e;
+    });
+
+    for (const e of effects) await this.applyUltraEffect(e);
+
+    return ok({
+      subscription: {
+        id: finalRow.id,
+        status: finalRow.status,
+        productId: finalRow.productId,
+        currentPeriodEnd: finalRow.currentPeriodEnd?.toISOString() ?? null,
+      },
+    });
+  }
+
+  /** Pure state-machine: maps (event, current subscription) → next state + ultra effect. NO DB writes. */
+  applyDecodedEvent(
+    decoded: DecodedGooglePlayEvent,
+    sub: SubscriptionRow,
+  ): { newStatus: SubscriptionStatus; newPeriodEnd: Date | null; ultraEffect: PostCommitUltraEffect } {
+    if (decoded.kind !== "subscription") {
+      return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+    }
+    const now = new Date();
+    const defaultEnd = new Date(now.getTime() + DEFAULT_SUBSCRIPTION_PERIOD_MS);
+    const name = decoded.notificationTypeName;
+    const grant = (end: Date): PostCommitUltraEffect =>
+      sub.userId !== null ? { kind: "grant", userId: sub.userId, expiresAt: end } : { kind: "none" };
+    const revoke = (): PostCommitUltraEffect =>
+      sub.userId !== null
+        ? { kind: "revoke_if_no_other_active", userId: sub.userId, excludeSubscriptionId: sub.id }
+        : { kind: "none" };
+
+    switch (name) {
+      case "PURCHASED":
+      case "RENEWED":
+      case "RECOVERED":
+      case "RESTARTED":
+        return { newStatus: "active", newPeriodEnd: defaultEnd, ultraEffect: grant(defaultEnd) };
+      case "IN_GRACE_PERIOD":
+        return { newStatus: "in_grace", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+      case "CANCELED":
+        return { newStatus: "canceled", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+      case "ON_HOLD":
+        return { newStatus: "on_hold", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "PAUSED":
+        return { newStatus: "paused", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "EXPIRED":
+        return { newStatus: "expired", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "REVOKED":
+        return { newStatus: "revoked", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "PRICE_CHANGE_CONFIRMED":
+      case "DEFERRED":
+      case "PAUSE_SCHEDULE_CHANGED":
+      case "ITEMS_CHANGED":
+      case "CANCELLATION_SCHEDULED":
+      case "PRICE_CHANGE_UPDATED":
+      case "PENDING_PURCHASE_CANCELED":
+      case "PRICE_STEP_UP_CONSENT_UPDATED":
+        return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+    }
+  }
+
+  private async applyUltraEffect(effect: PostCommitUltraEffect): Promise<void> {
+    if (effect.kind === "grant") {
+      await this.ultra.grant(effect.userId, effect.expiresAt);
+    } else if (effect.kind === "revoke_if_no_other_active") {
+      const hasOther = await this.repo.hasOtherActiveSubscription(this.db, effect.userId, effect.excludeSubscriptionId);
+      if (!hasOther) await this.ultra.revoke(effect.userId);
+    }
+  }
+}
+```
+
+- [ ] **Step 5.2: Failing service tests (mocked repo + ultra)**
+
+Create `apps/server/src/features/billing/billing.service.test.ts`. Cover:
+1. **PURCHASED webhook on a linked subscription**: state→active, currentPeriodEnd≈now+30d, ultra.grant called with that expiry.
+2. **PURCHASED on no-existing-subscription (pre-link)**: creates orphan, applies state, NO grant called.
+3. **EXPIRED on active with NO other active subscriptions**: state→expired, ultra.revoke called.
+4. **EXPIRED on active WITH another active subscription**: state→expired, ultra.revoke NOT called (multi-sub guard).
+5. **CANCELED**: state→canceled, no Ultra change.
+6. **Duplicate messageId**: second call returns ok with no effect; ultra.grant NOT called second time.
+7. **Unknown notificationType**: audit row inserted with `UNKNOWN_99` type, no state change, no grant/revoke.
+8. **`linkGooglePlayPurchase` happy path on token already owned by same user**: returns existing subscription, no error.
+9. **`linkGooglePlayPurchase` on token owned by other user**: throws ConflictError.
+10. **`linkGooglePlayPurchase` after pre-link webhook**: claims orphan, replays parked PURCHASED event, ultra.grant called.
+
+For each, build a `buildSut` helper similar to Phase 2E.3's service test pattern, mocking `BillingRepository` and `UltraService`. The service's `db` reference can be a stub since the mocked repo intercepts all calls — but the service does call `this.db.transaction(async (tx) => ...)`. Mock the transaction to immediately invoke the callback with `tx = mockRepo` (or use a thin `txRunner` injection — but staying consistent with existing pattern, mock `db.transaction` to call the callback with a stub).
+
+The mocked db pattern:
+```ts
+const db = { transaction: vi.fn(async (cb: (tx: any) => any) => cb(mockTx)) };
+```
+
+- [ ] **Step 5.3: Run tests, commit**
+
+```bash
+cd apps/server && bun test src/features/billing/
+```
+Expected: 10 unit + 8 integration + 10 decoder = 28 pass.
+
+```bash
+git add apps/server/src/features/billing/billing.service.ts apps/server/src/features/billing/billing.service.test.ts
+git commit -m "feat(billing): service — applydecodedevent state machine, two-phase ultra effect, multi-sub revoke guard, link-time replay"
+```
+
+---
+
+## Task 6 — Webhook route + Link route + plugin registration
+
+**Files:**
+- Create: `apps/server/src/features/billing/billing.route.ts`
+- Create: `apps/server/src/features/billing/index.ts`
+- Modify: `apps/server/src/index.ts`
+
+- [ ] **Step 6.1: Implement routes**
+
+Create `apps/server/src/features/billing/billing.route.ts`:
+
+```ts
+import { z } from "zod";
+import { timingSafeEqual } from "node:crypto";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import type { FastifyRequest, FastifyReply } from "fastify";
+import { GooglePlayLinkBodySchema, GooglePlayLinkResponseSchema } from "@pruvi/shared";
+import { env } from "@pruvi/env/server";
+import { db } from "@pruvi/db";
+import { successResponse, unwrapResult } from "../../types";
+import { BillingRepository } from "./billing.repository";
+import { BillingService } from "./billing.service";
+import { UltraRepository } from "../ultra/ultra.repository";
+import { UltraService } from "../ultra/ultra.service";
+
+const repo = new BillingRepository(db);
+const ultra = new UltraService(new UltraRepository(db));
+const service = new BillingService(db, repo, ultra);
+
+async function webhookGuard(request: FastifyRequest, reply: FastifyReply) {
+  if (!env.GOOGLE_PLAY_WEBHOOK_TOKEN) {
+    reply.code(503);
+    throw new Error("WEBHOOK_DISABLED");
+  }
+  const provided = request.headers["x-pruvi-webhook-token"];
+  if (typeof provided !== "string") {
+    reply.code(401);
+    throw new Error("UNAUTHORIZED");
+  }
+  const a = Buffer.from(provided);
+  const b = Buffer.from(env.GOOGLE_PLAY_WEBHOOK_TOKEN);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    reply.code(401);
+    throw new Error("UNAUTHORIZED");
+  }
+}
+
+export const billingRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.post(
+    "/webhooks/google-play",
+    {
+      schema: {
+        body: z.unknown(),
+        response: {
+          200: z.object({
+            success: z.literal(true),
+            data: z.object({ received: z.boolean(), messageId: z.string().optional(), kind: z.string().optional(), error: z.string().optional() }),
+          }),
+        },
+      },
+      preHandler: [webhookGuard],
+    },
+    async (request, reply) => {
+      const result = await service.processWebhookEnvelope(request.body);
+      if (result.isErr()) {
+        const error = result.error;
+        // For MALFORMED_ENVELOPE we still return 200 so Pub/Sub stops retrying.
+        if (error.code === "MALFORMED_ENVELOPE") {
+          fastify.log.warn({ err: error.message }, "google-play webhook malformed envelope");
+          return successResponse({ received: false, error: "MALFORMED_ENVELOPE" });
+        }
+        fastify.log.error({ err: error.message }, "google-play webhook processing failed");
+        return successResponse({ received: false, error: "PROCESSING_FAILED" });
+      }
+      return successResponse({ received: true, messageId: result.value.messageId, kind: result.value.kind });
+    },
+  );
+
+  fastify.post(
+    "/billing/google-play/link",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        body: GooglePlayLinkBodySchema,
+        response: { 200: z.object({ success: z.literal(true), data: GooglePlayLinkResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const data = unwrapResult(await service.linkGooglePlayPurchase(request.userId, request.body)).data;
+      return successResponse(data);
+    },
+  );
+};
+```
+
+Create `apps/server/src/features/billing/index.ts`:
+```ts
+export { billingRoutes } from "./billing.route";
+```
+
+- [ ] **Step 6.2: Register routes**
+
+In `apps/server/src/index.ts`, add the import and registration after `simuladosRoutes`:
+```ts
+import { billingRoutes } from "./features/billing";
+// ...
+await app.register(billingRoutes);
+```
+
+- [ ] **Step 6.3: Run typecheck + tests, commit**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi && pnpm -F server test src/features/billing/ && pnpm check-types 2>&1 | grep "billing\|simulados" || true
+```
+
+Expected: tests green; no NEW type errors in `billing/` (pre-existing errors in unrelated files are acceptable).
+
+```bash
+git add apps/server/src/features/billing/billing.route.ts apps/server/src/features/billing/index.ts apps/server/src/index.ts
+git commit -m "feat(billing): routes — webhook with shared-secret guard, link endpoint"
+```
+
+---
+
+## Task 7 — Push, open PR
+
+- [ ] **Step 7.1: Full test sweep**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi && pnpm -F server test
+```
+
+Expected: all green (pre-existing failures in unrelated tests are acceptable but flag them).
+
+- [ ] **Step 7.2: Push + PR**
+
+```bash
+git push -u origin feature/phase-2e4-billing-webhooks
+gh pr create --title "feat: phase 2e.4 — google play billing webhooks (ultra entitlement)" --body "$(cat <<'EOF'
+## Summary
+- New `billing` module wires Google Play RTDN → UltraService.grant/revoke
+- `subscription` table tracks per-user-per-token state; `billing_event` is an append-only audit log dedup'd on `(provider, message_id)`
+- Shared `applyDecodedEvent` state machine used by both webhook handler and link-time replay
+- Pre-link race resolved via orphan-subscription pattern + parked-event replay on link
+- Multi-subscription revoke guard prevents EXPIRED on old subscription from stripping Ultra from new one
+- Optional `GOOGLE_PLAY_WEBHOOK_TOKEN` env var; missing → 503; mismatch → 401
+- App Store deferred to 2E.5; schema accommodates `app_store` provider without migration
+
+## Workflow gates
+- ✅ Gate A — spec self-review (6 blockers → spec v2)
+- ✅ Gate B — plan self-review
+- ✅ Gate C — per-task review after each commit
+- ✅ Gate D — final spec-coverage review
+
+## Test plan
+- [ ] Decoder unit tests pass (10 cases including testNotification, unknown type, malformed envelope)
+- [ ] Repository integration tests pass (8 cases including dedup, orphan claim, multi-sub guard)
+- [ ] Service unit tests pass (10 cases including multi-sub guard, link-time replay)
+- [ ] Manual: POST /webhooks/google-play with missing header → 401; with bad token → 401; with no env token → 503
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (post Gate B)
+
+1. **Spec coverage** A1–A19: A1 → T6; A2 → T6; A3 → T4/T5; A4 → T5/T6; A5 → T5; A6 → T5; A7 → T5; A8 → T5; A9 → T5; A10 → T4/T5; A11 → T5; A12 → T2; A13 → T2; A14 → T5/T6 (structured logs); A15 → T4/T5 (multi-sub guard); A16 → T5 (shared `applyDecodedEvent`); A17 → T1 (env declaration); A18 → T2 (db-helpers update); A19 → T3/T5 (unknown branch).
+2. **Placeholder scan:** No TBDs.
+3. **Type consistency:** `BillingProvider`/`SubscriptionStatus` come from `@pruvi/shared` consistently across schema, repo, service, decoder.
+4. **No raw SQL where Drizzle has helpers** (except the `IN (...)` for multi-sub check — could be `inArray` but a sql template is acceptable for the `IN` with literal strings).
+5. **Migration safety:** drizzle-kit generates `0010_*`; no manual SQL edits.

--- a/docs/superpowers/plans/2026-05-12-phase-2e4-billing-webhooks.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e4-billing-webhooks.md
@@ -10,6 +10,8 @@
 
 **Authoritative spec:** `docs/superpowers/specs/2026-05-12-phase-2e4-billing-webhooks-design.md` (v2 post Gate A).
 
+**Plan revision:** v2 post Gate B — webhookGuard now throws AppError (was: plain Error → 500); multi-subscription GRANT guard added (was: only REVOKE guard); partial index `billing_event_unprocessed_idx` added to schema; concrete test code provided for the two highest-risk cases (multi-sub guard, link-time replay); Drizzle text-enum CHECK-constraint absence acknowledged.
+
 ---
 
 ## Task 1 — Env, shared schemas, notification-type enum
@@ -174,7 +176,7 @@ git commit -m "feat(shared,env): billing module — providers, statuses, google 
 Create `packages/db/src/schema/billing.ts`:
 
 ```ts
-import { relations } from "drizzle-orm";
+import { relations, isNull } from "drizzle-orm";
 import { index, integer, jsonb, pgTable, serial, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 
@@ -217,6 +219,9 @@ export const billingEvent = pgTable(
   (t) => [
     uniqueIndex("billing_event_provider_message_uq").on(t.provider, t.messageId),
     index("billing_event_token_idx").on(t.purchaseToken),
+    // Partial index — spec §5.2. Speeds up `listUnprocessedEventsForToken` on the
+    // link-replay hot path. Without it, that query degrades to a full scan.
+    index("billing_event_unprocessed_idx").on(t.processedAt).where(isNull(t.processedAt)),
   ],
 );
 
@@ -238,7 +243,16 @@ export * from "./billing";
 cd /Users/cesarcamillo/dev/pruvi && pnpm -F db db:generate
 ```
 
-(If the package script name differs, check `packages/db/package.json`.) Verify the generated `0010_*.sql` contains both tables with the expected constraints (CHECK for provider + status enums, UNIQUE indexes, ON DELETE SET NULL for user_id). If unrelated diffs appear, STOP and report BLOCKED.
+(If the package script name differs, check `packages/db/package.json`.) Verify the generated `0010_*.sql` contains:
+- Both `subscription` and `billing_event` tables with all columns.
+- UNIQUE indexes `subscription_provider_token_uq` and `billing_event_provider_message_uq`.
+- Plain index `subscription_user_idx`, `subscription_status_idx`, `billing_event_token_idx`.
+- Partial index `billing_event_unprocessed_idx ON billing_event (processed_at) WHERE processed_at IS NULL`.
+- `user_id` REFERENCES `"user"(id)` `ON DELETE SET NULL`.
+
+**Known Drizzle limitation:** `text("col", { enum: [...] })` is TypeScript-level only — it does NOT emit `CHECK (col IN (...))` constraints in the generated SQL. The spec describes CHECK constraints as a "safety net" but Drizzle does not generate them. Accepted gap for v1; application-level enum validation (Zod schemas in `@pruvi/shared`) is the primary guard. If a future hardening pass wants real DB CHECKs, they must be added by manually editing the migration or via a follow-up SQL migration. Do NOT add CHECK constraints manually now — keep the migration as drizzle-kit emits it for reproducibility.
+
+If unrelated diffs appear, STOP and report BLOCKED.
 
 - [ ] **Step 2.4: Update `cleanupTestDb`**
 
@@ -688,6 +702,31 @@ export class BillingRepository {
     return rows.length > 0;
   }
 
+  /** Returns the maximum `current_period_end` across all OTHER active/in_grace subscriptions for this user.
+   *  Used by the multi-subscription GRANT guard (spec §7.2): when granting Ultra, we must use
+   *  MAX(allActive.currentPeriodEnd) so a short renewal doesn't truncate a longer active plan. */
+  async getMaxOtherActivePeriodEnd(
+    tx: DbOrTx,
+    userId: string,
+    excludeSubscriptionId: number,
+  ): Promise<Date | null> {
+    const rows = await tx
+      .select({ end: subscription.currentPeriodEnd })
+      .from(subscription)
+      .where(
+        and(
+          eq(subscription.userId, userId),
+          ne(subscription.id, excludeSubscriptionId),
+          sql`${subscription.status} IN ('active','in_grace')`,
+        ),
+      );
+    let max: Date | null = null;
+    for (const r of rows) {
+      if (r.end && (!max || r.end > max)) max = r.end;
+    }
+    return max;
+  }
+
   private toSubscription(r: typeof subscription.$inferSelect): SubscriptionRow {
     return {
       id: r.id,
@@ -845,9 +884,13 @@ import type { db as DbClient } from "@pruvi/db";
 
 type Db = typeof DbClient;
 
-/** Effect to apply AFTER the transaction commits (two-phase pattern per spec §7.6). */
+/** Effect to apply AFTER the transaction commits (two-phase pattern per spec §7.6).
+ *  Both `grant` and `revoke` variants carry `excludeSubscriptionId` so the post-commit
+ *  step can consult OTHER active subscriptions (the multi-sub guards from §7.2):
+ *   - grant: final expiry = MAX(effect.expiresAt, otherActive.currentPeriodEnd) — never truncates a longer plan.
+ *   - revoke: revoke only if no other active subscription exists. */
 type PostCommitUltraEffect =
-  | { kind: "grant"; userId: string; expiresAt: Date }
+  | { kind: "grant"; userId: string; expiresAt: Date; excludeSubscriptionId: number }
   | { kind: "revoke_if_no_other_active"; userId: string; excludeSubscriptionId: number }
   | { kind: "none" };
 
@@ -994,7 +1037,9 @@ export class BillingService {
     const defaultEnd = new Date(now.getTime() + DEFAULT_SUBSCRIPTION_PERIOD_MS);
     const name = decoded.notificationTypeName;
     const grant = (end: Date): PostCommitUltraEffect =>
-      sub.userId !== null ? { kind: "grant", userId: sub.userId, expiresAt: end } : { kind: "none" };
+      sub.userId !== null
+        ? { kind: "grant", userId: sub.userId, expiresAt: end, excludeSubscriptionId: sub.id }
+        : { kind: "none" };
     const revoke = (): PostCommitUltraEffect =>
       sub.userId !== null
         ? { kind: "revoke_if_no_other_active", userId: sub.userId, excludeSubscriptionId: sub.id }
@@ -1032,9 +1077,18 @@ export class BillingService {
 
   private async applyUltraEffect(effect: PostCommitUltraEffect): Promise<void> {
     if (effect.kind === "grant") {
-      await this.ultra.grant(effect.userId, effect.expiresAt);
+      // Multi-sub GRANT guard (spec §7.2): the final expiry must be the MAX across this
+      // subscription's expiry and the currentPeriodEnd of any other active/in_grace subscriptions
+      // for the same user. A renewal of a short plan must NEVER truncate a long active plan.
+      const otherMax = await this.repo.getMaxOtherActivePeriodEnd(
+        this.db, effect.userId, effect.excludeSubscriptionId,
+      );
+      const finalEnd = otherMax && otherMax > effect.expiresAt ? otherMax : effect.expiresAt;
+      await this.ultra.grant(effect.userId, finalEnd);
     } else if (effect.kind === "revoke_if_no_other_active") {
-      const hasOther = await this.repo.hasOtherActiveSubscription(this.db, effect.userId, effect.excludeSubscriptionId);
+      const hasOther = await this.repo.hasOtherActiveSubscription(
+        this.db, effect.userId, effect.excludeSubscriptionId,
+      );
       if (!hasOther) await this.ultra.revoke(effect.userId);
     }
   }
@@ -1043,24 +1097,182 @@ export class BillingService {
 
 - [ ] **Step 5.2: Failing service tests (mocked repo + ultra)**
 
-Create `apps/server/src/features/billing/billing.service.test.ts`. Cover:
-1. **PURCHASED webhook on a linked subscription**: state→active, currentPeriodEnd≈now+30d, ultra.grant called with that expiry.
-2. **PURCHASED on no-existing-subscription (pre-link)**: creates orphan, applies state, NO grant called.
-3. **EXPIRED on active with NO other active subscriptions**: state→expired, ultra.revoke called.
-4. **EXPIRED on active WITH another active subscription**: state→expired, ultra.revoke NOT called (multi-sub guard).
-5. **CANCELED**: state→canceled, no Ultra change.
-6. **Duplicate messageId**: second call returns ok with no effect; ultra.grant NOT called second time.
-7. **Unknown notificationType**: audit row inserted with `UNKNOWN_99` type, no state change, no grant/revoke.
-8. **`linkGooglePlayPurchase` happy path on token already owned by same user**: returns existing subscription, no error.
-9. **`linkGooglePlayPurchase` on token owned by other user**: throws ConflictError.
-10. **`linkGooglePlayPurchase` after pre-link webhook**: claims orphan, replays parked PURCHASED event, ultra.grant called.
+Create `apps/server/src/features/billing/billing.service.test.ts`. Use the shared mock harness below, then implement all 10 cases. The two MUST-be-fleshed-out cases (multi-sub guard, link-time replay) are provided fully; the others follow the same shape.
 
-For each, build a `buildSut` helper similar to Phase 2E.3's service test pattern, mocking `BillingRepository` and `UltraService`. The service's `db` reference can be a stub since the mocked repo intercepts all calls — but the service does call `this.db.transaction(async (tx) => ...)`. Mock the transaction to immediately invoke the callback with `tx = mockRepo` (or use a thin `txRunner` injection — but staying consistent with existing pattern, mock `db.transaction` to call the callback with a stub).
-
-The mocked db pattern:
 ```ts
-const db = { transaction: vi.fn(async (cb: (tx: any) => any) => cb(mockTx)) };
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BillingService } from "./billing.service";
+import type { BillingRepository, SubscriptionRow, BillingEventRow } from "./billing.repository";
+import type { UltraService } from "../ultra/ultra.service";
+import type { db as DbClient } from "@pruvi/db";
+
+type Mocked<T> = { [K in keyof T]: T[K] extends (...a: infer A) => infer R ? ReturnType<typeof vi.fn<(...a: A) => R>> : T[K] };
+
+function buildSut(opts: {
+  insertEvent?: BillingEventRow | null;
+  findSubscription?: SubscriptionRow | null;
+  createOrphan?: SubscriptionRow;
+  updateState?: SubscriptionRow;
+  listUnprocessed?: BillingEventRow[];
+  hasOtherActive?: boolean;
+  maxOtherEnd?: Date | null;
+  upsertLinked?: { subscription: SubscriptionRow; created: boolean };
+  claimOrphan?: SubscriptionRow;
+} = {}) {
+  const repo = {
+    insertEvent: vi.fn().mockResolvedValue(opts.insertEvent ?? { id: 1, provider: "google_play", messageId: "m1", eventType: "PURCHASED", purchaseToken: "tok", payload: {}, receivedAt: new Date(), processedAt: null, processingError: null }),
+    findSubscriptionByToken: vi.fn().mockResolvedValue(opts.findSubscription ?? null),
+    createOrphanSubscription: vi.fn().mockResolvedValue(opts.createOrphan ?? { id: 10, userId: null, provider: "google_play", productId: "", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: null }),
+    upsertLinkedSubscription: vi.fn().mockResolvedValue(opts.upsertLinked ?? { subscription: { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() }, created: true }),
+    claimOrphanSubscription: vi.fn().mockResolvedValue(opts.claimOrphan ?? { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() }),
+    updateSubscriptionState: vi.fn().mockResolvedValue(opts.updateState ?? { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(Date.now() + 30 * 86400000), linkedAt: new Date() }),
+    markEventProcessed: vi.fn().mockResolvedValue(undefined),
+    listUnprocessedEventsForToken: vi.fn().mockResolvedValue(opts.listUnprocessed ?? []),
+    hasOtherActiveSubscription: vi.fn().mockResolvedValue(opts.hasOtherActive ?? false),
+    getMaxOtherActivePeriodEnd: vi.fn().mockResolvedValue(opts.maxOtherEnd ?? null),
+  } as unknown as Mocked<BillingRepository>;
+  const ultra = {
+    grant: vi.fn().mockResolvedValue(undefined),
+    revoke: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Mocked<UltraService>;
+  const db = {
+    transaction: vi.fn(async (cb: (tx: any) => Promise<any>) => cb(repo)),
+  } as unknown as typeof DbClient;
+  const service = new BillingService(db, repo as unknown as BillingRepository, ultra as unknown as UltraService);
+  return { service, repo, ultra, db };
+}
+
+function buildEnvelope(notificationType: number, purchaseToken = "tok", messageId = "msg-1") {
+  const inner = { packageName: "com.pruvi.app", subscriptionNotification: { notificationType, purchaseToken, version: "1.0" } };
+  return { message: { messageId, publishTime: "2026-05-12T10:00:00Z", data: Buffer.from(JSON.stringify(inner)).toString("base64") } };
+}
+
+describe("BillingService", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Case 1
+  it("PURCHASED on linked subscription: active + grant called with ~now+30d", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    const r = await service.processWebhookEnvelope(buildEnvelope(4));
+    expect(r.isOk()).toBe(true);
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "active" }));
+    expect(ultra.grant).toHaveBeenCalledTimes(1);
+    const grantedExpiry = ultra.grant.mock.calls[0]![1] as Date;
+    const expected = Date.now() + 30 * 86400000;
+    expect(Math.abs(grantedExpiry.getTime() - expected)).toBeLessThan(60_000);
+  });
+
+  // Case 2
+  it("PURCHASED with NO existing subscription: orphan created, NO grant", async () => {
+    const { service, ultra, repo } = buildSut({ findSubscription: null });
+    await service.processWebhookEnvelope(buildEnvelope(4));
+    expect(repo.createOrphanSubscription).toHaveBeenCalled();
+    expect(ultra.grant).not.toHaveBeenCalled();
+  });
+
+  // Case 3
+  it("EXPIRED with no other active subs: revoke called", async () => {
+    const active: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra } = buildSut({ findSubscription: active, hasOtherActive: false });
+    await service.processWebhookEnvelope(buildEnvelope(13));
+    expect(ultra.revoke).toHaveBeenCalledWith("u1");
+  });
+
+  // Case 4 — MULTI-SUB REVOKE GUARD (critical)
+  it("EXPIRED with another active subscription: revoke NOT called (multi-sub guard)", async () => {
+    const active: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: active, hasOtherActive: true });
+    await service.processWebhookEnvelope(buildEnvelope(13));
+    expect(repo.hasOtherActiveSubscription).toHaveBeenCalledWith(expect.anything(), "u1", 10);
+    expect(ultra.revoke).not.toHaveBeenCalled();
+  });
+
+  // Bonus: MULTI-SUB GRANT GUARD (also critical)
+  it("PURCHASED with another active sub having LATER period end: grant uses MAX expiry, not now+30d", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() };
+    const farFuture = new Date(Date.now() + 365 * 86400000); // 1 year out
+    const { service, ultra } = buildSut({ findSubscription: linked, maxOtherEnd: farFuture });
+    await service.processWebhookEnvelope(buildEnvelope(4));
+    expect(ultra.grant).toHaveBeenCalledWith("u1", farFuture);
+  });
+
+  // Case 5
+  it("CANCELED: state=canceled, no Ultra change", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    await service.processWebhookEnvelope(buildEnvelope(3));
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "canceled" }));
+    expect(ultra.grant).not.toHaveBeenCalled();
+    expect(ultra.revoke).not.toHaveBeenCalled();
+  });
+
+  // Case 6
+  it("Duplicate messageId: second call no-op (insertEvent returns null)", async () => {
+    const { service, ultra } = buildSut({ insertEvent: null });
+    await service.processWebhookEnvelope(buildEnvelope(4));
+    expect(ultra.grant).not.toHaveBeenCalled();
+  });
+
+  // Case 7
+  it("Unknown notificationType: UNKNOWN_99 event recorded, no state mutation", async () => {
+    const { service, ultra, repo } = buildSut();
+    await service.processWebhookEnvelope(buildEnvelope(99));
+    expect(repo.insertEvent).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: "UNKNOWN_99" }));
+    expect(repo.updateSubscriptionState).not.toHaveBeenCalled();
+    expect(ultra.grant).not.toHaveBeenCalled();
+  });
+
+  // Case 8
+  it("link: same user re-call returns existing subscription, no error", async () => {
+    const existing: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service } = buildSut({ findSubscription: existing });
+    const r = await service.linkGooglePlayPurchase("u1", { purchaseToken: "tok", productId: "p" });
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value.subscription.id).toBe(10);
+  });
+
+  // Case 9
+  it("link: token owned by other user throws ConflictError", async () => {
+    const owned: SubscriptionRow = { id: 10, userId: "OTHER", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service } = buildSut({ findSubscription: owned });
+    await expect(service.linkGooglePlayPurchase("u1", { purchaseToken: "tok", productId: "p" })).rejects.toThrow(/PURCHASE_TOKEN_OWNED/);
+  });
+
+  // Case 10 — LINK-TIME REPLAY (critical)
+  it("link after pre-link webhook: claims orphan, replays parked PURCHASED, ultra.grant called", async () => {
+    const orphan: SubscriptionRow = { id: 10, userId: null, provider: "google_play", productId: "", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: null };
+    const claimed: SubscriptionRow = { ...orphan, userId: "u1", productId: "p", linkedAt: new Date() };
+    const parkedEvent: BillingEventRow = {
+      id: 5,
+      provider: "google_play",
+      messageId: "m-parked",
+      eventType: "PURCHASED",
+      purchaseToken: "tok",
+      payload: { kind: "subscription", messageId: "m-parked", notificationType: 4, notificationTypeName: "PURCHASED", purchaseToken: "tok", publishTime: "", packageName: "", eventTimeMillis: "" } as unknown as Record<string, unknown>,
+      receivedAt: new Date(Date.now() - 60_000),
+      processedAt: null,
+      processingError: null,
+    };
+    const afterUpdate: SubscriptionRow = { ...claimed, status: "active", currentPeriodEnd: new Date(Date.now() + 30 * 86400000) };
+
+    const { service, repo, ultra } = buildSut({ findSubscription: orphan, claimOrphan: claimed, listUnprocessed: [parkedEvent], updateState: afterUpdate });
+    // After claim, findSubscriptionByToken inside the replay loop should return the claimed row.
+    (repo.findSubscriptionByToken as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(orphan)     // first call: pre-claim
+      .mockResolvedValueOnce(claimed)    // inside replay loop: post-claim, before applyDecoded
+      .mockResolvedValueOnce(afterUpdate); // final read at end of transaction
+
+    const r = await service.linkGooglePlayPurchase("u1", { purchaseToken: "tok", productId: "p" });
+    expect(r.isOk()).toBe(true);
+    expect(repo.claimOrphanSubscription).toHaveBeenCalledWith(expect.anything(), 10, "u1", "p");
+    expect(repo.markEventProcessed).toHaveBeenCalledWith(expect.anything(), 5);
+    expect(ultra.grant).toHaveBeenCalledTimes(1);
+  });
+});
 ```
+
+The harness above is exhaustive: the implementer should drop it in verbatim and adjust mock specifics only if Drizzle's internal types force tweaks. The two critical cases (Case 4 multi-sub revoke guard, Case 10 link-time replay) and the bonus multi-sub grant guard test MUST appear with their assertions intact — those exercise the two highest-risk behaviors from Gate B.
 
 - [ ] **Step 5.3: Run tests, commit**
 
@@ -1096,6 +1308,7 @@ import { GooglePlayLinkBodySchema, GooglePlayLinkResponseSchema } from "@pruvi/s
 import { env } from "@pruvi/env/server";
 import { db } from "@pruvi/db";
 import { successResponse, unwrapResult } from "../../types";
+import { AppError, UnauthorizedError } from "../../utils/errors";
 import { BillingRepository } from "./billing.repository";
 import { BillingService } from "./billing.service";
 import { UltraRepository } from "../ultra/ultra.repository";
@@ -1105,21 +1318,20 @@ const repo = new BillingRepository(db);
 const ultra = new UltraService(new UltraRepository(db));
 const service = new BillingService(db, repo, ultra);
 
-async function webhookGuard(request: FastifyRequest, reply: FastifyReply) {
+// IMPORTANT: throw AppError subclasses so the project's error handler maps statusCode correctly.
+// Plain `throw new Error(...)` would fall through to the 500 branch regardless of reply.code().
+async function webhookGuard(request: FastifyRequest, _reply: FastifyReply) {
   if (!env.GOOGLE_PLAY_WEBHOOK_TOKEN) {
-    reply.code(503);
-    throw new Error("WEBHOOK_DISABLED");
+    throw new AppError("WEBHOOK_DISABLED", 503, "WEBHOOK_DISABLED");
   }
   const provided = request.headers["x-pruvi-webhook-token"];
   if (typeof provided !== "string") {
-    reply.code(401);
-    throw new Error("UNAUTHORIZED");
+    throw new UnauthorizedError("UNAUTHORIZED");
   }
   const a = Buffer.from(provided);
   const b = Buffer.from(env.GOOGLE_PLAY_WEBHOOK_TOKEN);
   if (a.length !== b.length || !timingSafeEqual(a, b)) {
-    reply.code(401);
-    throw new Error("UNAUTHORIZED");
+    throw new UnauthorizedError("UNAUTHORIZED");
   }
 }
 

--- a/docs/superpowers/specs/2026-05-12-phase-2e4-billing-webhooks-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e4-billing-webhooks-design.md
@@ -1,0 +1,284 @@
+# Phase 2E.4 — Billing Webhooks: Google Play (Design Spec)
+
+**Status:** v1
+**Date:** 2026-05-12
+**Branch:** `feature/phase-2e4-billing-webhooks`
+**Product source:** `pruvi-freatures.md` §5.1 (Ultra subscription, "Cobrança via Google Play / App Store billing")
+
+---
+
+## 1. Goal
+
+Wire Google Play Real-Time Developer Notifications (RTDN) to the existing Ultra entitlement so that subscription purchases, renewals, and cancellations grant or revoke Ultra automatically — replacing the current admin-only manual grant path.
+
+## 2. Non-goals
+
+- **App Store Server Notifications V2** integration. Deferred to Phase 2E.5. The data model and abstractions in this phase MUST accommodate a future App Store adapter without schema changes, but the App Store webhook endpoint and decoder are out of scope here.
+- **Google Play Developer API "subscriptionsv2.get" verification**. v1 trusts the webhook payload after secret verification. Adding a server-to-server verification call (to confirm the purchase token is real and current) is a deferred hardening step.
+- **Google Cloud Pub/Sub push-subscription integration with OIDC authentication**. v1 uses a shared-secret HMAC header (`X-Pruvi-Webhook-Token`) on the receiving endpoint. Real Pub/Sub OIDC auth is deferred to infrastructure ticket.
+- **Referral-shield reward** (§4 of product doc — "ganha +100 XP ou 1 escudo de streak"). Existing invitations grant XP only; converting to optional shield grant is deferred to a separate phase.
+- **Protect-streak push notification** (§5.3 — "Seu escudo protegeu seu streak de X dias!"). The shield auto-protect already exists; the push hook is deferred.
+- **Refund handling.** REVOKED notifications are processed (per §6 state table) but explicit one-time-purchase refunds (vs subscription refund) are not in scope (we have no one-time purchases yet).
+- **Price-change consent UX.** PRICE_CHANGE_CONFIRMED is treated as a no-op in v1.
+- **Family-share, promo codes, manual extensions.** Out of scope.
+
+## 3. Concepts
+
+- **Provider**: `"google_play"` (v1). The DB schema includes the field so `"app_store"` can be added later without migrations.
+- **Purchase token**: opaque string Google issues per (user, productId, subscription period). Stable across renewals for the same subscription instance — Google explicitly recommends using it as the long-term identifier.
+- **Linking**: After the client completes a purchase via the Google Play Billing SDK, it MUST call `POST /billing/google-play/link` with the `purchaseToken` and `productId` so the server can associate the token with the authenticated `userId`. Without linking, incoming webhook events for that token are stored as audit rows but cannot grant Ultra (no user attribution).
+- **Idempotency**: Each RTDN event arrives via Pub/Sub with a `messageId`. We dedupe on `(provider, message_id)` at the audit log level so retries do not double-process.
+
+## 4. Mechanic
+
+1. User purchases Ultra via the Google Play Billing SDK in the mobile app.
+2. Mobile app receives a `purchaseToken` and calls `POST /billing/google-play/link { purchaseToken, productId }`.
+3. Server upserts a `subscription` row keyed by `(provider, purchase_token)` with `user_id` set, `status = "pending"`, `product_id` set, `current_period_end = NULL`.
+4. Google Play eventually sends an RTDN to our Pub/Sub topic; Pub/Sub push delivery hits our webhook endpoint `POST /webhooks/google-play`.
+5. Webhook handler verifies the shared-secret header, decodes the base64 payload, deduplicates by `(provider, message_id)`, parses the `subscriptionNotification`, and dispatches based on `notificationType`.
+6. Each handled event records a `billing_event` audit row, optionally updates the `subscription` row, and optionally calls `UltraService.grant` or `UltraService.revoke`.
+7. The user's `users.isUltra` and `users.ultraExpiresAt` reflect the current entitlement.
+
+Race-safety: linking before the webhook fires is the expected order; the webhook fires before linking is also possible (especially in a slow-network scenario). The handler MUST store the event regardless of whether a `subscription` row exists; if no row exists yet, the audit row is parked with `user_id = NULL` and the subscription is **created** in `pending` state. When the link call later arrives, the existing `pending` subscription row is updated with the `user_id`, and any unprocessed audit rows for that token are replayed inside the same transaction (best-effort; documented as a known limit if Pub/Sub retries don't naturally redeliver).
+
+## 5. Data model
+
+### 5.1 `subscription`
+
+```sql
+CREATE TABLE subscription (
+  id                  SERIAL PRIMARY KEY,
+  user_id             TEXT REFERENCES "user"(id) ON DELETE SET NULL,
+  provider            TEXT NOT NULL CHECK (provider IN ('google_play','app_store')),
+  product_id          TEXT NOT NULL,
+  purchase_token      TEXT NOT NULL,
+  status              TEXT NOT NULL CHECK (status IN ('pending','active','in_grace','on_hold','paused','canceled','expired','revoked')),
+  current_period_end  TIMESTAMP WITH TIME ZONE,
+  linked_at           TIMESTAMP WITH TIME ZONE,
+  created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  CONSTRAINT subscription_provider_token_uq UNIQUE (provider, purchase_token)
+);
+CREATE INDEX subscription_user_idx ON subscription (user_id);
+CREATE INDEX subscription_status_idx ON subscription (status);
+```
+
+Notes:
+- `user_id` is nullable to handle the race where a webhook arrives before linking.
+- `ON DELETE SET NULL` so deleting a user (LGPD/right-to-be-forgotten) preserves the audit subscription record without orphan FK errors.
+- `status` transitions are validated in `BillingService`; the DB CHECK is a safety net.
+
+### 5.2 `billing_event`
+
+```sql
+CREATE TABLE billing_event (
+  id            SERIAL PRIMARY KEY,
+  provider      TEXT NOT NULL CHECK (provider IN ('google_play','app_store')),
+  message_id    TEXT NOT NULL,           -- Pub/Sub message ID (or App Store notificationUUID later)
+  event_type    TEXT NOT NULL,           -- e.g. "SUBSCRIPTION_PURCHASED"
+  purchase_token TEXT,                   -- nullable: some events don't carry a token (test/init)
+  payload       JSONB NOT NULL,
+  received_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  processed_at  TIMESTAMP WITH TIME ZONE,
+  processing_error TEXT,
+  CONSTRAINT billing_event_provider_message_uq UNIQUE (provider, message_id)
+);
+CREATE INDEX billing_event_token_idx ON billing_event (purchase_token);
+CREATE INDEX billing_event_unprocessed_idx ON billing_event (processed_at) WHERE processed_at IS NULL;
+```
+
+Notes:
+- `UNIQUE (provider, message_id)` is the idempotency guard. Duplicate Pub/Sub deliveries are no-ops at the DB level via ON CONFLICT.
+- `processing_error` records the error string when a handler fails (so retries can be diagnosed); the row is committed BEFORE any state-mutating logic so a crash mid-process leaves an audit trail.
+
+## 6. Google Play notification → state machine
+
+| `notificationType` | Name | Action on subscription | Action on Ultra |
+|---|---|---|---|
+| 1 | RECOVERED | status → `active`, currentPeriodEnd from payload (if present; else keep) | grant until currentPeriodEnd |
+| 2 | RENEWED | status → `active`, currentPeriodEnd from payload | grant until currentPeriodEnd |
+| 3 | CANCELED | status → `canceled` (still entitled until period end) | leave grant in place until expiry |
+| 4 | PURCHASED | status → `active`, set currentPeriodEnd from payload | grant until currentPeriodEnd |
+| 5 | ON_HOLD | status → `on_hold` | revoke |
+| 6 | IN_GRACE_PERIOD | status → `in_grace` | leave grant in place |
+| 7 | RESTARTED | status → `active` | grant until currentPeriodEnd |
+| 8 | PRICE_CHANGE_CONFIRMED | no-op on status | no-op |
+| 9 | DEFERRED | no-op on status (rare; admin-initiated extension) | no-op |
+| 10 | PAUSED | status → `paused` | revoke |
+| 11 | PAUSE_SCHEDULE_CHANGED | no-op | no-op |
+| 12 | REVOKED | status → `revoked` | revoke |
+| 13 | EXPIRED | status → `expired` | revoke |
+
+**Rationale notes:**
+- "Leave grant in place" for CANCELED matches Google's policy: users who cancel mid-cycle retain benefits until period end. EXPIRED will fire at the period end and trigger revocation.
+- ON_HOLD and PAUSED revoke immediately because the user has lost payment method or paused billing; behavior aligns with Google's recommended UX.
+- IN_GRACE_PERIOD does NOT revoke (Google's grace allows the user to update payment without losing access).
+
+**Note on payload shape:** the RTDN body wraps a `subscriptionNotification` object with `purchaseToken`, `subscriptionId` (= productId), and `notificationType`. The payload does NOT include `currentPeriodEnd` directly. v1 has a documented gap: without calling Google Play Developer API to fetch the subscription state, we don't know the exact `expiryTimeMillis`. For v1, we set `currentPeriodEnd = now + 30 days` on PURCHASED/RENEWED/RECOVERED/RESTARTED as a conservative default. This is wrong by up to several days but ensures we never grant Ultra past a renewal failure. **Deferred hardening:** call `androidpublisher.purchases.subscriptionsv2.get` to fetch the real expiry.
+
+## 7. Architecture
+
+### 7.1 Module layout
+
+```
+apps/server/src/features/billing/
+├── billing.repository.ts
+├── billing.repository.integration.test.ts
+├── billing.service.ts
+├── billing.service.test.ts
+├── billing.route.ts          # POST /billing/google-play/link
+├── google-play.webhook.ts    # POST /webhooks/google-play
+├── google-play.decoder.ts    # parse + state-machine helper (pure)
+├── google-play.decoder.test.ts
+└── index.ts
+```
+
+Why split `google-play.decoder.ts` from `billing.service.ts`: the decoder is pure and easy to unit-test against fixture payloads. The service composes the decoder with the repository (which has side effects).
+
+### 7.2 Layering
+
+- **Webhook route** (`google-play.webhook.ts`): verifies shared-secret header, parses Pub/Sub envelope, dispatches to service. Returns 200 even on application-level errors (so Pub/Sub doesn't retry forever); errors are recorded in `billing_event.processing_error`.
+- **Link route** (`billing.route.ts`): authenticated; upserts the subscription row.
+- **Service** (`billing.service.ts`): orchestrates dedup → audit row insert → state-machine dispatch → subscription update → Ultra grant/revoke. Receives an injected `UltraService` reference.
+- **Decoder** (`google-play.decoder.ts`): pure function `decodeGooglePlayPubSubEnvelope(raw)` returning `{ messageId, eventType, purchaseToken, notificationType, productId }`. No DB or HTTP.
+- **Repository** (`billing.repository.ts`): Drizzle queries for subscriptions and events. All writes in a single transaction when crossing both tables.
+
+### 7.3 Shared-secret webhook auth
+
+The `/webhooks/google-play` endpoint expects an `X-Pruvi-Webhook-Token` header that matches `env.GOOGLE_PLAY_WEBHOOK_TOKEN`. Constant-time comparison via `timingSafeEqual`. If the token is missing in env, the endpoint returns `503 ADMIN_DISABLED` (matching the existing admin-route pattern). If the token doesn't match, 401.
+
+Real Pub/Sub OIDC auth is deferred. The shared-secret model is acceptable for a non-public infrastructure endpoint behind a known CDN/proxy IP allowlist.
+
+### 7.4 Pub/Sub envelope
+
+Google sends:
+```json
+{
+  "message": {
+    "messageId": "1234567890",
+    "publishTime": "2026-05-12T10:00:00Z",
+    "data": "<base64-encoded JSON>",
+    "attributes": { ... }
+  },
+  "subscription": "projects/PROJECT/subscriptions/SUB"
+}
+```
+
+The decoder:
+1. Reads `message.messageId` → audit dedup key.
+2. base64-decodes `message.data` → the inner notification JSON.
+3. Reads `subscriptionNotification.purchaseToken`, `subscriptionNotification.notificationType`, `subscriptionNotification.subscriptionId` (productId).
+4. Maps `notificationType` integer → enum string (see §6).
+5. Returns the structured decoded event.
+
+If the inner payload is a `testNotification` (Google sends test pings to verify the endpoint), the decoder returns `{ kind: "test" }`. The service records the audit row but takes no further action.
+
+### 7.5 Logging
+
+All webhook activity (received, decoded, processed, errors) goes through `fastify.log` (structured). No `console.error`. Audit trail is the `billing_event` table; logs are for ops visibility.
+
+## 8. API surface
+
+### 8.1 `POST /webhooks/google-play`
+
+**Auth:** `X-Pruvi-Webhook-Token` header matches `env.GOOGLE_PLAY_WEBHOOK_TOKEN`.
+**Body:** Pub/Sub push envelope (see §7.4).
+**Response:**
+- `200 { received: true, messageId }` — always returned when the message is accepted (even if processing later failed; processing errors are recorded in the audit row and inspected via ops tooling, NOT signaled back to Pub/Sub).
+- `401` — bad token.
+- `503` — env token not configured.
+- `400` — malformed envelope (NOT a Pub/Sub-recognized retryable shape; signals a real bug, so we DO want Pub/Sub to retry-with-backoff so we get alerted).
+
+### 8.2 `POST /billing/google-play/link`
+
+**Auth:** `fastify.authenticate` (logged-in user).
+**Body:**
+```ts
+GooglePlayLinkBodySchema = z.object({
+  purchaseToken: z.string().min(1),
+  productId: z.string().min(1),
+});
+```
+**Response:**
+```ts
+GooglePlayLinkResponseSchema = z.object({
+  subscription: z.object({
+    id: z.number().int(),
+    status: z.enum(["pending","active","in_grace","on_hold","paused","canceled","expired","revoked"]),
+    productId: z.string(),
+    currentPeriodEnd: z.string().nullable(),
+  }),
+});
+```
+
+Semantics:
+- Upserts on `(provider="google_play", purchase_token)`.
+- If a row exists with a different `user_id` already set: returns `409 PURCHASE_TOKEN_OWNED_BY_OTHER_USER`. (Defense against a malicious client copying another user's token.)
+- If a row exists with no `user_id`: claims it by setting `user_id` and replays any unprocessed `billing_event` rows for that token inside the transaction.
+- If no row exists: creates one with `status = "pending"`.
+- `linked_at` set to now() on the first time `user_id` is set.
+
+## 9. Migration
+
+`packages/db/src/migrations/0010_<name>.sql` (auto-named by drizzle-kit). Creates `subscription` and `billing_event` per §5. No data backfill.
+
+## 10. Testing strategy
+
+**Unit** (`google-play.decoder.test.ts`):
+- Decode each of the 13 `notificationType` values from a fixture envelope; assert eventType + productId + purchaseToken.
+- Decode a `testNotification`-shaped envelope; assert `kind === "test"`.
+- Decode an unknown notificationType; assert returns `{ kind: "unknown", raw: ... }` (handler will log and audit but not act).
+- Malformed base64 / malformed JSON → throws.
+
+**Service unit** (`billing.service.test.ts`, mocked repo + UltraService):
+- PURCHASED on a not-yet-linked token → audit row inserted with user_id=null, subscription created pending, NO Ultra grant.
+- PURCHASED on a linked token → audit row + subscription→active + Ultra granted with currentPeriodEnd=now+30d.
+- RENEWED → currentPeriodEnd advanced; Ultra re-granted.
+- CANCELED on active subscription → status→canceled; Ultra grant unchanged (still entitled until expiry).
+- EXPIRED → status→expired; Ultra revoked.
+- REVOKED → status→revoked; Ultra revoked.
+- IN_GRACE_PERIOD → status→in_grace; Ultra unchanged.
+- ON_HOLD / PAUSED → revoked.
+- Duplicate `messageId` → no-op (audit dedup), returns success.
+
+**Integration** (`billing.repository.integration.test.ts`, real Postgres):
+- Audit dedup: inserting two events with the same `(provider, message_id)` produces one row.
+- Subscription upsert: link → webhook RENEWED → state visible.
+- Pre-link webhook: insert audit row + create pending subscription; subsequent link call associates `user_id` and replays the audit row to grant Ultra.
+- Race: link arrives concurrently with the same webhook; the UNIQUE constraint protects.
+- Cascade: deleting a user with linked subscriptions sets `user_id = NULL` (ON DELETE SET NULL).
+
+## 11. Acceptance criteria
+
+A1. `POST /webhooks/google-play` with a valid `X-Pruvi-Webhook-Token` header and a well-formed Pub/Sub envelope returns 200.
+A2. With a missing/invalid header → 401; with no env token configured → 503.
+A3. Duplicate Pub/Sub deliveries (same `messageId`) are stored only once; the second response still returns 200 (Pub/Sub acks).
+A4. `POST /billing/google-play/link` with `{ purchaseToken, productId }` creates a `subscription` row in `pending` status owned by the authenticated user.
+A5. Re-calling `link` with the same token by the same user is idempotent (no error, returns the existing subscription).
+A6. Calling `link` with a token already owned by a different `user_id` returns `409 PURCHASE_TOKEN_OWNED_BY_OTHER_USER`.
+A7. Receiving a `PURCHASED` webhook for a linked token: `subscription.status = active`, `current_period_end ≈ now + 30 days`, `user.isUltra = true`, `user.ultraExpiresAt ≈ now + 30d`.
+A8. Receiving an `EXPIRED` webhook for an active subscription: `subscription.status = expired`, `user.isUltra = false`.
+A9. Receiving a `CANCELED` webhook does NOT revoke Ultra — the user retains entitlement until `current_period_end`.
+A10. Receiving a webhook BEFORE the link call: `billing_event` row is inserted with `purchase_token` set but `subscription.user_id` is NULL; no Ultra grant occurs. After the matching `link` call: the pending event is replayed and Ultra is granted (if event type warrants).
+A11. The state machine in §6 is enforced — each `notificationType` integer maps to the documented status transition and Ultra effect.
+A12. The `billing_event` table has UNIQUE `(provider, message_id)` enforced at the DB layer.
+A13. The `subscription` table has UNIQUE `(provider, purchase_token)` enforced at the DB layer.
+A14. All errors logged via `fastify.log` (structured). No `console.error` in production paths.
+
+## 12. Deferred items
+
+- App Store Server Notifications V2 receiver and decoder (Phase 2E.5).
+- Google Play Developer API `subscriptionsv2.get` verification for exact `expiryTimeMillis` (hardening).
+- Real Pub/Sub OIDC auth (infra ticket).
+- Refund handling for one-time purchases.
+- Referral-shield reward integration.
+- Protect-streak push notification.
+- Background sweeper that polls the Google Play Developer API for subscriptions whose `current_period_end` is approaching (catches missed RTDN deliveries).
+
+## 13. Open questions resolved during design
+
+- **v1 currentPeriodEnd guess vs. real API call:** We accept the 30-day conservative default in v1 and defer the API call to a hardening phase. Rationale: the API call requires a Google service account in env which infra hasn't provisioned. The 30-day default never grants past a missed-renewal event because RENEWED/EXPIRED webhooks fire on time.
+- **Shared-secret vs OIDC:** Shared secret for v1; OIDC is an infra ticket. The webhook endpoint must NOT log the secret.
+- **One subscription per user?** No. The schema allows multiple `subscription` rows per user (e.g., re-purchase after cancel). The "current" subscription is the one with `status IN ('active', 'in_grace')`.
+- **What if `link` is called but the webhook never arrives?** The subscription stays in `pending` indefinitely. No Ultra grant. Acceptable for v1; a future job could expire `pending` rows after 24 hours.
+- **What if the user has Ultra from a previous admin grant and then subscribes via Google Play?** The webhook grants Ultra again with the new expiry. The admin grant's expiry is overwritten — which is the right behavior (the paying user's expiry is the source of truth).

--- a/docs/superpowers/specs/2026-05-12-phase-2e4-billing-webhooks-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e4-billing-webhooks-design.md
@@ -1,6 +1,6 @@
 # Phase 2E.4 — Billing Webhooks: Google Play (Design Spec)
 
-**Status:** v1
+**Status:** v2 (post Gate A: productId source, extended notification types, multi-sub revoke guard, replay semantics, env wiring, test cleanup)
 **Date:** 2026-05-12
 **Branch:** `feature/phase-2e4-billing-webhooks`
 **Product source:** `pruvi-freatures.md` §5.1 (Ultra subscription, "Cobrança via Google Play / App Store billing")
@@ -39,7 +39,7 @@ Wire Google Play Real-Time Developer Notifications (RTDN) to the existing Ultra 
 6. Each handled event records a `billing_event` audit row, optionally updates the `subscription` row, and optionally calls `UltraService.grant` or `UltraService.revoke`.
 7. The user's `users.isUltra` and `users.ultraExpiresAt` reflect the current entitlement.
 
-Race-safety: linking before the webhook fires is the expected order; the webhook fires before linking is also possible (especially in a slow-network scenario). The handler MUST store the event regardless of whether a `subscription` row exists; if no row exists yet, the audit row is parked with `user_id = NULL` and the subscription is **created** in `pending` state. When the link call later arrives, the existing `pending` subscription row is updated with the `user_id`, and any unprocessed audit rows for that token are replayed inside the same transaction (best-effort; documented as a known limit if Pub/Sub retries don't naturally redeliver).
+Race-safety: linking before the webhook fires is the expected order; the webhook fires before linking is also possible (especially in a slow-network scenario). The handler MUST store the event regardless of whether a `subscription` row exists; if no row exists yet, the audit row is parked with `subscription_id = NULL` (resolved from `purchase_token` lookup which returns nothing). When the link call later arrives, the existing `pending` subscription row is updated with the `user_id` AND parked events are replayed (see §7.6 for the precise replay procedure).
 
 ## 5. Data model
 
@@ -107,7 +107,16 @@ Notes:
 | 10 | PAUSED | status → `paused` | revoke |
 | 11 | PAUSE_SCHEDULE_CHANGED | no-op | no-op |
 | 12 | REVOKED | status → `revoked` | revoke |
-| 13 | EXPIRED | status → `expired` | revoke |
+| 13 | EXPIRED | status → `expired` | revoke (subject to multi-sub guard, §7.2) |
+| 17 | ITEMS_CHANGED | no-op | no-op |
+| 18 | CANCELLATION_SCHEDULED | no-op (entitlement until expiry, like type 3) | no-op |
+| 19 | PRICE_CHANGE_UPDATED | no-op | no-op |
+| 20 | PENDING_PURCHASE_CANCELED | no-op | no-op |
+| 22 | PRICE_STEP_UP_CONSENT_UPDATED | no-op | no-op |
+
+Type 8 (PRICE_CHANGE_CONFIRMED) is **deprecated** in Google's current RTDN reference but still deliverable; treated as no-op.
+
+Notification types not listed above (e.g., future Google additions) are routed through the decoder's `{ kind: "unknown" }` branch: audit row recorded, no state mutation. Operators see them in the `billing_event` table for triage.
 
 **Rationale notes:**
 - "Leave grant in place" for CANCELED matches Google's policy: users who cancel mid-cycle retain benefits until period end. EXPIRED will fire at the period end and trigger revocation.
@@ -140,12 +149,18 @@ Why split `google-play.decoder.ts` from `billing.service.ts`: the decoder is pur
 - **Webhook route** (`google-play.webhook.ts`): verifies shared-secret header, parses Pub/Sub envelope, dispatches to service. Returns 200 even on application-level errors (so Pub/Sub doesn't retry forever); errors are recorded in `billing_event.processing_error`.
 - **Link route** (`billing.route.ts`): authenticated; upserts the subscription row.
 - **Service** (`billing.service.ts`): orchestrates dedup → audit row insert → state-machine dispatch → subscription update → Ultra grant/revoke. Receives an injected `UltraService` reference.
+
+  **Multi-subscription revoke guard (MANDATORY):** Before calling `UltraService.revoke(userId)`, the service MUST check whether the user has ANY OTHER subscription row with `status IN ('active', 'in_grace')`. If yes, the revoke is SKIPPED — the user retains Ultra from the still-entitled subscription. If no, `revoke` proceeds. Rationale: a user who re-subscribes before their cancelled subscription expires can hold two rows; the EXPIRED webhook for the old row must not strip Ultra from the new one. Concretely: `BillingService.handleRevocationFor(subscription)` queries `SELECT 1 FROM subscription WHERE user_id = $userId AND id != $subscriptionId AND status IN ('active','in_grace') LIMIT 1`; if any row exists, return without revoking.
+
+  **Multi-subscription grant guard (when fixing currentPeriodEnd):** When granting Ultra, if the user has another active subscription with a LATER `currentPeriodEnd`, use the maximum of the two as the Ultra expiry. Rule: `user.ultraExpiresAt = MAX(allActive.currentPeriodEnd)`.
 - **Decoder** (`google-play.decoder.ts`): pure function `decodeGooglePlayPubSubEnvelope(raw)` returning `{ messageId, eventType, purchaseToken, notificationType, productId }`. No DB or HTTP.
 - **Repository** (`billing.repository.ts`): Drizzle queries for subscriptions and events. All writes in a single transaction when crossing both tables.
 
 ### 7.3 Shared-secret webhook auth
 
-The `/webhooks/google-play` endpoint expects an `X-Pruvi-Webhook-Token` header that matches `env.GOOGLE_PLAY_WEBHOOK_TOKEN`. Constant-time comparison via `timingSafeEqual`. If the token is missing in env, the endpoint returns `503 ADMIN_DISABLED` (matching the existing admin-route pattern). If the token doesn't match, 401.
+The `/webhooks/google-play` endpoint expects an `X-Pruvi-Webhook-Token` header that matches `env.GOOGLE_PLAY_WEBHOOK_TOKEN`. Constant-time comparison via `timingSafeEqual`. If the token is missing in env, the endpoint returns `503 WEBHOOK_DISABLED`. If the token doesn't match, 401.
+
+**Env declaration:** `GOOGLE_PLAY_WEBHOOK_TOKEN` MUST be declared in `packages/env/src/server.ts` as `z.string().min(16).optional()` — mirroring the existing `ADMIN_API_TOKEN` pattern. Optional so dev environments without the token still boot; the route returns 503 at runtime when missing. The plan MUST include a task to add this env field.
 
 Real Pub/Sub OIDC auth is deferred. The shared-secret model is acceptable for a non-public infrastructure endpoint behind a known CDN/proxy IP allowlist.
 
@@ -164,14 +179,63 @@ Google sends:
 }
 ```
 
-The decoder:
+The inner `DeveloperNotification` (after base64 decode) has shape:
+```json
+{
+  "version": "1.0",
+  "packageName": "com.pruvi.app",
+  "eventTimeMillis": "1747044000000",
+  "subscriptionNotification": {
+    "version": "1.0",
+    "notificationType": 4,
+    "purchaseToken": "opaque-token-string"
+  }
+}
+```
+
+**Important: `subscriptionNotification` does NOT carry `subscriptionId` or `productId`.** Per Google's RTDN reference (https://developer.android.com/google/play/billing/rtdn-reference), the object has exactly three fields: `version`, `notificationType`, `purchaseToken`. The `productId` is NOT in the webhook payload — it MUST be retrieved from the `subscription` row we previously stored at link time (keyed by `(provider, purchase_token)`). If no `subscription` row exists yet (pre-link race), the event is still parked in `billing_event`; the productId stays unknown until link.
+
+The decoder is pure and returns:
+
+```ts
+type DecodedGooglePlayEvent =
+  | { kind: "subscription"; messageId: string; publishTime: string; packageName: string; eventTimeMillis: string; notificationType: number; notificationTypeName: GooglePlayNotificationTypeName; purchaseToken: string }
+  | { kind: "test"; messageId: string }
+  | { kind: "unknown"; messageId: string; notificationType: number; purchaseToken: string };
+```
+
+Steps:
 1. Reads `message.messageId` → audit dedup key.
 2. base64-decodes `message.data` → the inner notification JSON.
-3. Reads `subscriptionNotification.purchaseToken`, `subscriptionNotification.notificationType`, `subscriptionNotification.subscriptionId` (productId).
-4. Maps `notificationType` integer → enum string (see §6).
-5. Returns the structured decoded event.
+3. If the inner payload has `testNotification`: returns `{ kind: "test", messageId }`.
+4. Reads `subscriptionNotification.purchaseToken`, `notificationType` (integer).
+5. Maps `notificationType` integer → enum name (see §6 table). For values not in the mapped set, returns `{ kind: "unknown", messageId, notificationType, purchaseToken }` — the handler will record the audit row but take no Ultra-state action.
+6. Returns the decoded structure. **`productId` is intentionally NOT in the return type — looked up from the subscription row by the service.**
 
-If the inner payload is a `testNotification` (Google sends test pings to verify the endpoint), the decoder returns `{ kind: "test" }`. The service records the audit row but takes no further action.
+### 7.6 Parked-event replay (link-time)
+
+When `POST /billing/google-play/link` succeeds at associating `user_id` with a previously webhook-created `subscription` row (or creates the row fresh — same code path), the link handler MUST replay any unprocessed `billing_event` rows for that `purchase_token`. The procedure:
+
+1. **Inside the link transaction** (single `db.transaction`):
+   a. Find or create the `subscription` row by `(provider, purchase_token)`. Set `user_id`, `linked_at`, `product_id` (from the link request body) if not already set.
+   b. Fetch all `billing_event` rows where `purchase_token = $token AND provider = 'google_play' AND processed_at IS NULL`, ordered by `received_at ASC` (so earlier events apply before later ones).
+   c. For each parked event, call the SHARED state-machine dispatch function `applyDecodedEvent(decoded, subscription, tx)` — the same function used by the webhook handler. The function updates `subscription.status` and `current_period_end` per §6 and sets `processed_at = now()` on the audit row, all inside the transaction.
+   d. After applying all parked events, determine the final Ultra state from the subscription's final `status` and `current_period_end`.
+2. **Commit the transaction.** The subscription state + audit rows + linked user are now consistent.
+3. **After commit (outside the transaction)**, call `UltraService.grant(userId, currentPeriodEnd)` or `UltraService.revoke(userId)` (the multi-sub guard, §7.2). This is intentionally a two-phase pattern: the Ultra update on `users` is committed in a separate transaction. The window of inconsistency (link committed, Ultra not yet granted) is bounded by the duration of the grant call — sub-millisecond — and the grant is idempotent. If the process crashes between commit and grant, the `subscription` row exists in `active` status with `processed_at` set on the events but `user.isUltra = false`; a future state event (or operator) can reconcile. We accept this bounded inconsistency to keep the link transaction scope tight.
+
+**Why not include the Ultra update in the same transaction?** Two reasons: (1) `UltraService.grant` is on a separate concern boundary (Ultra entitlement is owned by the `ultra` module, not `billing`); reaching across boundaries to share a transaction couples them; (2) `user.isUltra` is touched by other features (admin grant, future flows) — putting it inside the billing transaction creates lock contention. The two-phase commit is the documented trade-off.
+
+**Webhook handler path: same shared `applyDecodedEvent` function.** The webhook handler:
+1. Validates auth, decodes envelope, computes `messageId`.
+2. Opens a transaction:
+   a. INSERT INTO `billing_event` (provider, message_id, event_type, purchase_token, payload, received_at) ... ON CONFLICT DO NOTHING. If conflict (duplicate delivery), commit and return 200.
+   b. Find `subscription` by `(provider, purchase_token)`. If none exists yet (pre-link), create one with `user_id = NULL`, `status = 'pending'`, `product_id = ''` (filled at link time).
+   c. Call `applyDecodedEvent(decoded, subscription, tx)` — same shared function. If `subscription.user_id IS NULL`, the function still updates subscription state but does NOT attempt Ultra grant/revoke; it sets `processed_at` so that link-time replay knows it has been state-applied. Actually — to support correct replay-on-link, the webhook handler at pre-link time should NOT set `processed_at`. Instead: when `subscription.user_id IS NULL`, the shared function leaves `processed_at = NULL` so that the link replay re-applies the state and triggers Ultra grant. Document this branch explicitly in the function.
+3. Commit the transaction.
+4. If `subscription.user_id` is set AND the event was newly applied (not a dup), call `UltraService.grant`/`revoke` after commit, same two-phase pattern as link.
+
+This shared `applyDecodedEvent(decoded, subscription, tx)` function is the heart of the service. Its signature, contract, and `processed_at` semantics MUST be precisely defined in the plan's task breakdown.
 
 ### 7.5 Logging
 
@@ -184,10 +248,11 @@ All webhook activity (received, decoded, processed, errors) goes through `fastif
 **Auth:** `X-Pruvi-Webhook-Token` header matches `env.GOOGLE_PLAY_WEBHOOK_TOKEN`.
 **Body:** Pub/Sub push envelope (see §7.4).
 **Response:**
-- `200 { received: true, messageId }` — always returned when the message is accepted (even if processing later failed; processing errors are recorded in the audit row and inspected via ops tooling, NOT signaled back to Pub/Sub).
-- `401` — bad token.
-- `503` — env token not configured.
-- `400` — malformed envelope (NOT a Pub/Sub-recognized retryable shape; signals a real bug, so we DO want Pub/Sub to retry-with-backoff so we get alerted).
+- `200 { received: true, messageId? }` — returned when the message is accepted or already-deduped. Also returned when the envelope is malformed (with `{ received: false, error: "MALFORMED_ENVELOPE" }` in body) — Pub/Sub treats non-200 as retry, and a 400 on malformed shapes would cause infinite retry storms. Ops monitors the `billing_event` and server logs to detect malformed payloads.
+- `200 { received: true, kind: "test" }` — Google's test ping.
+- `200 { received: true, error: "PROCESSING_FAILED" }` — application-level handler error after audit row write; the error string is logged + persisted to `billing_event.processing_error` for ops triage.
+- `401` — bad token (NOT 4xx for Pub/Sub from Google, so Google will retry — that's correct behavior; auth issues should surface as alerts).
+- `503` — env token not configured (returns `{ error: "WEBHOOK_DISABLED" }`).
 
 ### 8.2 `POST /billing/google-play/link`
 
@@ -214,9 +279,10 @@ GooglePlayLinkResponseSchema = z.object({
 Semantics:
 - Upserts on `(provider="google_play", purchase_token)`.
 - If a row exists with a different `user_id` already set: returns `409 PURCHASE_TOKEN_OWNED_BY_OTHER_USER`. (Defense against a malicious client copying another user's token.)
-- If a row exists with no `user_id`: claims it by setting `user_id` and replays any unprocessed `billing_event` rows for that token inside the transaction.
-- If no row exists: creates one with `status = "pending"`.
-- `linked_at` set to now() on the first time `user_id` is set.
+- If a row exists already linked to the SAME user (idempotent re-call): returns `200` with the CURRENT subscription state (status reflects whatever state the latest webhook moved it to — could be `pending`, `active`, `expired`, etc.). No-op on the row.
+- If a row exists with no `user_id` (parked from pre-link webhook): claims it by setting `user_id`, `linked_at`, and `product_id` (overwriting empty productId from webhook-creation), then replays unprocessed `billing_event` rows per §7.6 inside the link transaction.
+- If no row exists: creates one with `status = "pending"`, `product_id` from the request body, `linked_at = now()`.
+- `linked_at` set to now() on the first time `user_id` is associated.
 
 ## 9. Migration
 
@@ -241,6 +307,8 @@ Semantics:
 - ON_HOLD / PAUSED → revoked.
 - Duplicate `messageId` → no-op (audit dedup), returns success.
 
+**Test harness preparation:** `apps/server/src/test/db-helpers.ts` `cleanupTestDb` MUST be updated to include `billing_event, subscription` in the TRUNCATE list (children-first ordering relative to `user`; both have CASCADE/SET NULL semantics so the trailing CASCADE handles them, but explicit listing prevents leftover-row pollution across tests on the UNIQUE constraints).
+
 **Integration** (`billing.repository.integration.test.ts`, real Postgres):
 - Audit dedup: inserting two events with the same `(provider, message_id)` produces one row.
 - Subscription upsert: link → webhook RENEWED → state visible.
@@ -264,6 +332,11 @@ A11. The state machine in §6 is enforced — each `notificationType` integer ma
 A12. The `billing_event` table has UNIQUE `(provider, message_id)` enforced at the DB layer.
 A13. The `subscription` table has UNIQUE `(provider, purchase_token)` enforced at the DB layer.
 A14. All errors logged via `fastify.log` (structured). No `console.error` in production paths.
+A15. A user with two subscription rows (one expired, one active) does NOT lose Ultra when the EXPIRED webhook for the older row arrives — `BillingService` consults other subscriptions before revoking (§7.2 multi-sub revoke guard).
+A16. The shared `applyDecodedEvent(decoded, subscription, tx)` function is called from BOTH the webhook handler AND the link-time replay loop — single source of state transition logic (no duplication). See §7.6.
+A17. `GOOGLE_PLAY_WEBHOOK_TOKEN` is declared in `packages/env/src/server.ts` as `z.string().min(16).optional()`. Missing token at request time → 503 `WEBHOOK_DISABLED`.
+A18. `cleanupTestDb` in `apps/server/src/test/db-helpers.ts` includes `billing_event, subscription` in its TRUNCATE list (children before parents) so integration tests do not pollute each other on UNIQUE constraints.
+A19. Decoder returns `{ kind: "unknown", ... }` for any `notificationType` not in §6 (including future Google additions and types 17–22 documented but treated as no-op). Audit row recorded; no state mutation.
 
 ## 12. Deferred items
 

--- a/packages/db/src/migrations/0010_glamorous_morlocks.sql
+++ b/packages/db/src/migrations/0010_glamorous_morlocks.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "billing_event" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"provider" text NOT NULL,
+	"message_id" text NOT NULL,
+	"event_type" text NOT NULL,
+	"purchase_token" text,
+	"payload" jsonb NOT NULL,
+	"received_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"processed_at" timestamp with time zone,
+	"processing_error" text
+);
+--> statement-breakpoint
+CREATE TABLE "subscription" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text,
+	"provider" text NOT NULL,
+	"product_id" text NOT NULL,
+	"purchase_token" text NOT NULL,
+	"status" text NOT NULL,
+	"current_period_end" timestamp with time zone,
+	"linked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "subscription" ADD CONSTRAINT "subscription_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "billing_event_provider_message_uq" ON "billing_event" USING btree ("provider","message_id");--> statement-breakpoint
+CREATE INDEX "billing_event_token_idx" ON "billing_event" USING btree ("purchase_token");--> statement-breakpoint
+CREATE INDEX "billing_event_unprocessed_idx" ON "billing_event" USING btree ("processed_at") WHERE "billing_event"."processed_at" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "subscription_provider_token_uq" ON "subscription" USING btree ("provider","purchase_token");--> statement-breakpoint
+CREATE INDEX "subscription_user_idx" ON "subscription" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "subscription_status_idx" ON "subscription" USING btree ("status");

--- a/packages/db/src/migrations/meta/0010_snapshot.json
+++ b/packages/db/src/migrations/meta/0010_snapshot.json
@@ -1,0 +1,2018 @@
+{
+  "id": "a344d1bb-9b86-4b65-95b0-0b82a88e6756",
+  "prevId": "5c37fefc-7ff7-43c6-84c7-74ab678ede71",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives": {
+          "name": "lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lives_last_regen_at": {
+          "name": "lives_last_regen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "selected_exam": {
+          "name": "selected_exam",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulties": {
+          "name": "difficulties",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "daily_study_time_minutes": {
+          "name": "daily_study_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ultra": {
+          "name": "is_ultra",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ultra_expires_at": {
+          "name": "ultra_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)"
+        },
+        "notification_hour": {
+          "name": "notification_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 19
+        },
+        "streak_reminders_enabled": {
+          "name": "streak_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "achievement_notifications_enabled": {
+          "name": "achievement_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "streak_shields_available": {
+          "name": "streak_shields_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_shield_grant_at": {
+          "name": "last_shield_grant_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_event": {
+      "name": "billing_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_token": {
+          "name": "purchase_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "billing_event_provider_message_uq": {
+          "name": "billing_event_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_event_token_idx": {
+          "name": "billing_event_token_idx",
+          "columns": [
+            {
+              "expression": "purchase_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_event_unprocessed_idx": {
+          "name": "billing_event_unprocessed_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"billing_event\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_token": {
+          "name": "purchase_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_provider_token_uq": {
+          "name": "subscription_provider_token_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchase_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscription_user_idx": {
+          "name": "subscription_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscription_status_idx": {
+          "name": "subscription_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_session": {
+      "name": "daily_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_correct": {
+          "name": "questions_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastery_snapshot": {
+          "name": "mastery_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_session_user_created_idx": {
+          "name": "daily_session_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_session_user_id_user_id_fk": {
+          "name": "daily_session_user_id_user_id_fk",
+          "tableFrom": "daily_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "friendship_requester_idx": {
+          "name": "friendship_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendship_recipient_idx": {
+          "name": "friendship_recipient_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendship_requester_id_user_id_fk": {
+          "name": "friendship_requester_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_recipient_id_user_id_fk": {
+          "name": "friendship_recipient_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subject_name_unique": {
+          "name": "subject_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "subject_slug_unique": {
+          "name": "subject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopic": {
+      "name": "subtopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtopic_topic_order_idx": {
+          "name": "subtopic_topic_order_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopic_topic_id_topic_id_fk": {
+          "name": "subtopic_topic_id_topic_id_fk",
+          "tableFrom": "subtopic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtopic_topic_slug_uniq": {
+          "name": "subtopic_topic_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topic_subject_order_idx": {
+          "name": "topic_subject_order_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_subject_id_subject_id_fk": {
+          "name": "topic_subject_id_subject_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_subject_slug_uniq": {
+          "name": "topic_subject_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_option_index": {
+          "name": "correct_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_calculation": {
+          "name": "requires_calculation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtopic_id": {
+          "name": "subtopic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_subject_difficulty_idx": {
+          "name": "question_subject_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_subtopic_difficulty_idx": {
+          "name": "question_subtopic_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_subject_id_subject_id_fk": {
+          "name": "question_subject_id_subject_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_subtopic_id_subtopic_id_fk": {
+          "name": "question_subtopic_id_subtopic_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subtopic",
+          "columnsFrom": [
+            "subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_log": {
+      "name": "review_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "easiness_factor": {
+          "name": "easiness_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_log_user_next_review_idx": {
+          "name": "review_log_user_next_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_log_user_question_idx": {
+          "name": "review_log_user_question_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_log_user_id_user_id_fk": {
+          "name": "review_log_user_id_user_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_log_question_id_question_id_fk": {
+          "name": "review_log_question_id_question_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_token": {
+      "name": "push_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_token_user_idx": {
+          "name": "push_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_token_user_id_user_id_fk": {
+          "name": "push_token_user_id_user_id_fk",
+          "tableFrom": "push_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_token_token_unique": {
+          "name": "push_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_acceptance": {
+      "name": "invitation_acceptance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_acceptance_inviter_idx": {
+          "name": "invitation_acceptance_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_acceptance_inviter_id_user_id_fk": {
+          "name": "invitation_acceptance_inviter_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_acceptance_invitee_id_user_id_fk": {
+          "name": "invitation_acceptance_invitee_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invitee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_acceptance_invitee_id_unique": {
+          "name": "invitation_acceptance_invitee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_shield_usage": {
+      "name": "streak_shield_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protected_date": {
+          "name": "protected_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "streak_shield_usage_user_date_idx": {
+          "name": "streak_shield_usage_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protected_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "streak_shield_usage_user_idx": {
+          "name": "streak_shield_usage_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "streak_shield_usage_user_id_user_id_fk": {
+          "name": "streak_shield_usage_user_id_user_id_fk",
+          "tableFrom": "streak_shield_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_simulado": {
+      "name": "weekly_simulado",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start_date": {
+          "name": "week_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions_count": {
+          "name": "questions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weekly_simulado_user_week_uq": {
+          "name": "weekly_simulado_user_week_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_simulado_user_week_idx": {
+          "name": "weekly_simulado_user_week_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_simulado_user_id_user_id_fk": {
+          "name": "weekly_simulado_user_id_user_id_fk",
+          "tableFrom": "weekly_simulado",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_simulado_question": {
+      "name": "weekly_simulado_question",
+      "schema": "",
+      "columns": {
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_index": {
+          "name": "selected_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "weekly_simulado_question_simulado_question_uq": {
+          "name": "weekly_simulado_question_simulado_question_uq",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_simulado_question_simulado_idx": {
+          "name": "weekly_simulado_question_simulado_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_simulado_question_simulado_id_weekly_simulado_id_fk": {
+          "name": "weekly_simulado_question_simulado_id_weekly_simulado_id_fk",
+          "tableFrom": "weekly_simulado_question",
+          "tableTo": "weekly_simulado",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weekly_simulado_question_question_id_question_id_fk": {
+          "name": "weekly_simulado_question_question_id_question_id_fk",
+          "tableFrom": "weekly_simulado_question",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "weekly_simulado_question_simulado_id_position_pk": {
+          "name": "weekly_simulado_question_simulado_id_position_pk",
+          "columns": [
+            "simulado_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1778584840941,
       "tag": "0009_marvelous_johnny_blaze",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1778599774073,
+      "tag": "0010_glamorous_morlocks",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/billing.ts
+++ b/packages/db/src/schema/billing.ts
@@ -1,0 +1,52 @@
+import { relations, isNull } from "drizzle-orm";
+import { index, jsonb, pgTable, serial, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const subscription = pgTable(
+  "subscription",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id").references(() => user.id, { onDelete: "set null" }),
+    provider: text("provider", { enum: ["google_play", "app_store"] }).notNull(),
+    productId: text("product_id").notNull(),
+    purchaseToken: text("purchase_token").notNull(),
+    status: text("status", {
+      enum: ["pending", "active", "in_grace", "on_hold", "paused", "canceled", "expired", "revoked"],
+    }).notNull(),
+    currentPeriodEnd: timestamp("current_period_end", { withTimezone: true }),
+    linkedAt: timestamp("linked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => [
+    uniqueIndex("subscription_provider_token_uq").on(t.provider, t.purchaseToken),
+    index("subscription_user_idx").on(t.userId),
+    index("subscription_status_idx").on(t.status),
+  ],
+);
+
+export const billingEvent = pgTable(
+  "billing_event",
+  {
+    id: serial("id").primaryKey(),
+    provider: text("provider", { enum: ["google_play", "app_store"] }).notNull(),
+    messageId: text("message_id").notNull(),
+    eventType: text("event_type").notNull(),
+    purchaseToken: text("purchase_token"),
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    receivedAt: timestamp("received_at", { withTimezone: true }).defaultNow().notNull(),
+    processedAt: timestamp("processed_at", { withTimezone: true }),
+    processingError: text("processing_error"),
+  },
+  (t) => [
+    uniqueIndex("billing_event_provider_message_uq").on(t.provider, t.messageId),
+    index("billing_event_token_idx").on(t.purchaseToken),
+    // Partial index — spec §5.2. Speeds up `listUnprocessedEventsForToken` on the
+    // link-replay hot path. Without it, that query degrades to a full scan.
+    index("billing_event_unprocessed_idx").on(t.processedAt).where(isNull(t.processedAt)),
+  ],
+);
+
+export const subscriptionRelations = relations(subscription, ({ one }) => ({
+  user: one(user, { fields: [subscription.userId], references: [user.id] }),
+}));

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -9,3 +9,4 @@ export * from "./friendship";
 export * from "./invitation-acceptance";
 export * from "./streak-shield-usage";
 export * from "./weekly-simulado";
+export * from "./billing";

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -20,6 +20,7 @@ export const env = createEnv({
     APPLE_BUNDLE_ID: z.string().optional(),
     EXPO_ACCESS_TOKEN: z.string().optional(),
     ADMIN_API_TOKEN: z.string().min(16).optional(),
+    GOOGLE_PLAY_WEBHOOK_TOKEN: z.string().min(16).optional(),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/packages/shared/src/billing.test.ts
+++ b/packages/shared/src/billing.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  BILLING_PROVIDERS,
+  SUBSCRIPTION_STATUSES,
+  GOOGLE_PLAY_NOTIFICATION_TYPES,
+  GooglePlayLinkBodySchema,
+  DEFAULT_SUBSCRIPTION_PERIOD_MS,
+} from "./billing";
+
+describe("billing shared module", () => {
+  it("declares the v1 providers", () => {
+    expect(BILLING_PROVIDERS).toEqual(["google_play", "app_store"]);
+  });
+
+  it("declares all 8 subscription statuses", () => {
+    expect(SUBSCRIPTION_STATUSES).toHaveLength(8);
+    expect(SUBSCRIPTION_STATUSES).toContain("pending");
+    expect(SUBSCRIPTION_STATUSES).toContain("active");
+    expect(SUBSCRIPTION_STATUSES).toContain("expired");
+  });
+
+  it("maps Google Play notificationType integers to enum names", () => {
+    expect(GOOGLE_PLAY_NOTIFICATION_TYPES[4]).toBe("PURCHASED");
+    expect(GOOGLE_PLAY_NOTIFICATION_TYPES[13]).toBe("EXPIRED");
+    expect(GOOGLE_PLAY_NOTIFICATION_TYPES[18]).toBe("CANCELLATION_SCHEDULED");
+  });
+
+  it("DEFAULT_SUBSCRIPTION_PERIOD_MS is 30 days", () => {
+    expect(DEFAULT_SUBSCRIPTION_PERIOD_MS).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("validates link body shape", () => {
+    expect(GooglePlayLinkBodySchema.safeParse({ purchaseToken: "t", productId: "pruvi_ultra_monthly" }).success).toBe(true);
+    expect(GooglePlayLinkBodySchema.safeParse({ purchaseToken: "", productId: "x" }).success).toBe(false);
+  });
+});

--- a/packages/shared/src/billing.ts
+++ b/packages/shared/src/billing.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+export const BILLING_PROVIDERS = ["google_play", "app_store"] as const;
+export type BillingProvider = (typeof BILLING_PROVIDERS)[number];
+
+export const SUBSCRIPTION_STATUSES = [
+  "pending",
+  "active",
+  "in_grace",
+  "on_hold",
+  "paused",
+  "canceled",
+  "expired",
+  "revoked",
+] as const;
+export type SubscriptionStatus = (typeof SUBSCRIPTION_STATUSES)[number];
+
+/** Conservative default expiry when the webhook payload doesn't carry expiryTimeMillis. */
+export const DEFAULT_SUBSCRIPTION_PERIOD_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Mapping from Google Play RTDN notificationType integer → name. Values not listed
+ *  are decoded as { kind: "unknown" } and result in no state mutation. */
+export const GOOGLE_PLAY_NOTIFICATION_TYPES = {
+  1: "RECOVERED",
+  2: "RENEWED",
+  3: "CANCELED",
+  4: "PURCHASED",
+  5: "ON_HOLD",
+  6: "IN_GRACE_PERIOD",
+  7: "RESTARTED",
+  8: "PRICE_CHANGE_CONFIRMED",
+  9: "DEFERRED",
+  10: "PAUSED",
+  11: "PAUSE_SCHEDULE_CHANGED",
+  12: "REVOKED",
+  13: "EXPIRED",
+  17: "ITEMS_CHANGED",
+  18: "CANCELLATION_SCHEDULED",
+  19: "PRICE_CHANGE_UPDATED",
+  20: "PENDING_PURCHASE_CANCELED",
+  22: "PRICE_STEP_UP_CONSENT_UPDATED",
+} as const;
+export type GooglePlayNotificationTypeName =
+  (typeof GOOGLE_PLAY_NOTIFICATION_TYPES)[keyof typeof GOOGLE_PLAY_NOTIFICATION_TYPES];
+
+export const GooglePlayLinkBodySchema = z.object({
+  purchaseToken: z.string().min(1),
+  productId: z.string().min(1),
+});
+export type GooglePlayLinkBody = z.infer<typeof GooglePlayLinkBodySchema>;
+
+export const GooglePlayLinkResponseSchema = z.object({
+  subscription: z.object({
+    id: z.number().int(),
+    status: z.enum(SUBSCRIPTION_STATUSES),
+    productId: z.string(),
+    currentPeriodEnd: z.string().nullable(),
+  }),
+});
+export type GooglePlayLinkResponse = z.infer<typeof GooglePlayLinkResponseSchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,3 +18,4 @@ export * from "./ultra";
 export * from "./shields";
 export * from "./time";
 export * from "./simulado";
+export * from "./billing";


### PR DESCRIPTION
## Summary
- New `billing` module wires Google Play Real-Time Developer Notifications → `UltraService.grant/revoke`
- `subscription` table tracks per-(provider, purchase_token) state; `billing_event` is an append-only audit log dedup'd on `(provider, message_id)`
- **Shared `applyDecodedEvent` state machine** used by BOTH the webhook handler AND the link-time replay loop — single source of state-transition logic
- Pre-link race resolved via orphan-subscription pattern + parked-event replay on link
- **Multi-subscription REVOKE guard**: EXPIRED on old subscription won't strip Ultra from a still-active new one
- **Multi-subscription GRANT guard**: a short-plan renewal won't truncate a longer active plan (final expiry = MAX across all active subs)
- Optional `GOOGLE_PLAY_WEBHOOK_TOKEN` env var (z.string().min(16).optional()); missing → 503; mismatch → 401; `webhookGuard` throws `AppError`/`UnauthorizedError` so the error handler maps status codes
- 30-day conservative `currentPeriodEnd` default (documented gap; real API verification deferred)
- Decoded `productId` is NOT extracted from the webhook payload (Google's RTDN doesn't carry it) — retrieved from the linked subscription row instead
- App Store deferred to 2E.5; schema accepts `app_store` provider without migration

## Workflow gates
- ✅ Gate A — spec self-review (6 blockers → spec v2: productId source, extended notification types, multi-sub revoke guard, replay function, env declaration, test cleanup)
- ✅ Gate B — plan self-review (4 blockers → plan v2: AppError in guard, multi-sub GRANT guard, partial index, concrete service tests)
- ✅ Gate C — per-task review (6 tasks): caught missing decoder test, unused TS fields, unused imports
- ✅ Gate D — final spec-coverage review vs full diff: all 19 acceptance criteria mapped to implementation; 3 testing gaps closed in 15e68e0

## Test coverage (final state)
- 12 decoder unit tests (incl. all 13 core notification types looped, malformed envelope, test ping, unknown type, base64 errors)
- 11 repository integration tests (against real Postgres; incl. multi-sub guards both directions and ON DELETE SET NULL cascade)
- 11 service unit tests (incl. multi-sub REVOKE guard, multi-sub GRANT guard, link-time replay, dedup)

## Spec & plan
- Spec v2: docs/superpowers/specs/2026-05-12-phase-2e4-billing-webhooks-design.md
- Plan v2: docs/superpowers/plans/2026-05-12-phase-2e4-billing-webhooks.md

## Test plan
- [ ] CI runs the integration tests against Postgres
- [ ] Manual: POST /webhooks/google-play with missing header → 401; bad token → 401; no env token → 503
- [ ] Manual: POST /billing/google-play/link with valid auth → 200 + subscription row; second call with different user → 409
- [ ] Manual: simulate PURCHASED webhook → Ultra granted; EXPIRED → Ultra revoked