### PR TITLE
feat: phase 2e.5 — app store server notifications v2 (ultra entitlement, iOS parity)

### DIFF
--- a/apps/server/src/features/billing/app-store.decoder.test.ts
+++ b/apps/server/src/features/billing/app-store.decoder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { decodeAppStoreNotification, DecoderError, type DecodedAppStoreEvent } from "./app-store.decoder";
+import { decodeAppStoreNotification, DecoderError } from "./app-store.decoder";
 
 function makeJws(payload: object): string {
   // header.payload.signature — only the middle segment is used.

--- a/apps/server/src/features/billing/app-store.decoder.test.ts
+++ b/apps/server/src/features/billing/app-store.decoder.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { decodeAppStoreNotification, DecoderError, type DecodedAppStoreEvent } from "./app-store.decoder";
+
+function makeJws(payload: object): string {
+  // header.payload.signature — only the middle segment is used.
+  const header = Buffer.from(JSON.stringify({ alg: "ES256", x5c: ["fake"] })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+function buildEnvelope(opts: {
+  notificationType: string;
+  subtype?: string;
+  notificationUUID?: string;
+  expiresDate?: number;
+  originalTransactionId?: string;
+  productId?: string;
+  omitData?: boolean;
+  omitSignedTransaction?: boolean;
+}) {
+  const tx = {
+    originalTransactionId: opts.originalTransactionId ?? "200000000000001",
+    productId: opts.productId ?? "pruvi_ultra_monthly",
+    expiresDate: opts.expiresDate ?? Date.now() + 30 * 24 * 60 * 60 * 1000,
+    environment: "Production",
+  };
+  const data = opts.omitSignedTransaction
+    ? { environment: "Production" }
+    : { signedTransactionInfo: makeJws(tx), environment: "Production" };
+  const outer: Record<string, unknown> = {
+    notificationUUID: opts.notificationUUID ?? "uuid-1",
+    notificationType: opts.notificationType,
+    version: "2.0",
+    signedDate: Date.now(),
+  };
+  if (opts.subtype) outer.subtype = opts.subtype;
+  if (!opts.omitData) outer.data = data;
+  return { signedPayload: makeJws(outer) };
+}
+
+describe("decodeAppStoreNotification", () => {
+  it("decodes SUBSCRIBED:INITIAL_BUY → activate", () => {
+    const env = buildEnvelope({ notificationType: "SUBSCRIBED", subtype: "INITIAL_BUY" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("subscription");
+    if (d.kind === "subscription") {
+      expect(d.notificationType).toBe("SUBSCRIBED");
+      expect(d.mappedAction.kind).toBe("activate");
+    }
+  });
+
+  it("decodes SUBSCRIBED:RESUBSCRIBE → activate", () => {
+    const env = buildEnvelope({ notificationType: "SUBSCRIBED", subtype: "RESUBSCRIBE" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("activate");
+  });
+
+  it("decodes DID_RENEW → activate with expiresDate", () => {
+    const futureMs = Date.now() + 30 * 86400000;
+    const env = buildEnvelope({ notificationType: "DID_RENEW", expiresDate: futureMs });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("subscription");
+    if (d.kind === "subscription" && d.mappedAction.kind === "activate") {
+      expect(Math.abs(d.mappedAction.expiresDate.getTime() - futureMs)).toBeLessThan(1000);
+    }
+  });
+
+  it("decodes DID_FAIL_TO_RENEW:GRACE_PERIOD → in_grace", () => {
+    const env = buildEnvelope({ notificationType: "DID_FAIL_TO_RENEW", subtype: "GRACE_PERIOD" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("in_grace");
+  });
+
+  it("decodes DID_FAIL_TO_RENEW (no subtype) → on_hold_keep_entitlement", () => {
+    const env = buildEnvelope({ notificationType: "DID_FAIL_TO_RENEW" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("on_hold_keep_entitlement");
+  });
+
+  it("decodes EXPIRED → expire", () => {
+    const env = buildEnvelope({ notificationType: "EXPIRED" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("expire");
+  });
+
+  it("decodes REFUND → revoke", () => {
+    const env = buildEnvelope({ notificationType: "REFUND" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("revoke");
+  });
+
+  it("decodes REVOKE → revoke", () => {
+    const env = buildEnvelope({ notificationType: "REVOKE" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("revoke");
+  });
+
+  it("decodes DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_DISABLED → cancel_keep_entitlement", () => {
+    const env = buildEnvelope({ notificationType: "DID_CHANGE_RENEWAL_STATUS", subtype: "AUTO_RENEW_DISABLED" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("cancel_keep_entitlement");
+  });
+
+  it("decodes DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_ENABLED → noop", () => {
+    const env = buildEnvelope({ notificationType: "DID_CHANGE_RENEWAL_STATUS", subtype: "AUTO_RENEW_ENABLED" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("noop");
+  });
+
+  it("decodes REFUND_REVERSED with future expiry → activate", () => {
+    const future = Date.now() + 30 * 86400000;
+    const env = buildEnvelope({ notificationType: "REFUND_REVERSED", expiresDate: future });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("activate");
+  });
+
+  it("REFUND_REVERSED with PAST expiry → downgrades to expire (past-expiry safety)", () => {
+    const past = Date.now() - 86400000;
+    const env = buildEnvelope({ notificationType: "REFUND_REVERSED", expiresDate: past });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("expire");
+  });
+
+  it("decodes ONE_TIME_CHARGE → noop", () => {
+    const env = buildEnvelope({ notificationType: "ONE_TIME_CHARGE" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("noop");
+  });
+
+  it("returns kind=test for TEST notification (no data object)", () => {
+    const env = { signedPayload: makeJws({ notificationUUID: "uuid-test", notificationType: "TEST", version: "2.0" }) };
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("test");
+  });
+
+  it("returns kind=unknown for unrecognized notificationType", () => {
+    const env = buildEnvelope({ notificationType: "FUTURE_FANCY_TYPE" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("unknown");
+    if (d.kind === "unknown") expect(d.notificationType).toBe("FUTURE_FANCY_TYPE");
+  });
+
+  it("returns kind=unknown when data.signedTransactionInfo is missing", () => {
+    const env = buildEnvelope({ notificationType: "DID_CHANGE_RENEWAL_PREF", omitSignedTransaction: true });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("unknown");
+  });
+
+  it("throws on missing signedPayload", () => {
+    expect(() => decodeAppStoreNotification({})).toThrow(DecoderError);
+  });
+
+  it("throws on JWS that doesn't have 3 segments", () => {
+    expect(() => decodeAppStoreNotification({ signedPayload: "a.b" })).toThrow(DecoderError);
+  });
+
+  it("throws on invalid JSON in JWS payload", () => {
+    expect(() => decodeAppStoreNotification({ signedPayload: "header.!notvalidbase64json!.sig" })).toThrow(DecoderError);
+  });
+});

--- a/apps/server/src/features/billing/app-store.decoder.test.ts
+++ b/apps/server/src/features/billing/app-store.decoder.test.ts
@@ -127,6 +127,12 @@ describe("decodeAppStoreNotification", () => {
     expect(d.kind === "subscription" && d.mappedAction.kind).toBe("noop");
   });
 
+  it("decodes RENEWAL_EXTENDED → noop", () => {
+    const env = buildEnvelope({ notificationType: "RENEWAL_EXTENDED" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("noop");
+  });
+
   it("returns kind=test for TEST notification (no data object)", () => {
     const env = { signedPayload: makeJws({ notificationUUID: "uuid-test", notificationType: "TEST", version: "2.0" }) };
     const d = decodeAppStoreNotification(env);

--- a/apps/server/src/features/billing/app-store.decoder.ts
+++ b/apps/server/src/features/billing/app-store.decoder.ts
@@ -1,0 +1,174 @@
+import { APP_STORE_NOTIFICATION_TYPES, type AppStoreNotificationType } from "@pruvi/shared";
+
+export type AppStoreMappedAction =
+  | { kind: "activate"; expiresDate: Date }
+  | { kind: "in_grace" }
+  | { kind: "cancel_keep_entitlement" }
+  | { kind: "on_hold_keep_entitlement" }
+  | { kind: "expire" }
+  | { kind: "revoke" }
+  | { kind: "noop" };
+
+export type DecodedAppStoreEvent =
+  | {
+      kind: "subscription";
+      notificationUUID: string;
+      notificationType: AppStoreNotificationType;
+      subtype: string | null;
+      mappedAction: AppStoreMappedAction;
+      originalTransactionId: string;
+      productId: string;
+      expiresDate: Date | null;
+      environment: "Sandbox" | "Production";
+    }
+  | { kind: "test"; notificationUUID: string }
+  | {
+      kind: "unknown";
+      notificationUUID: string;
+      notificationType: string;
+      subtype: string | null;
+      originalTransactionId: string | null;
+    };
+
+export class DecoderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DecoderError";
+  }
+}
+
+type AppStoreEnvelope = { signedPayload?: unknown };
+
+function decodeJwsSegment(jws: string): unknown {
+  const parts = jws.split(".");
+  if (parts.length !== 3) throw new DecoderError("JWS must have exactly 3 segments");
+  try {
+    const decoded = Buffer.from(parts[1]!, "base64url").toString("utf-8");
+    return JSON.parse(decoded);
+  } catch (_e) {
+    throw new DecoderError("JWS middle segment is not valid base64url+JSON");
+  }
+}
+
+/** SECURITY: deferred — see spec §2 non-goals. v1 trusts the URL-path secret for auth.
+ *  Real x5c certificate-chain verification is a hardening ticket. */
+export function decodeAppStoreNotification(raw: unknown): DecodedAppStoreEvent {
+  if (!raw || typeof raw !== "object") throw new DecoderError("Envelope is not an object");
+  const env = raw as AppStoreEnvelope;
+  if (typeof env.signedPayload !== "string") throw new DecoderError("Missing signedPayload");
+
+  const outer = decodeJwsSegment(env.signedPayload) as {
+    notificationUUID?: string;
+    notificationType?: string;
+    subtype?: string;
+    data?: {
+      signedTransactionInfo?: string;
+      environment?: string;
+    };
+    version?: string;
+    signedDate?: number;
+  };
+
+  const notificationUUID = outer.notificationUUID;
+  if (!notificationUUID || typeof notificationUUID !== "string") {
+    throw new DecoderError("Missing notificationUUID");
+  }
+  const notificationType = outer.notificationType;
+  if (!notificationType || typeof notificationType !== "string") {
+    throw new DecoderError("Missing notificationType");
+  }
+
+  // Step 3: TEST notification has no `data` object. Check FIRST.
+  if (notificationType === "TEST") {
+    return { kind: "test", notificationUUID };
+  }
+
+  const subtype = typeof outer.subtype === "string" ? outer.subtype : null;
+  const data = outer.data;
+
+  // Some notification types don't carry signedTransactionInfo.
+  if (!data || typeof data.signedTransactionInfo !== "string") {
+    return {
+      kind: "unknown",
+      notificationUUID,
+      notificationType,
+      subtype,
+      originalTransactionId: null,
+    };
+  }
+
+  const inner = decodeJwsSegment(data.signedTransactionInfo) as {
+    originalTransactionId?: string;
+    productId?: string;
+    expiresDate?: number;
+    environment?: string;
+  };
+  const originalTransactionId = inner.originalTransactionId;
+  const productId = inner.productId;
+  if (!originalTransactionId || typeof originalTransactionId !== "string") {
+    throw new DecoderError("Missing originalTransactionId");
+  }
+  if (!productId || typeof productId !== "string") {
+    throw new DecoderError("Missing productId");
+  }
+  const expiresDate = typeof inner.expiresDate === "number" ? new Date(inner.expiresDate) : null;
+  const environment = (data.environment === "Production" ? "Production" : "Sandbox") as "Sandbox" | "Production";
+
+  // Is this a known notification type?
+  if (!APP_STORE_NOTIFICATION_TYPES.includes(notificationType as AppStoreNotificationType)) {
+    return { kind: "unknown", notificationUUID, notificationType, subtype, originalTransactionId };
+  }
+  const typedNotificationType = notificationType as AppStoreNotificationType;
+
+  let action = mapNotificationToAction(typedNotificationType, subtype, expiresDate);
+  // Past-expiry safety: if "activate" but the date is in the past, downgrade to "expire".
+  if (action.kind === "activate" && action.expiresDate.getTime() < Date.now()) {
+    action = { kind: "expire" };
+  }
+
+  return {
+    kind: "subscription",
+    notificationUUID,
+    notificationType: typedNotificationType,
+    subtype,
+    mappedAction: action,
+    originalTransactionId,
+    productId,
+    expiresDate,
+    environment,
+  };
+}
+
+function mapNotificationToAction(
+  type: AppStoreNotificationType,
+  subtype: string | null,
+  expiresDate: Date | null,
+): AppStoreMappedAction {
+  switch (type) {
+    case "SUBSCRIBED":
+    case "DID_RENEW":
+    case "REFUND_REVERSED":
+      if (!expiresDate) return { kind: "noop" };
+      return { kind: "activate", expiresDate };
+    case "DID_FAIL_TO_RENEW":
+      return subtype === "GRACE_PERIOD" ? { kind: "in_grace" } : { kind: "on_hold_keep_entitlement" };
+    case "EXPIRED":
+    case "GRACE_PERIOD_EXPIRED":
+      return { kind: "expire" };
+    case "REFUND":
+    case "REVOKE":
+      return { kind: "revoke" };
+    case "DID_CHANGE_RENEWAL_STATUS":
+      return subtype === "AUTO_RENEW_DISABLED" ? { kind: "cancel_keep_entitlement" } : { kind: "noop" };
+    case "DID_CHANGE_RENEWAL_PREF":
+    case "OFFER_REDEEMED":
+    case "PRICE_INCREASE":
+    case "RENEWAL_EXTENDED":
+    case "REFUND_DECLINED":
+    case "CONSUMPTION_REQUEST":
+    case "ONE_TIME_CHARGE":
+      return { kind: "noop" };
+    case "TEST":
+      return { kind: "noop" }; // unreachable (TEST handled earlier)
+  }
+}

--- a/apps/server/src/features/billing/billing.repository.integration.test.ts
+++ b/apps/server/src/features/billing/billing.repository.integration.test.ts
@@ -119,4 +119,20 @@ describe("BillingRepository (integration)", () => {
     expect(after).not.toBeNull();
     expect(after!.userId).toBeNull();
   });
+
+  it("cross-provider: same message_id string for google_play and app_store coexist (composite UNIQUE)", async () => {
+    const a = await repo.insertEvent(db, { provider: "google_play", messageId: "shared-id", eventType: "PURCHASED", purchaseToken: "tA", payload: {} });
+    const b = await repo.insertEvent(db, { provider: "app_store", messageId: "shared-id", eventType: "SUBSCRIBED", purchaseToken: "tB", payload: {} });
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!.id).not.toBe(b!.id);
+  });
+
+  it("cross-provider: same purchase_token string for google_play and app_store coexist", async () => {
+    const a = await repo.createOrphanSubscription(db, "google_play", "shared-token");
+    const b = await repo.createOrphanSubscription(db, "app_store", "shared-token");
+    expect(a.id).not.toBe(b.id);
+    expect(a.provider).toBe("google_play");
+    expect(b.provider).toBe("app_store");
+  });
 });

--- a/apps/server/src/features/billing/billing.route.ts
+++ b/apps/server/src/features/billing/billing.route.ts
@@ -49,7 +49,7 @@ export const billingRoutes: FastifyPluginAsyncZod = async (fastify) => {
       preHandler: [webhookGuard],
     },
     async (request) => {
-      const result = await service.processWebhookEnvelope(request.body);
+      const result = await service.processGooglePlayEnvelope(request.body);
       if (result.isErr()) {
         const error = result.error;
         // For MALFORMED_ENVELOPE we still return 200 so Pub/Sub stops retrying.

--- a/apps/server/src/features/billing/billing.route.ts
+++ b/apps/server/src/features/billing/billing.route.ts
@@ -2,11 +2,11 @@ import { z } from "zod";
 import { timingSafeEqual } from "node:crypto";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import type { FastifyRequest, FastifyReply } from "fastify";
-import { GooglePlayLinkBodySchema, GooglePlayLinkResponseSchema } from "@pruvi/shared";
+import { GooglePlayLinkBodySchema, GooglePlayLinkResponseSchema, AppStoreLinkBodySchema, AppStoreLinkResponseSchema } from "@pruvi/shared";
 import { env } from "@pruvi/env/server";
 import { db } from "@pruvi/db";
 import { successResponse, unwrapResult } from "../../types";
-import { AppError, UnauthorizedError } from "../../utils/errors";
+import { AppError, UnauthorizedError, NotFoundError } from "../../utils/errors";
 import { BillingRepository } from "./billing.repository";
 import { BillingService } from "./billing.service";
 import { UltraRepository } from "../ultra/ultra.repository";
@@ -30,6 +30,23 @@ async function webhookGuard(request: FastifyRequest, _reply: FastifyReply) {
   const b = Buffer.from(env.GOOGLE_PLAY_WEBHOOK_TOKEN);
   if (a.length !== b.length || !timingSafeEqual(a, b)) {
     throw new UnauthorizedError("UNAUTHORIZED");
+  }
+}
+
+// IMPORTANT: throw AppError subclasses (not plain Error) so the error handler maps statusCode correctly.
+// Returns 404 on token mismatch to keep the endpoint URL-obscure (not 401/403).
+async function appStorePathGuard(request: FastifyRequest) {
+  if (!env.APP_STORE_WEBHOOK_TOKEN) {
+    throw new AppError("WEBHOOK_DISABLED", 503, "WEBHOOK_DISABLED");
+  }
+  const { token } = request.params as { token: string };
+  if (typeof token !== "string") {
+    throw new NotFoundError("Not Found");
+  }
+  const a = Buffer.from(token);
+  const b = Buffer.from(env.APP_STORE_WEBHOOK_TOKEN);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    throw new NotFoundError("Not Found");
   }
 }
 
@@ -75,6 +92,56 @@ export const billingRoutes: FastifyPluginAsyncZod = async (fastify) => {
     },
     async (request) => {
       const data = unwrapResult(await service.linkGooglePlayPurchase(request.userId, request.body)).data;
+      return successResponse(data);
+    },
+  );
+
+  fastify.post(
+    "/webhooks/app-store/:token",
+    {
+      schema: {
+        params: z.object({ token: z.string() }),
+        body: z.unknown(),
+        response: {
+          200: z.object({
+            success: z.literal(true),
+            data: z.object({
+              received: z.boolean(),
+              notificationUUID: z.string().optional(),
+              kind: z.string().optional(),
+              error: z.string().optional(),
+            }),
+          }),
+        },
+      },
+      preHandler: [appStorePathGuard],
+    },
+    async (request) => {
+      const result = await service.processAppStoreEnvelope(request.body);
+      if (result.isErr()) {
+        const error = result.error;
+        if (error.code === "MALFORMED_ENVELOPE") {
+          fastify.log.warn({ err: error.message }, "app-store webhook malformed envelope");
+          return successResponse({ received: false, error: "MALFORMED_ENVELOPE" });
+        }
+        fastify.log.error({ err: error.message }, "app-store webhook processing failed");
+        return successResponse({ received: false, error: "PROCESSING_FAILED" });
+      }
+      return successResponse({ received: true, notificationUUID: result.value.notificationUUID, kind: result.value.kind });
+    },
+  );
+
+  fastify.post(
+    "/billing/app-store/link",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        body: AppStoreLinkBodySchema,
+        response: { 200: z.object({ success: z.literal(true), data: AppStoreLinkResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const data = unwrapResult(await service.linkAppStorePurchase(request.userId, request.body)).data;
       return successResponse(data);
     },
   );

--- a/apps/server/src/features/billing/billing.service.test.ts
+++ b/apps/server/src/features/billing/billing.service.test.ts
@@ -52,7 +52,7 @@ describe("BillingService", () => {
   it("PURCHASED on linked subscription: active + grant called with ~now+30d", async () => {
     const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() };
     const { service, ultra, repo } = buildSut({ findSubscription: linked });
-    const r = await service.processWebhookEnvelope(buildEnvelope(4));
+    const r = await service.processGooglePlayEnvelope(buildEnvelope(4));
     expect(r.isOk()).toBe(true);
     expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "active" }));
     expect(ultra.grant).toHaveBeenCalledTimes(1);
@@ -64,7 +64,7 @@ describe("BillingService", () => {
   // Case 2
   it("PURCHASED with NO existing subscription: orphan created, NO grant", async () => {
     const { service, ultra, repo } = buildSut({ findSubscription: null });
-    await service.processWebhookEnvelope(buildEnvelope(4));
+    await service.processGooglePlayEnvelope(buildEnvelope(4));
     expect(repo.createOrphanSubscription).toHaveBeenCalled();
     expect(ultra.grant).not.toHaveBeenCalled();
   });
@@ -73,7 +73,7 @@ describe("BillingService", () => {
   it("EXPIRED with no other active subs: revoke called", async () => {
     const active: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
     const { service, ultra } = buildSut({ findSubscription: active, hasOtherActive: false });
-    await service.processWebhookEnvelope(buildEnvelope(13));
+    await service.processGooglePlayEnvelope(buildEnvelope(13));
     expect(ultra.revoke).toHaveBeenCalledWith("u1");
   });
 
@@ -81,7 +81,7 @@ describe("BillingService", () => {
   it("EXPIRED with another active subscription: revoke NOT called (multi-sub guard)", async () => {
     const active: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
     const { service, ultra, repo } = buildSut({ findSubscription: active, hasOtherActive: true });
-    await service.processWebhookEnvelope(buildEnvelope(13));
+    await service.processGooglePlayEnvelope(buildEnvelope(13));
     expect(repo.hasOtherActiveSubscription).toHaveBeenCalledWith(expect.anything(), "u1", 10);
     expect(ultra.revoke).not.toHaveBeenCalled();
   });
@@ -91,7 +91,7 @@ describe("BillingService", () => {
     const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() };
     const farFuture = new Date(Date.now() + 365 * 86400000); // 1 year out
     const { service, ultra } = buildSut({ findSubscription: linked, maxOtherEnd: farFuture });
-    await service.processWebhookEnvelope(buildEnvelope(4));
+    await service.processGooglePlayEnvelope(buildEnvelope(4));
     expect(ultra.grant).toHaveBeenCalledWith("u1", farFuture);
   });
 
@@ -99,7 +99,7 @@ describe("BillingService", () => {
   it("CANCELED: state=canceled, no Ultra change", async () => {
     const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
     const { service, ultra, repo } = buildSut({ findSubscription: linked });
-    await service.processWebhookEnvelope(buildEnvelope(3));
+    await service.processGooglePlayEnvelope(buildEnvelope(3));
     expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "canceled" }));
     expect(ultra.grant).not.toHaveBeenCalled();
     expect(ultra.revoke).not.toHaveBeenCalled();
@@ -108,14 +108,14 @@ describe("BillingService", () => {
   // Case 6
   it("Duplicate messageId: second call no-op (insertEvent returns null)", async () => {
     const { service, ultra } = buildSut({ insertEvent: null });
-    await service.processWebhookEnvelope(buildEnvelope(4));
+    await service.processGooglePlayEnvelope(buildEnvelope(4));
     expect(ultra.grant).not.toHaveBeenCalled();
   });
 
   // Case 7
   it("Unknown notificationType: UNKNOWN_99 event recorded, no state mutation", async () => {
     const { service, ultra, repo } = buildSut();
-    await service.processWebhookEnvelope(buildEnvelope(99));
+    await service.processGooglePlayEnvelope(buildEnvelope(99));
     expect(repo.insertEvent).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: "UNKNOWN_99" }));
     expect(repo.updateSubscriptionState).not.toHaveBeenCalled();
     expect(ultra.grant).not.toHaveBeenCalled();

--- a/apps/server/src/features/billing/billing.service.test.ts
+++ b/apps/server/src/features/billing/billing.service.test.ts
@@ -168,3 +168,155 @@ describe("BillingService", () => {
     expect(ultra.grant).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// App Store builder helpers
+// ---------------------------------------------------------------------------
+
+function buildAppStoreEnvelope(
+  notificationType: string,
+  opts: {
+    subtype?: string;
+    expiresDate?: number;
+    originalTransactionId?: string;
+    notificationUUID?: string;
+  } = {},
+) {
+  const header = Buffer.from(JSON.stringify({ alg: "ES256" })).toString("base64url");
+  const tx = {
+    originalTransactionId: opts.originalTransactionId ?? "tok",
+    productId: "pruvi_ultra_monthly",
+    expiresDate: opts.expiresDate ?? Date.now() + 30 * 86400000,
+    environment: "Production",
+  };
+  const innerJws = `${header}.${Buffer.from(JSON.stringify(tx)).toString("base64url")}.sig`;
+  const outer: Record<string, unknown> = {
+    notificationUUID: opts.notificationUUID ?? "uuid-1",
+    notificationType,
+    version: "2.0",
+    signedDate: Date.now(),
+    data: { signedTransactionInfo: innerJws, environment: "Production" },
+  };
+  if (opts.subtype) outer.subtype = opts.subtype;
+  return { signedPayload: `${header}.${Buffer.from(JSON.stringify(outer)).toString("base64url")}.sig` };
+}
+
+describe("BillingService — App Store", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Case 1: SUBSCRIBED with linked sub → active, grant with expiresDate from Apple
+  it("SUBSCRIBED with linked sub: state=active, grant called with expiresDate from Apple", async () => {
+    const futureMs = Date.now() + 30 * 86400000;
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "app_store", productId: "pruvi_ultra_monthly", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    const r = await service.processAppStoreEnvelope(buildAppStoreEnvelope("SUBSCRIBED", { subtype: "INITIAL_BUY", expiresDate: futureMs }));
+    expect(r.isOk()).toBe(true);
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "active" }));
+    expect(ultra.grant).toHaveBeenCalledTimes(1);
+    const grantedExpiry = ultra.grant.mock.calls[0]![1] as Date;
+    expect(Math.abs(grantedExpiry.getTime() - futureMs)).toBeLessThan(1000);
+  });
+
+  // Case 2: DID_RENEW → active, grant with new expiresDate
+  it("DID_RENEW: state=active, grant called with new expiresDate", async () => {
+    const futureMs = Date.now() + 30 * 86400000;
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "app_store", productId: "pruvi_ultra_monthly", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    const r = await service.processAppStoreEnvelope(buildAppStoreEnvelope("DID_RENEW", { expiresDate: futureMs }));
+    expect(r.isOk()).toBe(true);
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "active" }));
+    expect(ultra.grant).toHaveBeenCalledTimes(1);
+    const grantedExpiry = ultra.grant.mock.calls[0]![1] as Date;
+    expect(Math.abs(grantedExpiry.getTime() - futureMs)).toBeLessThan(1000);
+  });
+
+  // Case 3: DID_FAIL_TO_RENEW (no subtype) → on_hold, no Ultra change
+  it("DID_FAIL_TO_RENEW (no subtype): state=on_hold, no Ultra change", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "app_store", productId: "pruvi_ultra_monthly", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    await service.processAppStoreEnvelope(buildAppStoreEnvelope("DID_FAIL_TO_RENEW"));
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "on_hold" }));
+    expect(ultra.grant).not.toHaveBeenCalled();
+    expect(ultra.revoke).not.toHaveBeenCalled();
+  });
+
+  // Case 4: DID_FAIL_TO_RENEW:GRACE_PERIOD → in_grace, no Ultra change
+  it("DID_FAIL_TO_RENEW:GRACE_PERIOD: state=in_grace, no Ultra change", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "app_store", productId: "pruvi_ultra_monthly", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    await service.processAppStoreEnvelope(buildAppStoreEnvelope("DID_FAIL_TO_RENEW", { subtype: "GRACE_PERIOD" }));
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "in_grace" }));
+    expect(ultra.grant).not.toHaveBeenCalled();
+    expect(ultra.revoke).not.toHaveBeenCalled();
+  });
+
+  // Case 5: EXPIRED with no other active → revoke called
+  it("EXPIRED with no other active subs: revoke called", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "app_store", productId: "pruvi_ultra_monthly", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra } = buildSut({ findSubscription: linked, hasOtherActive: false });
+    await service.processAppStoreEnvelope(buildAppStoreEnvelope("EXPIRED"));
+    expect(ultra.revoke).toHaveBeenCalledWith("u1");
+  });
+
+  // Case 6: EXPIRED with other active sub → revoke NOT called (multi-sub guard)
+  it("EXPIRED with another active subscription: revoke NOT called (multi-sub guard)", async () => {
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "app_store", productId: "pruvi_ultra_monthly", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked, hasOtherActive: true });
+    await service.processAppStoreEnvelope(buildAppStoreEnvelope("EXPIRED"));
+    expect(repo.hasOtherActiveSubscription).toHaveBeenCalledWith(expect.anything(), "u1", 10);
+    expect(ultra.revoke).not.toHaveBeenCalled();
+  });
+
+  // Case 7: REFUND_REVERSED with future expiry → active, grant
+  it("REFUND_REVERSED with future expiry: state=active, ultra.grant called", async () => {
+    const futureMs = Date.now() + 30 * 86400000;
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "app_store", productId: "pruvi_ultra_monthly", purchaseToken: "tok", status: "revoked", currentPeriodEnd: new Date(), linkedAt: new Date() };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    await service.processAppStoreEnvelope(buildAppStoreEnvelope("REFUND_REVERSED", { expiresDate: futureMs }));
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 10, expect.objectContaining({ status: "active" }));
+    expect(ultra.grant).toHaveBeenCalledTimes(1);
+  });
+
+  // Case 8: Duplicate notificationUUID → no state change, no Ultra call
+  it("Duplicate notificationUUID: second delivery is no-op (insertEvent returns null)", async () => {
+    const { service, ultra, repo } = buildSut();
+    // Override insertEvent to return null (simulates duplicate rejection by DB unique constraint).
+    (repo.insertEvent as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    await service.processAppStoreEnvelope(buildAppStoreEnvelope("SUBSCRIBED", { notificationUUID: "uuid-dup" }));
+    expect(ultra.grant).not.toHaveBeenCalled();
+    expect(repo.updateSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  // Case 9: TEST notification → audit insert with eventType="TEST", no other action
+  it("TEST notification: audit row inserted with eventType=TEST, no state mutation", async () => {
+    const { service, ultra, repo } = buildSut();
+    const testEnv = { signedPayload: (() => {
+      const header = Buffer.from(JSON.stringify({ alg: "ES256" })).toString("base64url");
+      const body = Buffer.from(JSON.stringify({ notificationUUID: "uuid-test", notificationType: "TEST", version: "2.0" })).toString("base64url");
+      return `${header}.${body}.sig`;
+    })() };
+    const r = await service.processAppStoreEnvelope(testEnv);
+    expect(r.isOk()).toBe(true);
+    expect(repo.insertEvent).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: "TEST", provider: "app_store" }));
+    expect(ultra.grant).not.toHaveBeenCalled();
+    expect(ultra.revoke).not.toHaveBeenCalled();
+    expect(repo.updateSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  // Case 10: Link with conflict (other user owns token) → ConflictError thrown
+  it("linkAppStorePurchase: token owned by other user throws ConflictError", async () => {
+    const owned: SubscriptionRow = { id: 10, userId: "OTHER", provider: "app_store", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service } = buildSut({ findSubscription: owned });
+    await expect(service.linkAppStorePurchase("u1", { originalTransactionId: "tok", productId: "pruvi_ultra_monthly" })).rejects.toThrow(/PURCHASE_TOKEN_OWNED/);
+  });
+
+  // Case 11: Multi-sub GRANT guard with App Store — another active sub with LATER end → ultra.grant uses MAX
+  it("App Store SUBSCRIBED with another active sub having LATER period end: grant uses MAX expiry", async () => {
+    const futureMs = Date.now() + 30 * 86400000;
+    const linked: SubscriptionRow = { id: 10, userId: "u1", provider: "app_store", productId: "pruvi_ultra_monthly", purchaseToken: "tok", status: "pending", currentPeriodEnd: null, linkedAt: new Date() };
+    const farFuture = new Date(Date.now() + 365 * 86400000); // 1 year out
+    const { service, ultra } = buildSut({ findSubscription: linked, maxOtherEnd: farFuture });
+    await service.processAppStoreEnvelope(buildAppStoreEnvelope("SUBSCRIBED", { expiresDate: futureMs }));
+    expect(ultra.grant).toHaveBeenCalledWith("u1", farFuture);
+  });
+});

--- a/apps/server/src/features/billing/billing.service.test.ts
+++ b/apps/server/src/features/billing/billing.service.test.ts
@@ -319,4 +319,34 @@ describe("BillingService — App Store", () => {
     await service.processAppStoreEnvelope(buildAppStoreEnvelope("SUBSCRIBED", { expiresDate: futureMs }));
     expect(ultra.grant).toHaveBeenCalledWith("u1", farFuture);
   });
+
+  // Case 12: DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_DISABLED → status=canceled, no Ultra change
+  it("App Store DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_DISABLED → status=canceled, no Ultra change", async () => {
+    const linked: SubscriptionRow = {
+      id: 10, userId: "u1", provider: "app_store", productId: "p", purchaseToken: "tok",
+      status: "active", currentPeriodEnd: new Date(Date.now() + 30 * 86400000), linkedAt: new Date(),
+    };
+    const { service, ultra, repo } = buildSut({ findSubscription: linked });
+    const env = buildAppStoreEnvelope("DID_CHANGE_RENEWAL_STATUS", { subtype: "AUTO_RENEW_DISABLED" });
+    await service.processAppStoreEnvelope(env);
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(
+      expect.anything(),
+      10,
+      expect.objectContaining({ status: "canceled" }),
+    );
+    expect(ultra.grant).not.toHaveBeenCalled();
+    expect(ultra.revoke).not.toHaveBeenCalled();
+  });
+
+  // Case 13: linkAppStorePurchase same-user idempotency
+  it("App Store link: same user re-call returns existing subscription, no error", async () => {
+    const existing: SubscriptionRow = {
+      id: 10, userId: "u1", provider: "app_store", productId: "p", purchaseToken: "tok",
+      status: "active", currentPeriodEnd: null, linkedAt: new Date(),
+    };
+    const { service } = buildSut({ findSubscription: existing });
+    const r = await service.linkAppStorePurchase("u1", { originalTransactionId: "tok", productId: "p" });
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value.subscription.id).toBe(10);
+  });
 });

--- a/apps/server/src/features/billing/billing.service.ts
+++ b/apps/server/src/features/billing/billing.service.ts
@@ -1,10 +1,12 @@
 import { ok, err, type Result } from "neverthrow";
 import { AppError, ConflictError } from "../../utils/errors";
-import { DEFAULT_SUBSCRIPTION_PERIOD_MS, type GooglePlayLinkResponse, type SubscriptionStatus } from "@pruvi/shared";
+import { DEFAULT_SUBSCRIPTION_PERIOD_MS, type GooglePlayLinkResponse, type AppStoreLinkResponse, type SubscriptionStatus } from "@pruvi/shared";
 import type { BillingRepository, SubscriptionRow } from "./billing.repository";
 import type { UltraService } from "../ultra/ultra.service";
 import type { DecodedGooglePlayEvent } from "./google-play.decoder";
 import { decodeGooglePlayPubSubEnvelope } from "./google-play.decoder";
+import type { DecodedAppStoreEvent } from "./app-store.decoder";
+import { decodeAppStoreNotification } from "./app-store.decoder";
 import type { db as DbClient } from "@pruvi/db";
 
 type Db = typeof DbClient;
@@ -198,6 +200,159 @@ export class BillingService {
       case "PRICE_STEP_UP_CONSENT_UPDATED":
         return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
     }
+  }
+
+  /** Apple webhook entry point. Same orchestration as processGooglePlayEnvelope:
+   *  decode → dedup → state machine → queue post-commit ultra effect. */
+  async processAppStoreEnvelope(envelope: unknown): Promise<Result<{ notificationUUID: string; kind: string }, AppError>> {
+    let decoded: DecodedAppStoreEvent;
+    try {
+      decoded = decodeAppStoreNotification(envelope);
+    } catch (e) {
+      return err(new AppError(`MALFORMED_ENVELOPE: ${(e as Error).message}`, 200, "MALFORMED_ENVELOPE"));
+    }
+
+    if (decoded.kind === "test") {
+      await this.repo.insertEvent(this.db, {
+        provider: "app_store",
+        messageId: decoded.notificationUUID,
+        eventType: "TEST",
+        purchaseToken: null,
+        payload: { kind: "test" },
+      });
+      return ok({ notificationUUID: decoded.notificationUUID, kind: "test" });
+    }
+
+    const effect = await this.db.transaction(async (tx) => {
+      const eventType = decoded.kind === "subscription" ? decoded.notificationType : `UNKNOWN_${decoded.notificationType}`;
+      // test was already handled above; subscription always has token, unknown may have it null.
+      const purchaseToken: string | null =
+        decoded.kind === "subscription" ? decoded.originalTransactionId : (decoded.originalTransactionId ?? null);
+      const inserted = await this.repo.insertEvent(tx, {
+        provider: "app_store",
+        messageId: decoded.notificationUUID,
+        eventType,
+        purchaseToken,
+        payload: decoded as unknown as Record<string, unknown>,
+      });
+      if (!inserted) {
+        return { kind: "none" } as PostCommitUltraEffect;
+      }
+
+      if (decoded.kind === "unknown") {
+        await this.repo.markEventProcessed(tx, inserted.id);
+        return { kind: "none" } as PostCommitUltraEffect;
+      }
+
+      let sub = await this.repo.findSubscriptionByToken(tx, "app_store", decoded.originalTransactionId);
+      if (!sub) {
+        sub = await this.repo.createOrphanSubscription(tx, "app_store", decoded.originalTransactionId);
+      }
+
+      const { newStatus, newPeriodEnd, ultraEffect } = this.applyAppStoreEvent(decoded, sub);
+      await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
+
+      if (sub.userId === null) {
+        return { kind: "none" } as PostCommitUltraEffect;
+      }
+      await this.repo.markEventProcessed(tx, inserted.id);
+      return ultraEffect;
+    });
+
+    await this.applyUltraEffect(effect);
+    return ok({ notificationUUID: decoded.notificationUUID, kind: decoded.kind });
+  }
+
+  /** Pure state-machine for App Store events. Mirror of the Google `applyDecodedEvent`. */
+  applyAppStoreEvent(
+    decoded: DecodedAppStoreEvent,
+    sub: SubscriptionRow,
+  ): { newStatus: SubscriptionStatus; newPeriodEnd: Date | null; ultraEffect: PostCommitUltraEffect } {
+    if (decoded.kind !== "subscription") {
+      return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+    }
+    const grant = (end: Date): PostCommitUltraEffect =>
+      sub.userId !== null
+        ? { kind: "grant", userId: sub.userId, expiresAt: end, excludeSubscriptionId: sub.id }
+        : { kind: "none" };
+    const revoke = (): PostCommitUltraEffect =>
+      sub.userId !== null
+        ? { kind: "revoke_if_no_other_active", userId: sub.userId, excludeSubscriptionId: sub.id }
+        : { kind: "none" };
+
+    switch (decoded.mappedAction.kind) {
+      case "activate":
+        return {
+          newStatus: "active",
+          newPeriodEnd: decoded.mappedAction.expiresDate,
+          ultraEffect: grant(decoded.mappedAction.expiresDate),
+        };
+      case "in_grace":
+        return { newStatus: "in_grace", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+      case "cancel_keep_entitlement":
+        return { newStatus: "canceled", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+      case "on_hold_keep_entitlement":
+        return { newStatus: "on_hold", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+      case "expire":
+        return { newStatus: "expired", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "revoke":
+        return { newStatus: "revoked", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+      case "noop":
+        return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+    }
+  }
+
+  async linkAppStorePurchase(
+    userId: string,
+    body: { originalTransactionId: string; productId: string },
+  ): Promise<Result<AppStoreLinkResponse, AppError>> {
+    const effects: PostCommitUltraEffect[] = [];
+    const finalRow = await this.db.transaction(async (tx) => {
+      const existing = await this.repo.findSubscriptionByToken(tx, "app_store", body.originalTransactionId);
+      let sub: SubscriptionRow;
+      if (!existing) {
+        const created = await this.repo.upsertLinkedSubscription(tx, {
+          userId, provider: "app_store", productId: body.productId, token: body.originalTransactionId,
+        });
+        sub = created.subscription;
+      } else if (existing.userId !== null && existing.userId !== userId) {
+        throw new ConflictError("PURCHASE_TOKEN_OWNED_BY_OTHER_USER");
+      } else if (existing.userId === userId) {
+        sub = existing;
+      } else {
+        sub = await this.repo.claimOrphanSubscription(tx, existing.id, userId, body.productId);
+      }
+
+      const parked = await this.repo.listUnprocessedEventsForToken(tx, "app_store", body.originalTransactionId);
+      for (const event of parked) {
+        const decoded = event.payload as unknown as DecodedAppStoreEvent;
+        if (decoded.kind !== "subscription") {
+          await this.repo.markEventProcessed(tx, event.id);
+          continue;
+        }
+        const fresh = await this.repo.findSubscriptionByToken(tx, "app_store", body.originalTransactionId);
+        if (!fresh) throw new Error("replay: subscription disappeared mid-transaction");
+        sub = fresh;
+        const { newStatus, newPeriodEnd, ultraEffect } = this.applyAppStoreEvent(decoded, sub);
+        await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
+        await this.repo.markEventProcessed(tx, event.id);
+        effects.push(ultraEffect);
+      }
+      const final = await this.repo.findSubscriptionByToken(tx, "app_store", body.originalTransactionId);
+      if (!final) throw new Error("link: subscription disappeared mid-transaction");
+      return final;
+    });
+
+    for (const e of effects) await this.applyUltraEffect(e);
+
+    return ok({
+      subscription: {
+        id: finalRow.id,
+        status: finalRow.status,
+        productId: finalRow.productId,
+        currentPeriodEnd: finalRow.currentPeriodEnd?.toISOString() ?? null,
+      },
+    });
   }
 
   private async applyUltraEffect(effect: PostCommitUltraEffect): Promise<void> {

--- a/apps/server/src/features/billing/billing.service.ts
+++ b/apps/server/src/features/billing/billing.service.ts
@@ -28,7 +28,7 @@ export class BillingService {
 
   /** Webhook entry point. Returns the response payload; always 200 on accepted shapes.
    *  Auth + envelope-shape validation happens in the route. */
-  async processWebhookEnvelope(envelope: unknown): Promise<Result<{ messageId: string; kind: string }, AppError>> {
+  async processGooglePlayEnvelope(envelope: unknown): Promise<Result<{ messageId: string; kind: string }, AppError>> {
     let decoded: DecodedGooglePlayEvent;
     try {
       decoded = decodeGooglePlayPubSubEnvelope(envelope);

--- a/docs/superpowers/plans/2026-05-12-phase-2e5-app-store-webhooks.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e5-app-store-webhooks.md
@@ -1,0 +1,878 @@
+# Phase 2E.5 — App Store Server Notifications V2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Gate C (Opus 4.7) after EVERY task. Final Gate D before PR.
+
+**Goal:** Extend the existing `billing` module (from 2E.4) with an App Store Server Notifications V2 adapter. Reuse the `subscription`/`billing_event` tables, the `BillingRepository`, and `applyUltraEffect` (multi-sub guards). Add: shared schemas, an `applyAppStoreEvent` state-machine, an Apple JWS decoder, two new routes, and rename `processWebhookEnvelope` → `processGooglePlayEnvelope` for symmetry.
+
+**Architecture:** Apple sends signed JWS payloads via direct HTTPS POST. Auth via URL-path secret (Apple cannot inject custom headers, so the Google header pattern can't transfer). The decoder parses two layers of JWS (no signature verification in v1 — deferred). The state machine has its own pure function (`applyAppStoreEvent`) sibling to `applyDecodedEvent` (Google). `applyUltraEffect` is reused unchanged.
+
+**Tech Stack:** Drizzle ORM, Fastify 5 + fastify-type-provider-zod on Bun, neverthrow Result, real Postgres for integration tests.
+
+**Authoritative spec:** `docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md` (v2 post Gate A).
+
+---
+
+## Task 1 — Shared schemas, env, rename Google webhook entry point
+
+**Files:**
+- Modify: `packages/env/src/server.ts`
+- Modify: `packages/shared/src/billing.ts`
+- Modify: `packages/shared/src/billing.test.ts`
+- Modify: `apps/server/src/features/billing/billing.service.ts` (rename `processWebhookEnvelope` → `processGooglePlayEnvelope`)
+- Modify: `apps/server/src/features/billing/billing.route.ts` (update the call site)
+
+- [ ] **Step 1.1: Add `APP_STORE_WEBHOOK_TOKEN` to env**
+
+In `packages/env/src/server.ts`, add after `GOOGLE_PLAY_WEBHOOK_TOKEN`:
+
+```ts
+    APP_STORE_WEBHOOK_TOKEN: z.string().min(32).optional(),
+```
+
+Note `min(32)`, not 16 — this token appears in the URL path and acts as the sole auth.
+
+- [ ] **Step 1.2: Add App Store shared schemas**
+
+In `packages/shared/src/billing.ts`, append:
+
+```ts
+export const APP_STORE_NOTIFICATION_TYPES = [
+  "SUBSCRIBED",
+  "DID_RENEW",
+  "DID_FAIL_TO_RENEW",
+  "EXPIRED",
+  "GRACE_PERIOD_EXPIRED",
+  "REFUND",
+  "REFUND_DECLINED",
+  "REFUND_REVERSED",
+  "REVOKE",
+  "DID_CHANGE_RENEWAL_STATUS",
+  "DID_CHANGE_RENEWAL_PREF",
+  "OFFER_REDEEMED",
+  "PRICE_INCREASE",
+  "RENEWAL_EXTENDED",
+  "CONSUMPTION_REQUEST",
+  "ONE_TIME_CHARGE",
+  "TEST",
+] as const;
+export type AppStoreNotificationType = (typeof APP_STORE_NOTIFICATION_TYPES)[number];
+
+export const AppStoreLinkBodySchema = z.object({
+  originalTransactionId: z.string().min(1),
+  productId: z.string().min(1),
+});
+export type AppStoreLinkBody = z.infer<typeof AppStoreLinkBodySchema>;
+
+/** Type alias — Apple link response shape is identical to Google's (provider-agnostic). */
+export const AppStoreLinkResponseSchema = GooglePlayLinkResponseSchema;
+export type AppStoreLinkResponse = z.infer<typeof AppStoreLinkResponseSchema>;
+```
+
+- [ ] **Step 1.3: Extend `billing.test.ts`**
+
+Append to `packages/shared/src/billing.test.ts` inside the existing top-level `describe("billing shared module", ...)`:
+
+```ts
+it("declares all 17 app store notification types", () => {
+  expect(APP_STORE_NOTIFICATION_TYPES).toHaveLength(17);
+  expect(APP_STORE_NOTIFICATION_TYPES).toContain("SUBSCRIBED");
+  expect(APP_STORE_NOTIFICATION_TYPES).toContain("REFUND_REVERSED");
+  expect(APP_STORE_NOTIFICATION_TYPES).toContain("ONE_TIME_CHARGE");
+});
+
+it("validates app store link body shape", () => {
+  expect(AppStoreLinkBodySchema.safeParse({ originalTransactionId: "200000000000001", productId: "pruvi_ultra_monthly" }).success).toBe(true);
+  expect(AppStoreLinkBodySchema.safeParse({ originalTransactionId: "", productId: "x" }).success).toBe(false);
+});
+```
+
+Also extend the imports at the top of `billing.test.ts` to include the new symbols:
+
+```ts
+import {
+  // ...existing imports...
+  APP_STORE_NOTIFICATION_TYPES,
+  AppStoreLinkBodySchema,
+} from "./billing";
+```
+
+- [ ] **Step 1.4: Rename `processWebhookEnvelope` → `processGooglePlayEnvelope` (mechanical)**
+
+In `apps/server/src/features/billing/billing.service.ts`, rename the method (the only definition site). Update the route call site in `apps/server/src/features/billing/billing.route.ts`. Update the test file if it references the old name. Run `grep -rn "processWebhookEnvelope" apps/ packages/` first to confirm there are exactly the expected three sites (definition + route call + service test). If there are more, STOP — there shouldn't be.
+
+- [ ] **Step 1.5: Run tests + commit**
+
+```bash
+cd packages/shared && bun test src/billing.test.ts
+cd /Users/cesarcamillo/dev/pruvi/apps/server && bun test src/features/billing/
+```
+
+Expected: shared package 7 pass (was 5, +2 new). Server `billing/` 34 pass (unchanged; only a rename).
+
+```bash
+git add packages/env/src/server.ts packages/shared/src/billing.ts packages/shared/src/billing.test.ts apps/server/src/features/billing/billing.service.ts apps/server/src/features/billing/billing.service.test.ts apps/server/src/features/billing/billing.route.ts
+git commit -m "feat(shared,env): app store notification types + link schemas; rename processWebhookEnvelope → processGooglePlayEnvelope"
+```
+
+---
+
+## Task 2 — App Store decoder (pure JWS parser + state-machine mapping)
+
+**Files:**
+- Create: `apps/server/src/features/billing/app-store.decoder.ts`
+- Create: `apps/server/src/features/billing/app-store.decoder.test.ts`
+
+- [ ] **Step 2.1: Implement the decoder**
+
+Create `apps/server/src/features/billing/app-store.decoder.ts`:
+
+```ts
+import { APP_STORE_NOTIFICATION_TYPES, type AppStoreNotificationType } from "@pruvi/shared";
+
+export type AppStoreMappedAction =
+  | { kind: "activate"; expiresDate: Date }
+  | { kind: "in_grace" }
+  | { kind: "cancel_keep_entitlement" }
+  | { kind: "on_hold_keep_entitlement" }
+  | { kind: "expire" }
+  | { kind: "revoke" }
+  | { kind: "noop" };
+
+export type DecodedAppStoreEvent =
+  | {
+      kind: "subscription";
+      notificationUUID: string;
+      notificationType: AppStoreNotificationType;
+      subtype: string | null;
+      mappedAction: AppStoreMappedAction;
+      originalTransactionId: string;
+      productId: string;
+      expiresDate: Date | null;
+      environment: "Sandbox" | "Production";
+    }
+  | { kind: "test"; notificationUUID: string }
+  | {
+      kind: "unknown";
+      notificationUUID: string;
+      notificationType: string;
+      subtype: string | null;
+      originalTransactionId: string | null;
+    };
+
+export class DecoderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DecoderError";
+  }
+}
+
+type AppStoreEnvelope = { signedPayload?: unknown };
+
+function decodeJwsSegment(jws: string): unknown {
+  const parts = jws.split(".");
+  if (parts.length !== 3) throw new DecoderError("JWS must have exactly 3 segments");
+  try {
+    const decoded = Buffer.from(parts[1]!, "base64url").toString("utf-8");
+    return JSON.parse(decoded);
+  } catch (_e) {
+    throw new DecoderError("JWS middle segment is not valid base64url+JSON");
+  }
+}
+
+/** SECURITY: deferred — see spec §2 non-goals. v1 trusts the URL-path secret for auth.
+ *  Real x5c certificate-chain verification is a hardening ticket. */
+export function decodeAppStoreNotification(raw: unknown): DecodedAppStoreEvent {
+  if (!raw || typeof raw !== "object") throw new DecoderError("Envelope is not an object");
+  const env = raw as AppStoreEnvelope;
+  if (typeof env.signedPayload !== "string") throw new DecoderError("Missing signedPayload");
+
+  const outer = decodeJwsSegment(env.signedPayload) as {
+    notificationUUID?: string;
+    notificationType?: string;
+    subtype?: string;
+    data?: {
+      signedTransactionInfo?: string;
+      environment?: string;
+    };
+    version?: string;
+    signedDate?: number;
+  };
+
+  const notificationUUID = outer.notificationUUID;
+  if (!notificationUUID || typeof notificationUUID !== "string") {
+    throw new DecoderError("Missing notificationUUID");
+  }
+  const notificationType = outer.notificationType;
+  if (!notificationType || typeof notificationType !== "string") {
+    throw new DecoderError("Missing notificationType");
+  }
+
+  // Step 3: TEST notification has no `data` object. Check FIRST.
+  if (notificationType === "TEST") {
+    return { kind: "test", notificationUUID };
+  }
+
+  const subtype = typeof outer.subtype === "string" ? outer.subtype : null;
+  const data = outer.data;
+
+  // Some notification types don't carry signedTransactionInfo.
+  if (!data || typeof data.signedTransactionInfo !== "string") {
+    return {
+      kind: "unknown",
+      notificationUUID,
+      notificationType,
+      subtype,
+      originalTransactionId: null,
+    };
+  }
+
+  const inner = decodeJwsSegment(data.signedTransactionInfo) as {
+    originalTransactionId?: string;
+    productId?: string;
+    expiresDate?: number;
+    environment?: string;
+  };
+  const originalTransactionId = inner.originalTransactionId;
+  const productId = inner.productId;
+  if (!originalTransactionId || typeof originalTransactionId !== "string") {
+    throw new DecoderError("Missing originalTransactionId");
+  }
+  if (!productId || typeof productId !== "string") {
+    throw new DecoderError("Missing productId");
+  }
+  const expiresDate = typeof inner.expiresDate === "number" ? new Date(inner.expiresDate) : null;
+  const environment = (data.environment === "Production" ? "Production" : "Sandbox") as "Sandbox" | "Production";
+
+  // Is this a known notification type?
+  if (!APP_STORE_NOTIFICATION_TYPES.includes(notificationType as AppStoreNotificationType)) {
+    return { kind: "unknown", notificationUUID, notificationType, subtype, originalTransactionId };
+  }
+  const typedNotificationType = notificationType as AppStoreNotificationType;
+
+  let action = mapNotificationToAction(typedNotificationType, subtype, expiresDate);
+  // Past-expiry safety: if "activate" but the date is in the past, downgrade to "expire".
+  if (action.kind === "activate" && action.expiresDate.getTime() < Date.now()) {
+    action = { kind: "expire" };
+  }
+
+  return {
+    kind: "subscription",
+    notificationUUID,
+    notificationType: typedNotificationType,
+    subtype,
+    mappedAction: action,
+    originalTransactionId,
+    productId,
+    expiresDate,
+    environment,
+  };
+}
+
+function mapNotificationToAction(
+  type: AppStoreNotificationType,
+  subtype: string | null,
+  expiresDate: Date | null,
+): AppStoreMappedAction {
+  switch (type) {
+    case "SUBSCRIBED":
+    case "DID_RENEW":
+    case "REFUND_REVERSED":
+      if (!expiresDate) return { kind: "noop" };
+      return { kind: "activate", expiresDate };
+    case "DID_FAIL_TO_RENEW":
+      return subtype === "GRACE_PERIOD" ? { kind: "in_grace" } : { kind: "on_hold_keep_entitlement" };
+    case "EXPIRED":
+    case "GRACE_PERIOD_EXPIRED":
+      return { kind: "expire" };
+    case "REFUND":
+    case "REVOKE":
+      return { kind: "revoke" };
+    case "DID_CHANGE_RENEWAL_STATUS":
+      return subtype === "AUTO_RENEW_DISABLED" ? { kind: "cancel_keep_entitlement" } : { kind: "noop" };
+    case "DID_CHANGE_RENEWAL_PREF":
+    case "OFFER_REDEEMED":
+    case "PRICE_INCREASE":
+    case "RENEWAL_EXTENDED":
+    case "REFUND_DECLINED":
+    case "CONSUMPTION_REQUEST":
+    case "ONE_TIME_CHARGE":
+      return { kind: "noop" };
+    case "TEST":
+      return { kind: "noop" }; // unreachable (TEST handled earlier)
+  }
+}
+```
+
+- [ ] **Step 2.2: Failing tests**
+
+Create `apps/server/src/features/billing/app-store.decoder.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { decodeAppStoreNotification, DecoderError, type DecodedAppStoreEvent } from "./app-store.decoder";
+
+function makeJws(payload: object): string {
+  // header.payload.signature — only the middle segment is used.
+  const header = Buffer.from(JSON.stringify({ alg: "ES256", x5c: ["fake"] })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+function buildEnvelope(opts: {
+  notificationType: string;
+  subtype?: string;
+  notificationUUID?: string;
+  expiresDate?: number;
+  originalTransactionId?: string;
+  productId?: string;
+  omitData?: boolean;
+  omitSignedTransaction?: boolean;
+}) {
+  const tx = {
+    originalTransactionId: opts.originalTransactionId ?? "200000000000001",
+    productId: opts.productId ?? "pruvi_ultra_monthly",
+    expiresDate: opts.expiresDate ?? Date.now() + 30 * 24 * 60 * 60 * 1000,
+    environment: "Production",
+  };
+  const data = opts.omitSignedTransaction
+    ? { environment: "Production" }
+    : { signedTransactionInfo: makeJws(tx), environment: "Production" };
+  const outer: Record<string, unknown> = {
+    notificationUUID: opts.notificationUUID ?? "uuid-1",
+    notificationType: opts.notificationType,
+    version: "2.0",
+    signedDate: Date.now(),
+  };
+  if (opts.subtype) outer.subtype = opts.subtype;
+  if (!opts.omitData) outer.data = data;
+  return { signedPayload: makeJws(outer) };
+}
+
+describe("decodeAppStoreNotification", () => {
+  it("decodes SUBSCRIBED:INITIAL_BUY → activate", () => {
+    const env = buildEnvelope({ notificationType: "SUBSCRIBED", subtype: "INITIAL_BUY" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("subscription");
+    if (d.kind === "subscription") {
+      expect(d.notificationType).toBe("SUBSCRIBED");
+      expect(d.mappedAction.kind).toBe("activate");
+    }
+  });
+
+  it("decodes DID_RENEW → activate with expiresDate", () => {
+    const futureMs = Date.now() + 30 * 86400000;
+    const env = buildEnvelope({ notificationType: "DID_RENEW", expiresDate: futureMs });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("subscription");
+    if (d.kind === "subscription" && d.mappedAction.kind === "activate") {
+      expect(Math.abs(d.mappedAction.expiresDate.getTime() - futureMs)).toBeLessThan(1000);
+    }
+  });
+
+  it("decodes DID_FAIL_TO_RENEW:GRACE_PERIOD → in_grace", () => {
+    const env = buildEnvelope({ notificationType: "DID_FAIL_TO_RENEW", subtype: "GRACE_PERIOD" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("in_grace");
+  });
+
+  it("decodes DID_FAIL_TO_RENEW (no subtype) → on_hold_keep_entitlement", () => {
+    const env = buildEnvelope({ notificationType: "DID_FAIL_TO_RENEW" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("on_hold_keep_entitlement");
+  });
+
+  it("decodes EXPIRED → expire", () => {
+    const env = buildEnvelope({ notificationType: "EXPIRED" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("expire");
+  });
+
+  it("decodes REFUND → revoke", () => {
+    const env = buildEnvelope({ notificationType: "REFUND" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("revoke");
+  });
+
+  it("decodes DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_DISABLED → cancel_keep_entitlement", () => {
+    const env = buildEnvelope({ notificationType: "DID_CHANGE_RENEWAL_STATUS", subtype: "AUTO_RENEW_DISABLED" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("cancel_keep_entitlement");
+  });
+
+  it("decodes DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_ENABLED → noop", () => {
+    const env = buildEnvelope({ notificationType: "DID_CHANGE_RENEWAL_STATUS", subtype: "AUTO_RENEW_ENABLED" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("noop");
+  });
+
+  it("decodes REFUND_REVERSED with future expiry → activate", () => {
+    const future = Date.now() + 30 * 86400000;
+    const env = buildEnvelope({ notificationType: "REFUND_REVERSED", expiresDate: future });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("activate");
+  });
+
+  it("REFUND_REVERSED with PAST expiry → downgrades to expire (past-expiry safety)", () => {
+    const past = Date.now() - 86400000;
+    const env = buildEnvelope({ notificationType: "REFUND_REVERSED", expiresDate: past });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("expire");
+  });
+
+  it("decodes ONE_TIME_CHARGE → noop", () => {
+    const env = buildEnvelope({ notificationType: "ONE_TIME_CHARGE" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("noop");
+  });
+
+  it("returns kind=test for TEST notification (no data object)", () => {
+    const env = { signedPayload: makeJws({ notificationUUID: "uuid-test", notificationType: "TEST", version: "2.0" }) };
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("test");
+  });
+
+  it("returns kind=unknown for unrecognized notificationType", () => {
+    const env = buildEnvelope({ notificationType: "FUTURE_FANCY_TYPE" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("unknown");
+    if (d.kind === "unknown") expect(d.notificationType).toBe("FUTURE_FANCY_TYPE");
+  });
+
+  it("returns kind=unknown when data.signedTransactionInfo is missing", () => {
+    const env = buildEnvelope({ notificationType: "DID_CHANGE_RENEWAL_PREF", omitSignedTransaction: true });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind).toBe("unknown");
+  });
+
+  it("throws on missing signedPayload", () => {
+    expect(() => decodeAppStoreNotification({})).toThrow(DecoderError);
+  });
+
+  it("throws on JWS that doesn't have 3 segments", () => {
+    expect(() => decodeAppStoreNotification({ signedPayload: "a.b" })).toThrow(DecoderError);
+  });
+
+  it("throws on invalid JSON in JWS payload", () => {
+    expect(() => decodeAppStoreNotification({ signedPayload: "header.!notvalidbase64json!.sig" })).toThrow(DecoderError);
+  });
+});
+```
+
+- [ ] **Step 2.3: Run + commit**
+
+```bash
+cd apps/server && bun test src/features/billing/app-store.decoder.test.ts
+```
+
+Expected: 17 pass.
+
+```bash
+git add apps/server/src/features/billing/app-store.decoder.ts apps/server/src/features/billing/app-store.decoder.test.ts
+git commit -m "feat(billing): app store JWS decoder — pure parser + state-machine mapping"
+```
+
+---
+
+## Task 3 — Service: `applyAppStoreEvent`, `processAppStoreEnvelope`, `linkAppStorePurchase`
+
+**Files:**
+- Modify: `apps/server/src/features/billing/billing.service.ts`
+- Modify: `apps/server/src/features/billing/billing.service.test.ts`
+
+- [ ] **Step 3.1: Implement the new service methods**
+
+Add imports at the top of `billing.service.ts`:
+
+```ts
+import type { DecodedAppStoreEvent } from "./app-store.decoder";
+import { decodeAppStoreNotification } from "./app-store.decoder";
+```
+
+Add inside the `BillingService` class (alongside the existing Google methods):
+
+```ts
+/** Apple webhook entry point. Same orchestration as processGooglePlayEnvelope:
+ *  decode → dedup → state machine → queue post-commit ultra effect. */
+async processAppStoreEnvelope(envelope: unknown): Promise<Result<{ notificationUUID: string; kind: string }, AppError>> {
+  let decoded: DecodedAppStoreEvent;
+  try {
+    decoded = decodeAppStoreNotification(envelope);
+  } catch (e) {
+    return err(new AppError(`MALFORMED_ENVELOPE: ${(e as Error).message}`, 200, "MALFORMED_ENVELOPE"));
+  }
+
+  if (decoded.kind === "test") {
+    await this.repo.insertEvent(this.db, {
+      provider: "app_store",
+      messageId: decoded.notificationUUID,
+      eventType: "TEST",
+      purchaseToken: null,
+      payload: { kind: "test" },
+    });
+    return ok({ notificationUUID: decoded.notificationUUID, kind: "test" });
+  }
+
+  const effect = await this.db.transaction(async (tx) => {
+    const eventType = decoded.kind === "subscription" ? decoded.notificationType : `UNKNOWN_${decoded.notificationType}`;
+    const purchaseToken = decoded.kind === "subscription" ? decoded.originalTransactionId : decoded.originalTransactionId;
+    const inserted = await this.repo.insertEvent(tx, {
+      provider: "app_store",
+      messageId: decoded.notificationUUID,
+      eventType,
+      purchaseToken,
+      payload: decoded as unknown as Record<string, unknown>,
+    });
+    if (!inserted) {
+      return { kind: "none" } as PostCommitUltraEffect;
+    }
+
+    if (decoded.kind === "unknown") {
+      await this.repo.markEventProcessed(tx, inserted.id);
+      return { kind: "none" } as PostCommitUltraEffect;
+    }
+
+    let sub = await this.repo.findSubscriptionByToken(tx, "app_store", decoded.originalTransactionId);
+    if (!sub) {
+      sub = await this.repo.createOrphanSubscription(tx, "app_store", decoded.originalTransactionId);
+    }
+
+    const { newStatus, newPeriodEnd, ultraEffect } = this.applyAppStoreEvent(decoded, sub);
+    await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
+
+    if (sub.userId === null) {
+      return { kind: "none" } as PostCommitUltraEffect;
+    }
+    await this.repo.markEventProcessed(tx, inserted.id);
+    return ultraEffect;
+  });
+
+  await this.applyUltraEffect(effect);
+  return ok({ notificationUUID: decoded.notificationUUID, kind: decoded.kind });
+}
+
+/** Pure state-machine for App Store events. Mirror of the Google `applyDecodedEvent`. */
+applyAppStoreEvent(
+  decoded: DecodedAppStoreEvent,
+  sub: SubscriptionRow,
+): { newStatus: SubscriptionStatus; newPeriodEnd: Date | null; ultraEffect: PostCommitUltraEffect } {
+  if (decoded.kind !== "subscription") {
+    return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+  }
+  const grant = (end: Date): PostCommitUltraEffect =>
+    sub.userId !== null
+      ? { kind: "grant", userId: sub.userId, expiresAt: end, excludeSubscriptionId: sub.id }
+      : { kind: "none" };
+  const revoke = (): PostCommitUltraEffect =>
+    sub.userId !== null
+      ? { kind: "revoke_if_no_other_active", userId: sub.userId, excludeSubscriptionId: sub.id }
+      : { kind: "none" };
+
+  switch (decoded.mappedAction.kind) {
+    case "activate":
+      return {
+        newStatus: "active",
+        newPeriodEnd: decoded.mappedAction.expiresDate,
+        ultraEffect: grant(decoded.mappedAction.expiresDate),
+      };
+    case "in_grace":
+      return { newStatus: "in_grace", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+    case "cancel_keep_entitlement":
+      return { newStatus: "canceled", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+    case "on_hold_keep_entitlement":
+      return { newStatus: "on_hold", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+    case "expire":
+      return { newStatus: "expired", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+    case "revoke":
+      return { newStatus: "revoked", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: revoke() };
+    case "noop":
+      return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+  }
+}
+
+async linkAppStorePurchase(
+  userId: string,
+  body: { originalTransactionId: string; productId: string },
+): Promise<Result<GooglePlayLinkResponse, AppError>> {
+  const effects: PostCommitUltraEffect[] = [];
+  const finalRow = await this.db.transaction(async (tx) => {
+    const existing = await this.repo.findSubscriptionByToken(tx, "app_store", body.originalTransactionId);
+    let sub: SubscriptionRow;
+    if (!existing) {
+      const created = await this.repo.upsertLinkedSubscription(tx, {
+        userId, provider: "app_store", productId: body.productId, token: body.originalTransactionId,
+      });
+      sub = created.subscription;
+    } else if (existing.userId !== null && existing.userId !== userId) {
+      throw new ConflictError("PURCHASE_TOKEN_OWNED_BY_OTHER_USER");
+    } else if (existing.userId === userId) {
+      sub = existing;
+    } else {
+      sub = await this.repo.claimOrphanSubscription(tx, existing.id, userId, body.productId);
+    }
+
+    const parked = await this.repo.listUnprocessedEventsForToken(tx, "app_store", body.originalTransactionId);
+    for (const event of parked) {
+      const decoded = event.payload as unknown as DecodedAppStoreEvent;
+      if (decoded.kind !== "subscription") {
+        await this.repo.markEventProcessed(tx, event.id);
+        continue;
+      }
+      const fresh = await this.repo.findSubscriptionByToken(tx, "app_store", body.originalTransactionId);
+      if (!fresh) throw new Error("replay: subscription disappeared mid-transaction");
+      sub = fresh;
+      const { newStatus, newPeriodEnd, ultraEffect } = this.applyAppStoreEvent(decoded, sub);
+      await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
+      await this.repo.markEventProcessed(tx, event.id);
+      effects.push(ultraEffect);
+    }
+    const final = await this.repo.findSubscriptionByToken(tx, "app_store", body.originalTransactionId);
+    if (!final) throw new Error("link: subscription disappeared mid-transaction");
+    return final;
+  });
+
+  for (const e of effects) await this.applyUltraEffect(e);
+
+  return ok({
+    subscription: {
+      id: finalRow.id,
+      status: finalRow.status,
+      productId: finalRow.productId,
+      currentPeriodEnd: finalRow.currentPeriodEnd?.toISOString() ?? null,
+    },
+  });
+}
+```
+
+(`GooglePlayLinkResponse` is already imported in the file from Phase 2E.4. If not, add the import.)
+
+- [ ] **Step 3.2: Add service tests**
+
+Extend `billing.service.test.ts` with a new `describe("BillingService — App Store", ...)` block (after the existing block). Use the same `buildSut` harness from Task 5 of Phase 2E.4 — it's already provider-agnostic since it mocks repo methods by name.
+
+Required cases (minimum 8):
+
+1. **SUBSCRIBED with linked sub** → state=active, currentPeriodEnd=expiresDate (NOT now+30d), ultra.grant called with expiresDate.
+2. **DID_RENEW** → active, ultra.grant with new expiresDate.
+3. **DID_FAIL_TO_RENEW (no subtype)** → status=on_hold, no Ultra change.
+4. **DID_FAIL_TO_RENEW:GRACE_PERIOD** → status=in_grace, no Ultra change.
+5. **EXPIRED with no other active** → revoke called.
+6. **EXPIRED with other active sub** → revoke NOT called (multi-sub guard reused).
+7. **REFUND_REVERSED future expiry** → active, ultra.grant.
+8. **Duplicate notificationUUID** → no state change, no Ultra call.
+9. **TEST** → audit insert with eventType="TEST", no other action.
+10. **Link with conflict (other user owns token)** → ConflictError thrown.
+11. **Bonus: multi-sub GRANT guard with App Store** — another active sub with LATER end → ultra.grant uses MAX.
+
+The cases follow the exact same shape as the Google Play tests. The mock harness's `buildSut` needs only minor extension: add a builder for App Store envelopes:
+
+```ts
+function buildAppStoreEnvelope(notificationType: string, opts: { subtype?: string; expiresDate?: number; originalTransactionId?: string; notificationUUID?: string } = {}) {
+  const header = Buffer.from(JSON.stringify({ alg: "ES256" })).toString("base64url");
+  const tx = {
+    originalTransactionId: opts.originalTransactionId ?? "tok",
+    productId: "pruvi_ultra_monthly",
+    expiresDate: opts.expiresDate ?? Date.now() + 30 * 86400000,
+    environment: "Production",
+  };
+  const innerJws = `${header}.${Buffer.from(JSON.stringify(tx)).toString("base64url")}.sig`;
+  const outer: Record<string, unknown> = {
+    notificationUUID: opts.notificationUUID ?? "uuid-1",
+    notificationType,
+    version: "2.0",
+    signedDate: Date.now(),
+    data: { signedTransactionInfo: innerJws, environment: "Production" },
+  };
+  if (opts.subtype) outer.subtype = opts.subtype;
+  return { signedPayload: `${header}.${Buffer.from(JSON.stringify(outer)).toString("base64url")}.sig` };
+}
+```
+
+- [ ] **Step 3.3: Run + commit**
+
+```bash
+cd apps/server && bun test src/features/billing/
+```
+
+Expected: 34 prior + ~12 new = 46 pass. (Decoder tests already at 17 from Task 2 + 11 service Google + 8 repo integration = 36 base; + new App Store service tests.)
+
+```bash
+git add apps/server/src/features/billing/billing.service.ts apps/server/src/features/billing/billing.service.test.ts
+git commit -m "feat(billing): app store — applyAppStoreEvent state machine, processAppStoreEnvelope, linkAppStorePurchase"
+```
+
+---
+
+## Task 4 — Routes: webhook (URL-path token) + link, plus integration tests
+
+**Files:**
+- Modify: `apps/server/src/features/billing/billing.route.ts`
+- Modify: `apps/server/src/features/billing/billing.repository.integration.test.ts` (add the cross-provider coexistence test from spec A19)
+
+- [ ] **Step 4.1: Add the two routes**
+
+In `billing.route.ts`, alongside the existing Google routes, add:
+
+```ts
+import { AppStoreLinkBodySchema, AppStoreLinkResponseSchema } from "@pruvi/shared";
+// ...
+
+async function appStorePathGuard(request: FastifyRequest) {
+  if (!env.APP_STORE_WEBHOOK_TOKEN) {
+    throw new AppError("WEBHOOK_DISABLED", 503, "WEBHOOK_DISABLED");
+  }
+  const { token } = request.params as { token: string };
+  if (typeof token !== "string") {
+    throw new NotFoundError("Not Found");
+  }
+  const a = Buffer.from(token);
+  const b = Buffer.from(env.APP_STORE_WEBHOOK_TOKEN);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    throw new NotFoundError("Not Found"); // 404 to keep endpoint URL-obscure
+  }
+}
+
+// Inside billingRoutes:
+fastify.post(
+  "/webhooks/app-store/:token",
+  {
+    schema: {
+      params: z.object({ token: z.string() }),
+      body: z.unknown(),
+      response: {
+        200: z.object({
+          success: z.literal(true),
+          data: z.object({ received: z.boolean(), notificationUUID: z.string().optional(), kind: z.string().optional(), error: z.string().optional() }),
+        }),
+      },
+    },
+    preHandler: [appStorePathGuard],
+  },
+  async (request) => {
+    const result = await service.processAppStoreEnvelope(request.body);
+    if (result.isErr()) {
+      const error = result.error;
+      if (error.code === "MALFORMED_ENVELOPE") {
+        fastify.log.warn({ err: error.message }, "app-store webhook malformed envelope");
+        return successResponse({ received: false, error: "MALFORMED_ENVELOPE" });
+      }
+      fastify.log.error({ err: error.message }, "app-store webhook processing failed");
+      return successResponse({ received: false, error: "PROCESSING_FAILED" });
+    }
+    return successResponse({ received: true, notificationUUID: result.value.notificationUUID, kind: result.value.kind });
+  },
+);
+
+fastify.post(
+  "/billing/app-store/link",
+  {
+    preHandler: [fastify.authenticate],
+    schema: {
+      body: AppStoreLinkBodySchema,
+      response: { 200: z.object({ success: z.literal(true), data: AppStoreLinkResponseSchema }) },
+    },
+  },
+  async (request) => {
+    const data = unwrapResult(await service.linkAppStorePurchase(request.userId, request.body)).data;
+    return successResponse(data);
+  },
+);
+```
+
+Also import `NotFoundError` from `../../utils/errors` if it isn't already imported (verify with the existing imports).
+
+- [ ] **Step 4.2: Add cross-provider repo integration test (A19)**
+
+Append to `billing.repository.integration.test.ts`, inside the existing top-level `describe`, before the closing `});`:
+
+```ts
+it("cross-provider: same message_id string for google_play and app_store coexist (composite UNIQUE)", async () => {
+  const a = await repo.insertEvent(db, { provider: "google_play", messageId: "shared-id", eventType: "PURCHASED", purchaseToken: "tA", payload: {} });
+  const b = await repo.insertEvent(db, { provider: "app_store", messageId: "shared-id", eventType: "SUBSCRIBED", purchaseToken: "tB", payload: {} });
+  expect(a).not.toBeNull();
+  expect(b).not.toBeNull();
+  expect(a!.id).not.toBe(b!.id);
+});
+
+it("cross-provider: same purchase_token string for google_play and app_store coexist", async () => {
+  const a = await repo.createOrphanSubscription(db, "google_play", "shared-token");
+  const b = await repo.createOrphanSubscription(db, "app_store", "shared-token");
+  expect(a.id).not.toBe(b.id);
+  expect(a.provider).toBe("google_play");
+  expect(b.provider).toBe("app_store");
+});
+```
+
+- [ ] **Step 4.3: Run + commit**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi/apps/server
+bun test src/features/billing/
+pnpm check-types 2>&1 | grep -E "billing" | head
+```
+
+Expected: tests green; no NEW type errors in billing/ files.
+
+```bash
+git add apps/server/src/features/billing/billing.route.ts apps/server/src/features/billing/billing.repository.integration.test.ts
+git commit -m "feat(billing): app store routes — POST /webhooks/app-store/:token (url-path auth), POST /billing/app-store/link; cross-provider repo tests"
+```
+
+---
+
+## Task 5 — Final typecheck, push, PR
+
+- [ ] **Step 5.1: Full repo typecheck**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi && pnpm check-types 2>&1 | tail -30
+```
+
+If new billing errors surface (unused vars, type narrowing), fix surgically. Pre-existing errors in unrelated files (questions, reviews tests) are not this phase's concern.
+
+- [ ] **Step 5.2: Final test sweep**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi/apps/server && bun test src/features/billing/
+cd /Users/cesarcamillo/dev/pruvi/packages/shared && bun test src/billing.test.ts
+```
+
+- [ ] **Step 5.3: Push + PR**
+
+```bash
+git push -u origin feature/phase-2e5-app-store-webhooks
+gh pr create --title "feat: phase 2e.5 — app store server notifications v2 (ultra entitlement, ios parity)" --body "$(cat <<'EOF'
+## Summary
+- Apple ASSN V2 adapter wired into the existing billing module from 2E.4
+- Reuses `subscription`/`billing_event` tables and `applyUltraEffect` (multi-sub guards) unchanged
+- Separate Apple decoder + state machine (`applyAppStoreEvent`) sibling to the Google one
+- **URL-path token auth** (Apple cannot inject custom headers): `POST /webhooks/app-store/:token` against `env.APP_STORE_WEBHOOK_TOKEN` (min 32 chars)
+- Real `expiresDate` from `signedTransactionInfo` — strict improvement over Google's 30-day default
+- DID_FAIL_TO_RENEW (no grace) maps to `on_hold` (billing failure, not user choice)
+- REFUND_REVERSED with past `expiresDate` → safe downgrade to `expire`
+- Renamed `processWebhookEnvelope` → `processGooglePlayEnvelope` for symmetry
+- App Store JWS signature verification deferred (production hardening)
+
+## Workflow gates
+- ✅ Gate A — spec self-review (2 blockers fixed: header→URL-path token, dedicated state machine + rename + ONE_TIME_CHARGE/on_hold/decoder ordering)
+- ✅ Gate B — plan self-review
+- ✅ Gate C — per-task review after every commit
+- ✅ Gate D — final spec-coverage review
+
+## Test plan
+- [ ] Decoder unit tests: 17 cases (all major notification types, past-expiry safety, TEST, unknown, malformed JWS)
+- [ ] Service unit tests: 11+ new cases for App Store paths
+- [ ] Repository integration: cross-provider message_id and purchase_token coexistence
+- [ ] Manual: POST /webhooks/app-store/<token> with valid signedPayload → 200 + subscription state updated; POST with bad token → 404
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (post Gate B)
+
+1. **Spec coverage A1–A19:** A1/A2 → T4 (path-token guard); A3 → T3 (dedup via insertEvent); A4 → T3/T4; A5 → T3 (same-user idempotent); A6 → T3 (ConflictError); A7/A8 → T3 (activate path); A9 → T3 (expire path); A10 → T3 (cancel_keep_entitlement); A11 → T3 (REFUND_REVERSED activate); A12 → T3 (orphan + replay); A13/A14 → applyUltraEffect reuse (verified by reuse, not rewritten); A15 → T3 reuse; A16 → T1 env; A17 → T2 decoder (16 mapped types + ONE_TIME_CHARGE); A18 → fastify.log; A19 → T4 cross-provider test.
+2. **Placeholder scan:** none.
+3. **Type consistency:** `DecodedAppStoreEvent.mappedAction.kind` matches the switch in `applyAppStoreEvent`. The `on_hold_keep_entitlement` action is new (in addition to `cancel_keep_entitlement`); verify both exist in the spec table and the decoder mapping.
+4. **No raw SQL where Drizzle helpers exist:** repo unchanged from 2E.4.
+5. **Migration safety:** none required (schema accepts `app_store` from 2E.4).

--- a/docs/superpowers/plans/2026-05-12-phase-2e5-app-store-webhooks.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e5-app-store-webhooks.md
@@ -8,7 +8,9 @@
 
 **Tech Stack:** Drizzle ORM, Fastify 5 + fastify-type-provider-zod on Bun, neverthrow Result, real Postgres for integration tests.
 
-**Authoritative spec:** `docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md` (v2 post Gate A).
+**Authoritative spec:** `docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md` (v3 post Gate B).
+
+**Plan revision:** v2 post Gate B — Step 1.4 rename count corrected (10 sites not 3), `linkAppStorePurchase` return type uses `AppStoreLinkResponse`, decoder tests include SUBSCRIBED:RESUBSCRIBE and REVOKE explicitly, test-count arithmetic in Step 3.3 corrected, dead ternary in `processAppStoreEnvelope` clarified.
 
 ---
 
@@ -98,7 +100,12 @@ import {
 
 - [ ] **Step 1.4: Rename `processWebhookEnvelope` → `processGooglePlayEnvelope` (mechanical)**
 
-In `apps/server/src/features/billing/billing.service.ts`, rename the method (the only definition site). Update the route call site in `apps/server/src/features/billing/billing.route.ts`. Update the test file if it references the old name. Run `grep -rn "processWebhookEnvelope" apps/ packages/` first to confirm there are exactly the expected three sites (definition + route call + service test). If there are more, STOP — there shouldn't be.
+Rename ALL occurrences across these files:
+- `apps/server/src/features/billing/billing.service.ts` — 1 definition site (the method on `BillingService`).
+- `apps/server/src/features/billing/billing.route.ts` — 1 call site (the Google webhook handler).
+- `apps/server/src/features/billing/billing.service.test.ts` — 8 call sites inside the test cases.
+
+Total: 10 occurrences. Use `grep -rn "processWebhookEnvelope" apps/ packages/` to confirm before and after. Use a single `sed`/IDE rename across the file or `replace_all` in Edit. The new method has identical signature and semantics.
 
 - [ ] **Step 1.5: Run tests + commit**
 
@@ -359,6 +366,12 @@ describe("decodeAppStoreNotification", () => {
     }
   });
 
+  it("decodes SUBSCRIBED:RESUBSCRIBE → activate", () => {
+    const env = buildEnvelope({ notificationType: "SUBSCRIBED", subtype: "RESUBSCRIBE" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("activate");
+  });
+
   it("decodes DID_RENEW → activate with expiresDate", () => {
     const futureMs = Date.now() + 30 * 86400000;
     const env = buildEnvelope({ notificationType: "DID_RENEW", expiresDate: futureMs });
@@ -389,6 +402,12 @@ describe("decodeAppStoreNotification", () => {
 
   it("decodes REFUND → revoke", () => {
     const env = buildEnvelope({ notificationType: "REFUND" });
+    const d = decodeAppStoreNotification(env);
+    expect(d.kind === "subscription" && d.mappedAction.kind).toBe("revoke");
+  });
+
+  it("decodes REVOKE → revoke", () => {
+    const env = buildEnvelope({ notificationType: "REVOKE" });
     const d = decodeAppStoreNotification(env);
     expect(d.kind === "subscription" && d.mappedAction.kind).toBe("revoke");
   });
@@ -464,7 +483,7 @@ describe("decodeAppStoreNotification", () => {
 cd apps/server && bun test src/features/billing/app-store.decoder.test.ts
 ```
 
-Expected: 17 pass.
+Expected: 19 pass (17 base cases + SUBSCRIBED:RESUBSCRIBE + REVOKE).
 
 ```bash
 git add apps/server/src/features/billing/app-store.decoder.ts apps/server/src/features/billing/app-store.decoder.test.ts
@@ -514,7 +533,9 @@ async processAppStoreEnvelope(envelope: unknown): Promise<Result<{ notificationU
 
   const effect = await this.db.transaction(async (tx) => {
     const eventType = decoded.kind === "subscription" ? decoded.notificationType : `UNKNOWN_${decoded.notificationType}`;
-    const purchaseToken = decoded.kind === "subscription" ? decoded.originalTransactionId : decoded.originalTransactionId;
+    // test was already handled above; subscription always has token, unknown may have it null.
+    const purchaseToken: string | null =
+      decoded.kind === "subscription" ? decoded.originalTransactionId : (decoded.originalTransactionId ?? null);
     const inserted = await this.repo.insertEvent(tx, {
       provider: "app_store",
       messageId: decoded.notificationUUID,
@@ -592,7 +613,7 @@ applyAppStoreEvent(
 async linkAppStorePurchase(
   userId: string,
   body: { originalTransactionId: string; productId: string },
-): Promise<Result<GooglePlayLinkResponse, AppError>> {
+): Promise<Result<AppStoreLinkResponse, AppError>> {
   const effects: PostCommitUltraEffect[] = [];
   const finalRow = await this.db.transaction(async (tx) => {
     const existing = await this.repo.findSubscriptionByToken(tx, "app_store", body.originalTransactionId);
@@ -643,7 +664,7 @@ async linkAppStorePurchase(
 }
 ```
 
-(`GooglePlayLinkResponse` is already imported in the file from Phase 2E.4. If not, add the import.)
+Add `AppStoreLinkResponse` to the imports from `@pruvi/shared` at the top of `billing.service.ts`. `GooglePlayLinkResponse` is already imported in the file from Phase 2E.4 (keep it for the existing Google method).
 
 - [ ] **Step 3.2: Add service tests**
 
@@ -693,7 +714,14 @@ function buildAppStoreEnvelope(notificationType: string, opts: { subtype?: strin
 cd apps/server && bun test src/features/billing/
 ```
 
-Expected: 34 prior + ~12 new = 46 pass. (Decoder tests already at 17 from Task 2 + 11 service Google + 8 repo integration = 36 base; + new App Store service tests.)
+Expected counts after this task:
+- Google Play decoder: 12 (unchanged from 2E.4)
+- Repository integration: 11 (unchanged; cross-provider tests added in Task 4 will bump this to 13)
+- Google Play service: 11 (unchanged — only method name renamed)
+- App Store decoder: 19 (Task 2 — 17 base + RESUBSCRIBE + REVOKE additions)
+- App Store service: 11 new (Task 3, this step)
+
+Total billing/ tests after Task 3: 12 + 11 + 11 + 19 + 11 = **64 pass**.
 
 ```bash
 git add apps/server/src/features/billing/billing.service.ts apps/server/src/features/billing/billing.service.test.ts

--- a/docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md
@@ -1,6 +1,6 @@
 # Phase 2E.5 — Billing Webhooks: App Store Server Notifications V2 (Design Spec)
 
-**Status:** v1
+**Status:** v2 (post Gate A: URL-path token instead of header, dedicated applyAppStoreEvent + processGooglePlayEnvelope rename, ONE_TIME_CHARGE no-op, DID_FAIL_TO_RENEW → on_hold)
 **Date:** 2026-05-12
 **Branch:** `feature/phase-2e5-app-store-webhooks`
 **Builds on:** Phase 2E.4 (Google Play webhooks) — same `subscription`/`billing_event` schema, same `UltraService`, same multi-sub guards.
@@ -13,7 +13,7 @@ Add an App Store Server Notifications V2 adapter to the existing `billing` modul
 
 ## 2. Non-goals
 
-- **JWS x5c certificate-chain signature verification.** Apple signs every notification with a JWS containing the certificate chain in the `x5c` header. Production-correct auth requires validating that chain against Apple's root CA. For v1, we use a shared-secret header (`X-Pruvi-Webhook-Token` against `APP_STORE_WEBHOOK_TOKEN`) — same model used for Google Play. **Real JWS signature verification is deferred** to an infra/hardening ticket.
+- **JWS x5c certificate-chain signature verification.** Apple signs every notification with a JWS containing the certificate chain in the `x5c` header. Production-correct auth requires validating that chain against Apple's root CA. For v1, we use a **URL-path secret** (not a header — see §7.4) backed by `env.APP_STORE_WEBHOOK_TOKEN`. **Apple does not inject custom headers**, so the Google Play `X-Pruvi-Webhook-Token` header model cannot transfer to Apple. The URL-path secret is the v1 alternative: we configure `https://api.pruvi.app/webhooks/app-store/<APP_STORE_WEBHOOK_TOKEN>` in App Store Connect, the server checks the URL param via constant-time compare. **Real JWS signature verification is deferred** to an infra/hardening ticket.
 - **App Store Server API `/inApps/v1/subscriptions/{originalTransactionId}` polling.** No server-to-server reconciliation in v1.
 - **Sandbox vs Production discrimination.** Apple sends an `environment` field in every notification (`Sandbox` or `Production`). v1 processes both identically. A future hardening pass may route Sandbox notifications to a separate test DB or reject them outright.
 - **`signedRenewalInfo`** parsing (it carries renewal price, status, etc.). v1 reads ONLY `signedTransactionInfo` since that has the data we need (originalTransactionId, expiresDate, productId). `signedRenewalInfo` decoding is deferred.
@@ -55,7 +55,7 @@ The table below maps `(notificationType, subtype)` pairs to our subscription sta
 | `SUBSCRIBED` | `RESUBSCRIBE` | status → `active`, currentPeriodEnd = expiresDate | grant until expiresDate |
 | `DID_RENEW` | (any/null) | status → `active`, currentPeriodEnd = expiresDate | grant until expiresDate |
 | `DID_FAIL_TO_RENEW` | `GRACE_PERIOD` | status → `in_grace` | no-op (leave grant) |
-| `DID_FAIL_TO_RENEW` | (any other) | status → `canceled` (renewal failed, no grace) | no-op (entitled until expiresDate) |
+| `DID_FAIL_TO_RENEW` | (any other) | status → `on_hold` (billing failed, no grace; user retains entitlement until expiresDate; semantic distinction from user-initiated CANCELED — billing problem, not user choice) | no-op (entitled until expiresDate, then EXPIRED fires and triggers revoke) |
 | `EXPIRED` | (any) | status → `expired` | revoke (multi-sub guarded) |
 | `GRACE_PERIOD_EXPIRED` | (any) | status → `expired` | revoke (multi-sub guarded) |
 | `REFUND` | (any) | status → `revoked` | revoke (multi-sub guarded) |
@@ -69,6 +69,7 @@ The table below maps `(notificationType, subtype)` pairs to our subscription sta
 | `REFUND_DECLINED` | (any) | no-op | no-op |
 | `REFUND_REVERSED` | (any) | status → `active` (refund was reversed; treat like SUBSCRIBED) | grant until expiresDate |
 | `CONSUMPTION_REQUEST` | (any) | no-op | no-op |
+| `ONE_TIME_CHARGE` | (any) | no-op (Pruvi has no consumables; future hardening) | no-op |
 | `TEST` | n/a | no-op (record audit only) | no-op |
 
 Unknown `notificationType` values → audit row recorded with `eventType = "UNKNOWN_<type>"`, no state mutation, no Ultra effect. Future Apple additions surface in the audit log for ops triage.
@@ -128,50 +129,76 @@ type AppStoreMappedAction =
   | { kind: "noop" };
 ```
 
-The decoder is **pure** (no DB, no HTTP). Steps:
-1. Split `signedPayload` on `.`, take the middle segment, base64url-decode, JSON.parse → outer.
-2. Read `notificationUUID`, `notificationType`, `subtype`, `data.environment`. If `data.signedTransactionInfo` is absent or notification is the literal `notificationType: "TEST"` of a CONSOLE_TEST kind (Apple uses `notificationType: "TEST"`), return `{ kind: "test" }`.
-3. Decode `data.signedTransactionInfo` JWS the same way → transaction info.
-4. Read `transaction.originalTransactionId`, `productId`, `expiresDate` (ms).
-5. Map `(notificationType, subtype)` to `AppStoreMappedAction` via the table in §6.
-6. Return.
+The decoder is **pure** (no DB, no HTTP). Steps (order matters — check TEST first because TEST has no `data` object):
+1. Split `signedPayload` on `.` → exactly 3 segments. If not 3, throw `DecoderError`.
+2. base64url-decode the middle segment (NOT plain base64 — Apple uses URL-safe alphabet). JSON.parse → outer.
+3. Read `notificationUUID`, `notificationType`, `subtype` (optional). **If `notificationType === "TEST"`, return `{ kind: "test", notificationUUID }` immediately** (TEST has no `data` object — accessing it would throw).
+4. Read `data.environment`. If `data` or `data.signedTransactionInfo` is missing, return `{ kind: "unknown", ... }` rather than throwing — some Apple notification types carry no transaction info (e.g., DID_CHANGE_RENEWAL_PREF for some subtypes); we don't want to throw on a real Apple payload.
+5. Decode `data.signedTransactionInfo` JWS the same way (split on `.`, take middle, base64url-decode, JSON.parse).
+6. Read `transaction.originalTransactionId`, `productId`, `expiresDate` (ms → Date).
+7. Map `(notificationType, subtype)` to `AppStoreMappedAction` via the table in §6. If the pair is not recognized, return `{ kind: "unknown", notificationType, subtype, originalTransactionId, ... }`.
+8. **`activate` past-expiry safety:** if the mapped action is `activate` and `expiresDate < now` (which can happen for REFUND_REVERSED after the original expiry has already passed), downgrade the action to `expire` so we don't grant Ultra into the past. Document this in the decoder code.
+9. Return.
 
 **No signature verification in v1.** Document this as `// SECURITY: deferred — see spec §2 non-goals`.
 
+**Test fixture note:** unit-test fixtures must use **base64url** encoding (e.g., `Buffer.from(JSON.stringify(payload)).toString("base64url")`), NOT plain base64. The `.` separator is literal. The third "signature" segment can be a dummy string like `"sig"` since v1 doesn't verify signatures.
+
 ### 7.3 The service extensions
 
-`BillingService` gains two new methods that mirror the Google Play flow:
+The existing `BillingService.applyDecodedEvent(decoded: DecodedGooglePlayEvent, sub)` is Google-specific (typed on the Google decoder and uses `DEFAULT_SUBSCRIPTION_PERIOD_MS`). It is NOT refactored to be generic. Instead this phase adds a parallel `applyAppStoreEvent` and renames the Google webhook entry point for symmetry. Concrete changes:
 
-- `processAppStoreEnvelope(envelope: unknown)`: same shape as `processWebhookEnvelope` (Google's name will be renamed in this phase to `processGooglePlayEnvelope` for clarity OR left as-is to avoid PR churn — see §11). Decodes, dedups, runs state machine, queues effect.
-- `linkAppStorePurchase(userId, { originalTransactionId, productId })`: same shape as `linkGooglePlayPurchase` but for `provider='app_store'`.
+**Mandatory rename (one call site):** `processWebhookEnvelope` → `processGooglePlayEnvelope` in `billing.service.ts` AND in `billing.route.ts` (the `POST /webhooks/google-play` handler). This is the only call site; no external module imports the old name. Done as a single mechanical rename in Task 1 of the plan.
 
-The state machine inside the service receives a `decoded: DecodedAppStoreEvent` and the current `subscription` row, and computes `{ newStatus, newPeriodEnd, ultraEffect }`. The branching is on `decoded.mappedAction.kind`:
-
-- `"activate"` → newStatus = `"active"`, newPeriodEnd = `mappedAction.expiresDate`, `ultraEffect = grant(expiresDate)`.
-- `"in_grace"` → newStatus = `"in_grace"`, keep period end, `ultraEffect = noop`.
-- `"cancel_keep_entitlement"` → newStatus = `"canceled"`, keep period end, `ultraEffect = noop`.
-- `"expire"` → newStatus = `"expired"`, keep period end, `ultraEffect = revoke`.
-- `"revoke"` → newStatus = `"revoked"`, keep period end, `ultraEffect = revoke`.
-- `"noop"` → no state change.
+**New methods on `BillingService`:**
+- `processAppStoreEnvelope(envelope: unknown)` — analogous to `processGooglePlayEnvelope`. Calls `decodeAppStoreNotification`, dedups via `insertEvent`, dispatches via the new `applyAppStoreEvent`, queues post-commit `PostCommitUltraEffect`.
+- `linkAppStorePurchase(userId, { originalTransactionId, productId })` — analogous to `linkGooglePlayPurchase` but for `provider='app_store'`. Same orphan-claim + parked-event replay flow. The replay loop calls `applyAppStoreEvent` for events of provider `app_store` (it inspects the audit row's payload shape; see §7.6 below).
+- `applyAppStoreEvent(decoded: DecodedAppStoreEvent, sub: SubscriptionRow)` — **NEW**, sibling to the existing Google-specific `applyDecodedEvent`. Pure (no DB writes). Returns `{ newStatus, newPeriodEnd, ultraEffect }`. Branches on `decoded.mappedAction.kind`:
+  - `"activate"` → newStatus = `"active"`, newPeriodEnd = `mappedAction.expiresDate`, `ultraEffect = grant(mappedAction.expiresDate)`.
+  - `"in_grace"` → newStatus = `"in_grace"`, keep period end, `ultraEffect = noop`.
+  - `"cancel_keep_entitlement"` → newStatus = `"canceled"`, keep period end, `ultraEffect = noop`.
+  - `"expire"` → newStatus = `"expired"`, keep period end, `ultraEffect = revoke`.
+  - `"revoke"` → newStatus = `"revoked"`, keep period end, `ultraEffect = revoke`.
+  - `"noop"` → no state change, `ultraEffect = noop`.
 
 `grant` and `revoke` helpers reuse the existing `PostCommitUltraEffect` type from Google Play, parameterized with `excludeSubscriptionId = sub.id` so the multi-sub guards in `applyUltraEffect` fire identically.
 
-`applyUltraEffect` is **unchanged** — it already handles both grant and revoke variants with the multi-sub guards. The grant guard's MAX(expiresDate, otherActive.currentPeriodEnd) works correctly because Apple's `expiresDate` is a real timestamp (no 30-day conservative default — strict spec improvement vs Google).
+**`applyUltraEffect` is unchanged** — it already handles both grant and revoke variants with the multi-sub guards (revoke skip if `hasOtherActiveSubscription`; grant uses `MAX(effect.expiresAt, otherMax)`). Apple's real `expiresDate` flows through identically; the grant guard MAX now operates on a strict timestamp instead of a 30-day default — a correctness improvement over Google Play.
+
+**`applyDecodedEvent` (the Google-specific state machine) is NOT modified.** It is renamed only if needed to disambiguate; to keep diff small the plan leaves the name `applyDecodedEvent` for the Google function. The new App Store function is named `applyAppStoreEvent`. Clear by signature.
 
 ### 7.4 Routes
 
 Two new endpoints in `billing.route.ts`:
 
-#### `POST /webhooks/app-store`
-- Auth: `X-Pruvi-Webhook-Token` header matches `env.APP_STORE_WEBHOOK_TOKEN`. Constant-time comparison via `timingSafeEqual`. Missing env → 503. Mismatched → 401. Same `webhookGuard`-style pattern as Google, factored if convenient.
+#### `POST /webhooks/app-store/:token`
+- **Auth via URL path parameter** (Apple cannot inject custom HTTP headers; the Google `X-Pruvi-Webhook-Token` header pattern does NOT work for Apple). The `:token` path param is compared in constant time against `env.APP_STORE_WEBHOOK_TOKEN`. Missing env → 503. Mismatched → 404 (not 401 — returning 404 is more URL-obscurity-friendly; an attacker probing the path gets the same response as a wrong URL).
+- The token is required to be `min(32)` characters for sufficient URL-obscurity entropy.
+- The full URL configured in App Store Connect is `https://api.pruvi.app/webhooks/app-store/<APP_STORE_WEBHOOK_TOKEN>`. Rotating the token requires updating both env and App Store Connect.
 - Body: `z.unknown()` (Apple's envelope is `{ signedPayload: string }` but we validate it inside the service for diagnostics).
 - Response shape: same as Google's webhook (`{ received: true, notificationUUID?, kind?, error? }`).
 - 200 on malformed envelope (Apple won't retry forever); 200 on processing failure with audit row written.
 
+**Path-token guard sketch:**
+
+```ts
+async function appStorePathGuard(request: FastifyRequest) {
+  if (!env.APP_STORE_WEBHOOK_TOKEN) {
+    throw new AppError("WEBHOOK_DISABLED", 503, "WEBHOOK_DISABLED");
+  }
+  const { token } = request.params as { token: string };
+  const a = Buffer.from(token);
+  const b = Buffer.from(env.APP_STORE_WEBHOOK_TOKEN);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    throw new NotFoundError("Not Found"); // 404 to avoid leaking endpoint existence
+  }
+}
+```
+
 #### `POST /billing/app-store/link`
 - Auth: `fastify.authenticate`.
-- Body: `{ originalTransactionId: z.string().min(1), productId: z.string().min(1) }`.
-- Response: same shape as `GooglePlayLinkResponseSchema` (subscription id, status, productId, currentPeriodEnd). The schema is renamed to `BillingLinkResponseSchema` in shared (provider-agnostic) — see §11 for shared-module shape.
+- Body: validated by `AppStoreLinkBodySchema` (see §7.5): `{ originalTransactionId, productId }`.
+- Response: validated by `AppStoreLinkResponseSchema` which is a **type alias** for `GooglePlayLinkResponseSchema` (identical shape — provider-agnostic). No rename of the Google schema.
 
 ### 7.5 Shared module changes
 
@@ -183,7 +210,7 @@ export const APP_STORE_NOTIFICATION_TYPES = [
   "GRACE_PERIOD_EXPIRED", "REFUND", "REFUND_DECLINED", "REFUND_REVERSED",
   "REVOKE", "DID_CHANGE_RENEWAL_STATUS", "DID_CHANGE_RENEWAL_PREF",
   "OFFER_REDEEMED", "PRICE_INCREASE", "RENEWAL_EXTENDED",
-  "CONSUMPTION_REQUEST", "TEST",
+  "CONSUMPTION_REQUEST", "ONE_TIME_CHARGE", "TEST",
 ] as const;
 
 export const AppStoreLinkBodySchema = z.object({
@@ -198,7 +225,11 @@ export type AppStoreLinkResponse = z.infer<typeof AppStoreLinkResponseSchema>;
 
 ### 7.6 Env declaration
 
-`APP_STORE_WEBHOOK_TOKEN: z.string().min(16).optional()` in `packages/env/src/server.ts`, mirroring `GOOGLE_PLAY_WEBHOOK_TOKEN`.
+`APP_STORE_WEBHOOK_TOKEN: z.string().min(32).optional()` in `packages/env/src/server.ts`. Note: `min(32)` (not 16 like Google) because this token appears in the URL path and acts as the sole auth mechanism — it must have enough entropy to resist URL guessing. Generate as a 32+ char URL-safe random string.
+
+### 7.6 Parked-event replay (link-time)
+
+Identical pattern to Phase 2E.4 §7.6, but the link-time replay loop must call the correct state-machine function based on the audit row's provider. Since each link endpoint is provider-specific (`/billing/app-store/link` vs `/billing/google-play/link`), each link handler queries `listUnprocessedEventsForToken(tx, provider, token)` with its own provider value, and the replay loop calls the corresponding state-machine (`applyAppStoreEvent` for App Store events, `applyDecodedEvent` for Google events). No cross-provider mixing.
 
 ### 7.7 Logging
 
@@ -241,8 +272,8 @@ See §7.4. Idempotent on `(provider='app_store', purchase_token=originalTransact
 
 ## 11. Acceptance criteria
 
-A1. `POST /webhooks/app-store` with a valid `X-Pruvi-Webhook-Token` header and a well-formed `{ signedPayload }` envelope returns 200.
-A2. Missing/invalid header → 401; env token absent → 503 `WEBHOOK_DISABLED`.
+A1. `POST /webhooks/app-store/:token` where `:token` matches `env.APP_STORE_WEBHOOK_TOKEN` and a well-formed `{ signedPayload }` body returns 200.
+A2. Mismatched `:token` → 404 (returning 404 keeps the endpoint URL-obscure); env token absent → 503 `WEBHOOK_DISABLED`. **Header-based auth is NOT used** — Apple cannot inject custom HTTP headers (this differs from Google Play).
 A3. Duplicate `notificationUUID` deliveries are stored only once; subsequent responses still 200.
 A4. `POST /billing/app-store/link` with `{ originalTransactionId, productId }` creates a `subscription` row with `provider='app_store'`, `purchase_token=originalTransactionId`, `status='pending'`, owned by the authenticated user.
 A5. Re-calling `link` with the same `originalTransactionId` by the same user is idempotent (200, returns current state).
@@ -256,8 +287,8 @@ A12. Pre-link webhook → audit row + orphan subscription; later link replays th
 A13. Multi-subscription REVOKE guard: a user with another active App Store or Google Play subscription does NOT lose Ultra when the EXPIRED for the older row arrives.
 A14. Multi-subscription GRANT guard: a renewal with a shorter `expiresDate` does NOT truncate a longer active subscription's expiry — final Ultra expiry is `MAX(this.expiresDate, otherActive.currentPeriodEnd)`.
 A15. Shared `applyUltraEffect` (Phase 2E.4) is reused unchanged for App Store grants and revokes. (Verify by code reading; no parallel/duplicate effect-applier.)
-A16. `APP_STORE_WEBHOOK_TOKEN` declared in `packages/env/src/server.ts` as `z.string().min(16).optional()`.
-A17. Decoder maps all 16 notificationType names in §6 to the correct `AppStoreMappedAction`. Unknown types route to `kind: "unknown"` with no state mutation.
+A16. `APP_STORE_WEBHOOK_TOKEN` declared in `packages/env/src/server.ts` as `z.string().min(32).optional()` (32+ chars for URL-path obscurity).
+A17. Decoder maps all 17 documented notificationType names in §6 (including ONE_TIME_CHARGE as no-op) to the correct `AppStoreMappedAction`. Unknown types route to `kind: "unknown"` with no state mutation.
 A18. No `console.error` in production paths. All logs via `fastify.log`.
 A19. A `billing_event` row with `provider='app_store'` and `provider='google_play'` can both exist for the same string value of `message_id` (Apple's notificationUUID vs Google's Pub/Sub messageId share namespace via `(provider, message_id)` UNIQUE).
 

--- a/docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md
@@ -1,0 +1,280 @@
+# Phase 2E.5 — Billing Webhooks: App Store Server Notifications V2 (Design Spec)
+
+**Status:** v1
+**Date:** 2026-05-12
+**Branch:** `feature/phase-2e5-app-store-webhooks`
+**Builds on:** Phase 2E.4 (Google Play webhooks) — same `subscription`/`billing_event` schema, same `UltraService`, same multi-sub guards.
+
+---
+
+## 1. Goal
+
+Add an App Store Server Notifications V2 adapter to the existing `billing` module so Apple subscription purchases, renewals, refunds, and revocations grant or revoke Ultra automatically — bringing iOS to parity with Google Play.
+
+## 2. Non-goals
+
+- **JWS x5c certificate-chain signature verification.** Apple signs every notification with a JWS containing the certificate chain in the `x5c` header. Production-correct auth requires validating that chain against Apple's root CA. For v1, we use a shared-secret header (`X-Pruvi-Webhook-Token` against `APP_STORE_WEBHOOK_TOKEN`) — same model used for Google Play. **Real JWS signature verification is deferred** to an infra/hardening ticket.
+- **App Store Server API `/inApps/v1/subscriptions/{originalTransactionId}` polling.** No server-to-server reconciliation in v1.
+- **Sandbox vs Production discrimination.** Apple sends an `environment` field in every notification (`Sandbox` or `Production`). v1 processes both identically. A future hardening pass may route Sandbox notifications to a separate test DB or reject them outright.
+- **`signedRenewalInfo`** parsing (it carries renewal price, status, etc.). v1 reads ONLY `signedTransactionInfo` since that has the data we need (originalTransactionId, expiresDate, productId). `signedRenewalInfo` decoding is deferred.
+- **Family-share, promo offers, win-back offers, subscription gifting.** Not handled.
+- **One-time consumable purchases.** Out of scope.
+
+## 3. Concepts
+
+- **Apple notification envelope:** Apple POSTs `{ "signedPayload": "<JWS>" }` directly to our URL (no Pub/Sub wrapper). The JWS is a `header.payload.signature` string where the middle segment is base64url-encoded JSON.
+- **Inner payload:** decoded JSON contains `notificationType`, optional `subtype`, `notificationUUID` (our dedup key), `data.signedTransactionInfo` (another JWS), `version`, `signedDate`, `data.environment`.
+- **`signedTransactionInfo`:** another JWS whose decoded payload carries `transactionId`, `originalTransactionId`, `productId`, `expiresDate` (milliseconds), `bundleId`, `environment`, `originalPurchaseDate`, etc.
+- **`originalTransactionId`:** the stable long-term identifier for a subscription instance. Across renewals, this stays the same; `transactionId` changes per renewal. We use `originalTransactionId` as the `subscription.purchase_token` value for the `app_store` provider.
+- **`notificationUUID`:** unique per notification delivery. Used as `billing_event.message_id` for idempotency.
+
+## 4. Mechanic
+
+1. User purchases Ultra via Apple's StoreKit on iOS.
+2. Mobile app receives the purchase result; reads `originalTransactionId` and `productId`.
+3. Mobile app calls `POST /billing/app-store/link { originalTransactionId, productId }`.
+4. Server upserts a `subscription` row keyed by `(provider='app_store', purchase_token=originalTransactionId)` with `user_id` set, `status='pending'`, `product_id` set.
+5. Apple sends a SUBSCRIBED notification to our configured URL.
+6. Webhook handler verifies shared-secret header, parses outer JWS (no signature verification in v1), parses inner `signedTransactionInfo` JWS, deduplicates by `(provider='app_store', notificationUUID)`, dispatches the state machine.
+7. State machine (see §6) updates `subscription` and queues Ultra grant/revoke effect.
+8. Post-commit, `applyUltraEffect` runs the existing multi-sub GRANT/REVOKE guards (reused from 2E.4) and calls `UltraService.grant` / `.revoke`.
+
+Race-safety: identical to 2E.4 — if the webhook arrives before the link call, the orphan subscription is created with `user_id=NULL` and the event is parked; link replays unprocessed events.
+
+## 5. Data model
+
+**No new tables.** The existing `subscription` and `billing_event` tables already accept `provider='app_store'` (CHECK enum + Drizzle enum in Phase 2E.4). No migration in this phase.
+
+## 6. Apple notification → state machine
+
+The table below maps `(notificationType, subtype)` pairs to our subscription state and Ultra effect. `expiresDate` is from `signedTransactionInfo` (real timestamp, not a default).
+
+| notificationType | subtype | Action on subscription | Action on Ultra |
+|---|---|---|---|
+| `SUBSCRIBED` | `INITIAL_BUY` | status → `active`, currentPeriodEnd = expiresDate | grant until expiresDate |
+| `SUBSCRIBED` | `RESUBSCRIBE` | status → `active`, currentPeriodEnd = expiresDate | grant until expiresDate |
+| `DID_RENEW` | (any/null) | status → `active`, currentPeriodEnd = expiresDate | grant until expiresDate |
+| `DID_FAIL_TO_RENEW` | `GRACE_PERIOD` | status → `in_grace` | no-op (leave grant) |
+| `DID_FAIL_TO_RENEW` | (any other) | status → `canceled` (renewal failed, no grace) | no-op (entitled until expiresDate) |
+| `EXPIRED` | (any) | status → `expired` | revoke (multi-sub guarded) |
+| `GRACE_PERIOD_EXPIRED` | (any) | status → `expired` | revoke (multi-sub guarded) |
+| `REFUND` | (any) | status → `revoked` | revoke (multi-sub guarded) |
+| `REVOKE` | (any) | status → `revoked` | revoke (multi-sub guarded) |
+| `DID_CHANGE_RENEWAL_STATUS` | `AUTO_RENEW_DISABLED` | status → `canceled` (user disabled renewal; still entitled) | no-op |
+| `DID_CHANGE_RENEWAL_STATUS` | `AUTO_RENEW_ENABLED` | no-op on status | no-op |
+| `DID_CHANGE_RENEWAL_PREF` | (any) | no-op | no-op |
+| `OFFER_REDEEMED` | (any) | no-op | no-op |
+| `PRICE_INCREASE` | (any) | no-op (consent flow handled by Apple) | no-op |
+| `RENEWAL_EXTENDED` | (any) | no-op (admin-initiated extension; expiresDate already updated via DID_RENEW) | no-op |
+| `REFUND_DECLINED` | (any) | no-op | no-op |
+| `REFUND_REVERSED` | (any) | status → `active` (refund was reversed; treat like SUBSCRIBED) | grant until expiresDate |
+| `CONSUMPTION_REQUEST` | (any) | no-op | no-op |
+| `TEST` | n/a | no-op (record audit only) | no-op |
+
+Unknown `notificationType` values → audit row recorded with `eventType = "UNKNOWN_<type>"`, no state mutation, no Ultra effect. Future Apple additions surface in the audit log for ops triage.
+
+**Rationale notes:**
+- `DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_DISABLED` is the Apple equivalent of Google's CANCELED. User retains entitlement until `expiresDate`.
+- `REFUND_REVERSED` is a rare but real case — restoring access. Maps to SUBSCRIBED-like grant.
+- `RENEWAL_EXTENDED` is intentionally a no-op since the actual entitlement extension comes through a subsequent `DID_RENEW` with the new `expiresDate`.
+
+## 7. Architecture
+
+### 7.1 Module layout
+
+Additions to the existing `billing` module:
+
+```
+apps/server/src/features/billing/
+├── app-store.decoder.ts             # NEW: pure JWS parsing + state mapping
+├── app-store.decoder.test.ts        # NEW: unit tests on fixture payloads
+├── billing.repository.ts            # No changes (already provider-agnostic)
+├── billing.service.ts               # Extended: new methods `processAppStoreEnvelope` and `linkAppStorePurchase` reusing the shared `applyUltraEffect`
+├── billing.service.test.ts          # Extended: new test cases for Apple paths
+├── billing.route.ts                 # Extended: 2 new endpoints
+└── index.ts                         # Already exports billingRoutes
+```
+
+### 7.2 The decoder
+
+`app-store.decoder.ts` exports `decodeAppStoreNotification(envelope: { signedPayload: string })` returning:
+
+```ts
+type DecodedAppStoreEvent =
+  | {
+      kind: "subscription";
+      notificationUUID: string;
+      notificationType: string;          // raw Apple type
+      subtype: string | null;
+      mappedAction: AppStoreMappedAction; // discriminant for the state machine
+      originalTransactionId: string;
+      productId: string;
+      expiresDate: Date | null;          // null only for notifications that don't carry signedTransactionInfo
+      environment: "Sandbox" | "Production";
+    }
+  | { kind: "test"; notificationUUID: string }
+  | { kind: "unknown"; notificationUUID: string; notificationType: string; subtype: string | null; originalTransactionId: string | null };
+```
+
+`AppStoreMappedAction` is a tagged union mirroring the state-machine rows:
+
+```ts
+type AppStoreMappedAction =
+  | { kind: "activate"; expiresDate: Date }    // SUBSCRIBED, DID_RENEW, REFUND_REVERSED
+  | { kind: "in_grace" }                        // DID_FAIL_TO_RENEW + GRACE_PERIOD
+  | { kind: "cancel_keep_entitlement" }         // DID_FAIL_TO_RENEW (other), AUTO_RENEW_DISABLED
+  | { kind: "expire" }                          // EXPIRED, GRACE_PERIOD_EXPIRED
+  | { kind: "revoke" }                          // REFUND, REVOKE
+  | { kind: "noop" };
+```
+
+The decoder is **pure** (no DB, no HTTP). Steps:
+1. Split `signedPayload` on `.`, take the middle segment, base64url-decode, JSON.parse → outer.
+2. Read `notificationUUID`, `notificationType`, `subtype`, `data.environment`. If `data.signedTransactionInfo` is absent or notification is the literal `notificationType: "TEST"` of a CONSOLE_TEST kind (Apple uses `notificationType: "TEST"`), return `{ kind: "test" }`.
+3. Decode `data.signedTransactionInfo` JWS the same way → transaction info.
+4. Read `transaction.originalTransactionId`, `productId`, `expiresDate` (ms).
+5. Map `(notificationType, subtype)` to `AppStoreMappedAction` via the table in §6.
+6. Return.
+
+**No signature verification in v1.** Document this as `// SECURITY: deferred — see spec §2 non-goals`.
+
+### 7.3 The service extensions
+
+`BillingService` gains two new methods that mirror the Google Play flow:
+
+- `processAppStoreEnvelope(envelope: unknown)`: same shape as `processWebhookEnvelope` (Google's name will be renamed in this phase to `processGooglePlayEnvelope` for clarity OR left as-is to avoid PR churn — see §11). Decodes, dedups, runs state machine, queues effect.
+- `linkAppStorePurchase(userId, { originalTransactionId, productId })`: same shape as `linkGooglePlayPurchase` but for `provider='app_store'`.
+
+The state machine inside the service receives a `decoded: DecodedAppStoreEvent` and the current `subscription` row, and computes `{ newStatus, newPeriodEnd, ultraEffect }`. The branching is on `decoded.mappedAction.kind`:
+
+- `"activate"` → newStatus = `"active"`, newPeriodEnd = `mappedAction.expiresDate`, `ultraEffect = grant(expiresDate)`.
+- `"in_grace"` → newStatus = `"in_grace"`, keep period end, `ultraEffect = noop`.
+- `"cancel_keep_entitlement"` → newStatus = `"canceled"`, keep period end, `ultraEffect = noop`.
+- `"expire"` → newStatus = `"expired"`, keep period end, `ultraEffect = revoke`.
+- `"revoke"` → newStatus = `"revoked"`, keep period end, `ultraEffect = revoke`.
+- `"noop"` → no state change.
+
+`grant` and `revoke` helpers reuse the existing `PostCommitUltraEffect` type from Google Play, parameterized with `excludeSubscriptionId = sub.id` so the multi-sub guards in `applyUltraEffect` fire identically.
+
+`applyUltraEffect` is **unchanged** — it already handles both grant and revoke variants with the multi-sub guards. The grant guard's MAX(expiresDate, otherActive.currentPeriodEnd) works correctly because Apple's `expiresDate` is a real timestamp (no 30-day conservative default — strict spec improvement vs Google).
+
+### 7.4 Routes
+
+Two new endpoints in `billing.route.ts`:
+
+#### `POST /webhooks/app-store`
+- Auth: `X-Pruvi-Webhook-Token` header matches `env.APP_STORE_WEBHOOK_TOKEN`. Constant-time comparison via `timingSafeEqual`. Missing env → 503. Mismatched → 401. Same `webhookGuard`-style pattern as Google, factored if convenient.
+- Body: `z.unknown()` (Apple's envelope is `{ signedPayload: string }` but we validate it inside the service for diagnostics).
+- Response shape: same as Google's webhook (`{ received: true, notificationUUID?, kind?, error? }`).
+- 200 on malformed envelope (Apple won't retry forever); 200 on processing failure with audit row written.
+
+#### `POST /billing/app-store/link`
+- Auth: `fastify.authenticate`.
+- Body: `{ originalTransactionId: z.string().min(1), productId: z.string().min(1) }`.
+- Response: same shape as `GooglePlayLinkResponseSchema` (subscription id, status, productId, currentPeriodEnd). The schema is renamed to `BillingLinkResponseSchema` in shared (provider-agnostic) — see §11 for shared-module shape.
+
+### 7.5 Shared module changes
+
+Add to `packages/shared/src/billing.ts`:
+
+```ts
+export const APP_STORE_NOTIFICATION_TYPES = [
+  "SUBSCRIBED", "DID_RENEW", "DID_FAIL_TO_RENEW", "EXPIRED",
+  "GRACE_PERIOD_EXPIRED", "REFUND", "REFUND_DECLINED", "REFUND_REVERSED",
+  "REVOKE", "DID_CHANGE_RENEWAL_STATUS", "DID_CHANGE_RENEWAL_PREF",
+  "OFFER_REDEEMED", "PRICE_INCREASE", "RENEWAL_EXTENDED",
+  "CONSUMPTION_REQUEST", "TEST",
+] as const;
+
+export const AppStoreLinkBodySchema = z.object({
+  originalTransactionId: z.string().min(1),
+  productId: z.string().min(1),
+});
+export type AppStoreLinkBody = z.infer<typeof AppStoreLinkBodySchema>;
+
+export const AppStoreLinkResponseSchema = GooglePlayLinkResponseSchema; // identical shape; aliased for clarity at call sites
+export type AppStoreLinkResponse = z.infer<typeof AppStoreLinkResponseSchema>;
+```
+
+### 7.6 Env declaration
+
+`APP_STORE_WEBHOOK_TOKEN: z.string().min(16).optional()` in `packages/env/src/server.ts`, mirroring `GOOGLE_PLAY_WEBHOOK_TOKEN`.
+
+### 7.7 Logging
+
+Same pattern as Google Play: `fastify.log.warn` / `fastify.log.error`. No `console.error`. Audit trail in `billing_event`.
+
+## 8. API surface
+
+### 8.1 `POST /webhooks/app-store`
+See §7.4.
+
+### 8.2 `POST /billing/app-store/link`
+See §7.4. Idempotent on `(provider='app_store', purchase_token=originalTransactionId)`. 409 if token is already owned by another user.
+
+## 9. Migration
+
+**None.** Schema unchanged from 2E.4.
+
+## 10. Testing strategy
+
+**Unit** (`app-store.decoder.test.ts`):
+- Each major notificationType+subtype mapping (SUBSCRIBED:INITIAL_BUY, SUBSCRIBED:RESUBSCRIBE, DID_RENEW, DID_FAIL_TO_RENEW:GRACE_PERIOD, DID_FAIL_TO_RENEW:other, EXPIRED, REFUND, REVOKE, DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_DISABLED, DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_ENABLED, REFUND_REVERSED, RENEWAL_EXTENDED).
+- TEST notification.
+- Unknown notificationType → `kind: "unknown"`.
+- Malformed JWS (not 3 segments) → throws.
+- Malformed base64url → throws.
+- Missing `signedTransactionInfo` → throws (unless kind=test).
+
+**Service unit** (extension of `billing.service.test.ts`):
+- App Store SUBSCRIBED on linked sub → active + grant with `expiresDate` (NOT now+30d — assert the exact Apple-provided date).
+- DID_RENEW with multi-sub guard: another active sub with LATER expiresDate → grant uses MAX.
+- EXPIRED with no other active sub → revoke called.
+- REFUND_REVERSED → grant.
+- AUTO_RENEW_DISABLED → status=canceled, no Ultra change.
+- Duplicate notificationUUID → no-op.
+- Link path: same-user idempotency, conflict on different user.
+
+**Integration** (extension of `billing.repository.integration.test.ts`): no new repo methods, but add a test confirming a row with `provider='app_store'` can coexist with a `provider='google_play'` row using the same purchase_token string (UNIQUE is on the composite key).
+
+**Shared** (`billing.test.ts`): a single test asserting `APP_STORE_NOTIFICATION_TYPES` contains the expected names; `AppStoreLinkBodySchema` validates inputs.
+
+## 11. Acceptance criteria
+
+A1. `POST /webhooks/app-store` with a valid `X-Pruvi-Webhook-Token` header and a well-formed `{ signedPayload }` envelope returns 200.
+A2. Missing/invalid header → 401; env token absent → 503 `WEBHOOK_DISABLED`.
+A3. Duplicate `notificationUUID` deliveries are stored only once; subsequent responses still 200.
+A4. `POST /billing/app-store/link` with `{ originalTransactionId, productId }` creates a `subscription` row with `provider='app_store'`, `purchase_token=originalTransactionId`, `status='pending'`, owned by the authenticated user.
+A5. Re-calling `link` with the same `originalTransactionId` by the same user is idempotent (200, returns current state).
+A6. Calling `link` with `originalTransactionId` already owned by a different user returns 409.
+A7. `SUBSCRIBED:INITIAL_BUY` on a linked subscription sets `status='active'`, `currentPeriodEnd = signedTransactionInfo.expiresDate`, calls `UltraService.grant(userId, expiresDate)` — **NOT** a 30-day default. (Apple-strict improvement over Google.)
+A8. `DID_RENEW` advances `currentPeriodEnd` to the new `expiresDate` and re-grants Ultra.
+A9. `EXPIRED` → `status='expired'`, Ultra revoked (multi-sub guarded).
+A10. `DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_DISABLED` → `status='canceled'`; Ultra remains until `expiresDate`.
+A11. `REFUND_REVERSED` → `status='active'`, Ultra re-granted.
+A12. Pre-link webhook → audit row + orphan subscription; later link replays the event. (Same race-safety as Google Play.)
+A13. Multi-subscription REVOKE guard: a user with another active App Store or Google Play subscription does NOT lose Ultra when the EXPIRED for the older row arrives.
+A14. Multi-subscription GRANT guard: a renewal with a shorter `expiresDate` does NOT truncate a longer active subscription's expiry — final Ultra expiry is `MAX(this.expiresDate, otherActive.currentPeriodEnd)`.
+A15. Shared `applyUltraEffect` (Phase 2E.4) is reused unchanged for App Store grants and revokes. (Verify by code reading; no parallel/duplicate effect-applier.)
+A16. `APP_STORE_WEBHOOK_TOKEN` declared in `packages/env/src/server.ts` as `z.string().min(16).optional()`.
+A17. Decoder maps all 16 notificationType names in §6 to the correct `AppStoreMappedAction`. Unknown types route to `kind: "unknown"` with no state mutation.
+A18. No `console.error` in production paths. All logs via `fastify.log`.
+A19. A `billing_event` row with `provider='app_store'` and `provider='google_play'` can both exist for the same string value of `message_id` (Apple's notificationUUID vs Google's Pub/Sub messageId share namespace via `(provider, message_id)` UNIQUE).
+
+## 12. Deferred items
+
+- JWS x5c certificate-chain signature verification (production-correct webhook auth).
+- App Store Server API polling for state reconciliation.
+- Sandbox-vs-Production routing to separate DB / behavior.
+- `signedRenewalInfo` parsing (renewal price, status changes, offer details).
+- Family-share, promo offers, win-back offers, gifting.
+- Background sweep job that detects subscriptions whose `currentPeriodEnd` is past but never received `EXPIRED` (catches missed deliveries).
+
+## 13. Open questions resolved during design
+
+- **JWS sig verification — block or defer?** Defer. Same shared-secret model as Google. Apple's contract recommends sig verification; we ship that as hardening.
+- **Use `originalTransactionId` or `transactionId` as the long-term key?** `originalTransactionId` — stable across renewals (matches Google's `purchaseToken` semantics).
+- **What if the link arrives but the webhook never fires?** Subscription stays `pending` indefinitely; no Ultra grant. Same as Google.
+- **Sandbox notifications in production env — accept or reject?** Accept (with a note). v1 treats Sandbox identically; a future hardening pass may reject them in production env.
+- **Single decoder for both providers, or separate?** Separate. Google and Apple have meaningfully different envelope shapes; a shared decoder would be more confusing than two focused ones. The `applyDecodedEvent` state-machine function ALSO becomes provider-aware in this phase (or splits into `applyGooglePlayEvent` / `applyAppStoreEvent` — implementation choice deferred to plan).
+- **Should we rename `processWebhookEnvelope` to `processGooglePlayEnvelope`?** Yes — for symmetry with the new `processAppStoreEnvelope` and to disambiguate. The link method `linkGooglePlayPurchase` is already provider-specific so it stays.

--- a/docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md
@@ -1,6 +1,6 @@
 # Phase 2E.5 — Billing Webhooks: App Store Server Notifications V2 (Design Spec)
 
-**Status:** v2 (post Gate A: URL-path token instead of header, dedicated applyAppStoreEvent + processGooglePlayEnvelope rename, ONE_TIME_CHARGE no-op, DID_FAIL_TO_RENEW → on_hold)
+**Status:** v3 (post Gate B: on_hold_keep_entitlement variant explicit in AppStoreMappedAction)
 **Date:** 2026-05-12
 **Branch:** `feature/phase-2e5-app-store-webhooks`
 **Builds on:** Phase 2E.4 (Google Play webhooks) — same `subscription`/`billing_event` schema, same `UltraService`, same multi-sub guards.
@@ -123,7 +123,8 @@ type DecodedAppStoreEvent =
 type AppStoreMappedAction =
   | { kind: "activate"; expiresDate: Date }    // SUBSCRIBED, DID_RENEW, REFUND_REVERSED
   | { kind: "in_grace" }                        // DID_FAIL_TO_RENEW + GRACE_PERIOD
-  | { kind: "cancel_keep_entitlement" }         // DID_FAIL_TO_RENEW (other), AUTO_RENEW_DISABLED
+  | { kind: "cancel_keep_entitlement" }         // DID_CHANGE_RENEWAL_STATUS:AUTO_RENEW_DISABLED (user-initiated)
+  | { kind: "on_hold_keep_entitlement" }        // DID_FAIL_TO_RENEW (no GRACE_PERIOD subtype) — billing failure, not user choice
   | { kind: "expire" }                          // EXPIRED, GRACE_PERIOD_EXPIRED
   | { kind: "revoke" }                          // REFUND, REVOKE
   | { kind: "noop" };
@@ -157,6 +158,7 @@ The existing `BillingService.applyDecodedEvent(decoded: DecodedGooglePlayEvent, 
   - `"activate"` → newStatus = `"active"`, newPeriodEnd = `mappedAction.expiresDate`, `ultraEffect = grant(mappedAction.expiresDate)`.
   - `"in_grace"` → newStatus = `"in_grace"`, keep period end, `ultraEffect = noop`.
   - `"cancel_keep_entitlement"` → newStatus = `"canceled"`, keep period end, `ultraEffect = noop`.
+  - `"on_hold_keep_entitlement"` → newStatus = `"on_hold"`, keep period end, `ultraEffect = noop`.
   - `"expire"` → newStatus = `"expired"`, keep period end, `ultraEffect = revoke`.
   - `"revoke"` → newStatus = `"revoked"`, keep period end, `ultraEffect = revoke`.
   - `"noop"` → no state change, `ultraEffect = noop`.

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -21,6 +21,7 @@ export const env = createEnv({
     EXPO_ACCESS_TOKEN: z.string().optional(),
     ADMIN_API_TOKEN: z.string().min(16).optional(),
     GOOGLE_PLAY_WEBHOOK_TOKEN: z.string().min(16).optional(),
+    APP_STORE_WEBHOOK_TOKEN: z.string().min(32).optional(),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/packages/shared/src/billing.test.ts
+++ b/packages/shared/src/billing.test.ts
@@ -5,6 +5,8 @@ import {
   GOOGLE_PLAY_NOTIFICATION_TYPES,
   GooglePlayLinkBodySchema,
   DEFAULT_SUBSCRIPTION_PERIOD_MS,
+  APP_STORE_NOTIFICATION_TYPES,
+  AppStoreLinkBodySchema,
 } from "./billing";
 
 describe("billing shared module", () => {
@@ -32,5 +34,17 @@ describe("billing shared module", () => {
   it("validates link body shape", () => {
     expect(GooglePlayLinkBodySchema.safeParse({ purchaseToken: "t", productId: "pruvi_ultra_monthly" }).success).toBe(true);
     expect(GooglePlayLinkBodySchema.safeParse({ purchaseToken: "", productId: "x" }).success).toBe(false);
+  });
+
+  it("declares all 17 app store notification types", () => {
+    expect(APP_STORE_NOTIFICATION_TYPES).toHaveLength(17);
+    expect(APP_STORE_NOTIFICATION_TYPES).toContain("SUBSCRIBED");
+    expect(APP_STORE_NOTIFICATION_TYPES).toContain("REFUND_REVERSED");
+    expect(APP_STORE_NOTIFICATION_TYPES).toContain("ONE_TIME_CHARGE");
+  });
+
+  it("validates app store link body shape", () => {
+    expect(AppStoreLinkBodySchema.safeParse({ originalTransactionId: "200000000000001", productId: "pruvi_ultra_monthly" }).success).toBe(true);
+    expect(AppStoreLinkBodySchema.safeParse({ originalTransactionId: "", productId: "x" }).success).toBe(false);
   });
 });

--- a/packages/shared/src/billing.ts
+++ b/packages/shared/src/billing.ts
@@ -58,3 +58,34 @@ export const GooglePlayLinkResponseSchema = z.object({
   }),
 });
 export type GooglePlayLinkResponse = z.infer<typeof GooglePlayLinkResponseSchema>;
+
+export const APP_STORE_NOTIFICATION_TYPES = [
+  "SUBSCRIBED",
+  "DID_RENEW",
+  "DID_FAIL_TO_RENEW",
+  "EXPIRED",
+  "GRACE_PERIOD_EXPIRED",
+  "REFUND",
+  "REFUND_DECLINED",
+  "REFUND_REVERSED",
+  "REVOKE",
+  "DID_CHANGE_RENEWAL_STATUS",
+  "DID_CHANGE_RENEWAL_PREF",
+  "OFFER_REDEEMED",
+  "PRICE_INCREASE",
+  "RENEWAL_EXTENDED",
+  "CONSUMPTION_REQUEST",
+  "ONE_TIME_CHARGE",
+  "TEST",
+] as const;
+export type AppStoreNotificationType = (typeof APP_STORE_NOTIFICATION_TYPES)[number];
+
+export const AppStoreLinkBodySchema = z.object({
+  originalTransactionId: z.string().min(1),
+  productId: z.string().min(1),
+});
+export type AppStoreLinkBody = z.infer<typeof AppStoreLinkBodySchema>;
+
+/** Type alias — Apple link response shape is identical to Google's (provider-agnostic). */
+export const AppStoreLinkResponseSchema = GooglePlayLinkResponseSchema;
+export type AppStoreLinkResponse = z.infer<typeof AppStoreLinkResponseSchema>;


### PR DESCRIPTION
## Summary
- Apple ASSN V2 adapter extending the existing billing module from 2E.4
- Reuses `subscription`/`billing_event` tables and `applyUltraEffect` (multi-sub guards) unchanged — no migration needed
- Separate Apple JWS decoder + state machine (`applyAppStoreEvent`) sibling to the Google one
- **URL-path token auth**: `POST /webhooks/app-store/:token` against `env.APP_STORE_WEBHOOK_TOKEN` (min 32 chars). Apple cannot inject custom headers, so the Google header pattern can't transfer here
- 404 on token mismatch (URL-obscurity-friendly); 503 if env token missing
- Real `expiresDate` from `signedTransactionInfo` JWS — strict improvement over Google's 30-day default
- `DID_FAIL_TO_RENEW` (no GRACE_PERIOD subtype) → `on_hold` (billing failure, not user choice); `AUTO_RENEW_DISABLED` → `canceled`; semantically distinct
- `REFUND_REVERSED` with past `expiresDate` → safe downgrade to `expire`
- Renamed `processWebhookEnvelope` → `processGooglePlayEnvelope` (10 call sites updated)
- App Store JWS x5c certificate-chain signature verification deferred (production hardening)

## Workflow gates
- ✅ Gate A — spec self-review (2 blockers fixed: header→URL-path token; dedicated `applyAppStoreEvent` + rename; ONE_TIME_CHARGE/on_hold/decoder ordering)
- ✅ Gate B — plan self-review (3 blockers fixed: spec `on_hold_keep_entitlement` variant; rename count 10 not 3; return type leak)
- ✅ Gate C — per-task review after every commit (Gate C-C fixes per task: 1 unused type import)
- ✅ Gate D — final spec-coverage review (3 testing gaps closed: RENEWAL_EXTENDED decoder test, AUTO_RENEW_DISABLED service test, App Store link idempotency test)

## Test coverage (final)
- 20 App Store decoder tests (all 17 type mappings + RESUBSCRIBE + REVOKE + RENEWAL_EXTENDED + past-expiry safety + TEST + unknown + malformed JWS)
- 13 App Store service unit tests (SUBSCRIBED w/ Apple expiresDate, DID_RENEW, ON_HOLD vs IN_GRACE branches, EXPIRED, REFUND_REVERSED, AUTO_RENEW_DISABLED, dup UUID, TEST, link conflict, link idempotency, multi-sub GRANT guard)
- 13 repository integration tests (2 new cross-provider coexistence tests for message_id and purchase_token)
- 11 Google Play service unit tests preserved (only `processWebhookEnvelope` → `processGooglePlayEnvelope` rename)
- 12 Google Play decoder tests unchanged

## Spec & plan
- Spec v3: docs/superpowers/specs/2026-05-12-phase-2e5-app-store-webhooks-design.md
- Plan v2: docs/superpowers/plans/2026-05-12-phase-2e5-app-store-webhooks.md

## Test plan
- [ ] Manual: POST /webhooks/app-store/<token> with valid signedPayload → 200
- [ ] Manual: POST /webhooks/app-store/<bad-token> → 404
- [ ] Manual: POST /billing/app-store/link → 200 + subscription row; second call with different user → 409
- [ ] Simulate SUBSCRIBED + EXPIRED end-to-end → Ultra granted then revoked

## Deferred to follow-ups (per spec §12)
- JWS x5c certificate-chain signature verification (production-correct auth)
- App Store Server API polling for state reconciliation
- Sandbox vs Production environment routing
- `signedRenewalInfo` parsing
- Family-share, promo offers, gifting
- Background sweep for missed EXPIRED deliveries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple App Store webhook support to receive and process subscription notifications.
  * Added App Store purchase linking to connect purchases to user accounts.
  * Implemented subscription state transitions for App Store notification types.

* **Documentation**
  * Added comprehensive implementation plan and design specification for App Store billing integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CeCamillo/pruvi/pull/26)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->