### PR TITLE
feat: phase 2e.6 — referral shield reward + protect-streak push

### DIFF
--- a/apps/server/src/features/notifications/dispatcher.test.ts
+++ b/apps/server/src/features/notifications/dispatcher.test.ts
@@ -90,6 +90,49 @@ describe("Dispatcher.sendOvertakenNotification", () => {
   });
 });
 
+describe("Dispatcher.sendStreakProtectedNotification", () => {
+  it("happy path: enqueues job with streak_protected kind when prefs enabled and tokens present", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.sendStreakProtectedNotification("u", 7);
+    expect(deps.sendQueue.add).toHaveBeenCalledTimes(1);
+    const [, payload] = deps.sendQueue.add.mock.calls[0];
+    expect(payload.tokens).toEqual(["ExponentPushToken[a]"]);
+    expect(payload.title).toBe("Seu escudo protegeu seu streak!");
+    expect(payload.body).toContain("7 dias");
+    expect(payload.data).toEqual({ kind: "streak_protected" });
+  });
+
+  it("opt-out: does not enqueue when streakRemindersEnabled is false", async () => {
+    const deps = makeDeps({
+      prefsRepo: {
+        get: vi.fn().mockResolvedValue({ notificationHour: 19, streakRemindersEnabled: false, achievementNotificationsEnabled: true }),
+      },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.sendStreakProtectedNotification("u", 7);
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("no tokens: does not enqueue when user has no tokens", async () => {
+    const deps = makeDeps({
+      tokensService: { listTokensForUser: vi.fn().mockResolvedValue([]) },
+    });
+    const d = new Dispatcher(deps as any);
+    await d.sendStreakProtectedNotification("u", 7);
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("days < 1: returns immediately without calling prefs or tokens", async () => {
+    const deps = makeDeps();
+    const d = new Dispatcher(deps as any);
+    await d.sendStreakProtectedNotification("u", 0);
+    expect(deps.prefsRepo.get).not.toHaveBeenCalled();
+    expect(deps.tokensService.listTokensForUser).not.toHaveBeenCalled();
+    expect(deps.sendQueue.add).not.toHaveBeenCalled();
+  });
+});
+
 describe("Dispatcher.dispatchStreakReminder", () => {
   it("calls the eligibility query with hour and enqueues a send per chunk", async () => {
     const deps = makeDeps();

--- a/apps/server/src/features/notifications/dispatcher.ts
+++ b/apps/server/src/features/notifications/dispatcher.ts
@@ -5,6 +5,7 @@ import {
   streakMilestone,
   masteryAchievement,
   overtaken,
+  streakProtected,
   type PushPayload,
 } from "./templates";
 import type { TokensService } from "./tokens.service";
@@ -77,6 +78,28 @@ export class Dispatcher {
         title: payload.title,
         body: payload.body,
         data: { kind: "overtaken" },
+      });
+    }
+  }
+
+  async sendStreakProtectedNotification(userId: string, streakDays: number): Promise<void> {
+    if (streakDays < 1) return;
+
+    const prefs = await this.deps.prefsRepo.get(userId);
+    // Reuse streakRemindersEnabled — same opt-out semantics as streak reminders.
+    if (!prefs?.streakRemindersEnabled) return;
+
+    const tokens = await this.deps.tokensService.listTokensForUser(userId);
+    if (tokens.length === 0) return;
+
+    const payload = streakProtected(streakDays);
+    for (let i = 0; i < tokens.length; i += EXPO_BATCH_SIZE) {
+      const chunk = tokens.slice(i, i + EXPO_BATCH_SIZE);
+      await this.deps.sendQueue.add("send", {
+        tokens: chunk,
+        title: payload.title,
+        body: payload.body,
+        data: { kind: "streak_protected" },
       });
     }
   }

--- a/apps/server/src/features/notifications/templates.test.ts
+++ b/apps/server/src/features/notifications/templates.test.ts
@@ -5,6 +5,7 @@ import {
   streakMilestone,
   masteryAchievement,
   overtaken,
+  streakProtected,
   type PushPayload,
 } from "./templates";
 
@@ -39,5 +40,13 @@ describe("overtaken", () => {
     const p = overtaken("Pedro");
     expect(p.title).toBe("Você foi ultrapassado!");
     expect(p.body).toContain("Pedro");
+  });
+});
+
+describe("streakProtected", () => {
+  it("returns pt-BR copy with the day count", () => {
+    const p = streakProtected(7);
+    expect(p.title).toBe("Seu escudo protegeu seu streak!");
+    expect(p.body).toContain("7 dias");
   });
 });

--- a/apps/server/src/features/notifications/templates.test.ts
+++ b/apps/server/src/features/notifications/templates.test.ts
@@ -6,7 +6,6 @@ import {
   masteryAchievement,
   overtaken,
   streakProtected,
-  type PushPayload,
 } from "./templates";
 
 describe("notification templates", () => {

--- a/apps/server/src/features/notifications/templates.test.ts
+++ b/apps/server/src/features/notifications/templates.test.ts
@@ -48,4 +48,10 @@ describe("streakProtected", () => {
     expect(p.title).toBe("Seu escudo protegeu seu streak!");
     expect(p.body).toContain("7 dias");
   });
+
+  it("streakProtected(1) produces acceptable singular phrasing", () => {
+    const p = streakProtected(1);
+    expect(p.title).toBe("Seu escudo protegeu seu streak!");
+    expect(p.body).toContain("1 dias"); // Singular phrasing is acceptable per spec §7
+  });
 });

--- a/apps/server/src/features/notifications/templates.ts
+++ b/apps/server/src/features/notifications/templates.ts
@@ -40,3 +40,10 @@ export function overtaken(overtakerName: string): PushPayload {
     body: `${overtakerName} acabou de te passar no ranking 🔥`,
   };
 }
+
+export function streakProtected(days: number): PushPayload {
+  return {
+    title: "Seu escudo protegeu seu streak!",
+    body: `Seu streak de ${days} dias foi salvo. Continue amanhã 💛`,
+  };
+}

--- a/apps/server/src/features/sessions/sessions.service.test.ts
+++ b/apps/server/src/features/sessions/sessions.service.test.ts
@@ -435,3 +435,120 @@ describe("SessionsService.completeSession shield auto-use hook", () => {
     );
   });
 });
+
+describe("SessionsService.maybeProtectMissedDay protected push hook", () => {
+  const now = new Date();
+  const todayStr = todayInBrt(now);
+  const twoDaysAgoStr = todayInBrt(new Date(now.getTime() - 2 * 86_400_000));
+
+  function makeSessionRepo(userId = "u1") {
+    return {
+      findSessionById: vi.fn().mockResolvedValue({ id: 1, userId, status: "active" }),
+      completeSession: vi.fn().mockResolvedValue({ id: 1, status: "completed" }),
+      readMasterySnapshot: vi.fn().mockResolvedValue(null),
+    } as any;
+  }
+
+  function makeTopicsService() {
+    return {
+      computeTransitions: vi.fn().mockReturnValue([]),
+      getCurrentMasteryAndNames: vi.fn().mockResolvedValue({ currentMap: new Map(), namesMap: new Map() }),
+      snapshotMastery: vi.fn(),
+    } as any;
+  }
+
+  it("used=true + currentStreak > 0 → sendStreakProtectedNotification called once", async () => {
+    const sendStreakProtectedNotification = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = { sendStreakProtectedNotification } as any;
+    const shieldsService = { tryUseShield: vi.fn().mockResolvedValue({ used: true, balanceAfter: 0 }) } as any;
+    const streaksService = {
+      getStreaks: vi.fn().mockResolvedValue(ok({ currentStreak: 5, longestStreak: 5, totalSessions: 5 })),
+      getRecentCompletedDates: vi.fn().mockResolvedValue([todayStr, twoDaysAgoStr]),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      streaksService,
+      dispatcher,
+      shieldsService,
+    );
+
+    await service.completeSession("u1", 1, 5, 4);
+    await new Promise((r) => setImmediate(r));
+
+    expect(sendStreakProtectedNotification).toHaveBeenCalledTimes(1);
+    expect(sendStreakProtectedNotification).toHaveBeenCalledWith("u1", 5);
+  });
+
+  it("used=false → dispatcher not called", async () => {
+    const sendStreakProtectedNotification = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = { sendStreakProtectedNotification } as any;
+    const shieldsService = { tryUseShield: vi.fn().mockResolvedValue({ used: false, balanceAfter: null }) } as any;
+    const streaksService = {
+      getStreaks: vi.fn().mockResolvedValue(ok({ currentStreak: 5, longestStreak: 5, totalSessions: 5 })),
+      getRecentCompletedDates: vi.fn().mockResolvedValue([todayStr, twoDaysAgoStr]),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      streaksService,
+      dispatcher,
+      shieldsService,
+    );
+
+    await service.completeSession("u1", 1, 5, 4);
+    await new Promise((r) => setImmediate(r));
+
+    expect(sendStreakProtectedNotification).not.toHaveBeenCalled();
+  });
+
+  it("used=true but currentStreak=0 → dispatcher not called (days<1 guard)", async () => {
+    const sendStreakProtectedNotification = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = { sendStreakProtectedNotification } as any;
+    const shieldsService = { tryUseShield: vi.fn().mockResolvedValue({ used: true, balanceAfter: 0 }) } as any;
+    const streaksService = {
+      getStreaks: vi.fn().mockResolvedValue(ok({ currentStreak: 0, longestStreak: 3, totalSessions: 3 })),
+      getRecentCompletedDates: vi.fn().mockResolvedValue([todayStr, twoDaysAgoStr]),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      streaksService,
+      dispatcher,
+      shieldsService,
+    );
+
+    await service.completeSession("u1", 1, 5, 4);
+    await new Promise((r) => setImmediate(r));
+
+    expect(sendStreakProtectedNotification).not.toHaveBeenCalled();
+  });
+
+  it("used=true but dispatcher is null → no error thrown", async () => {
+    const shieldsService = { tryUseShield: vi.fn().mockResolvedValue({ used: true, balanceAfter: 0 }) } as any;
+    const streaksService = {
+      getStreaks: vi.fn().mockResolvedValue(ok({ currentStreak: 5, longestStreak: 5, totalSessions: 5 })),
+      getRecentCompletedDates: vi.fn().mockResolvedValue([todayStr, twoDaysAgoStr]),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      streaksService,
+      null, // dispatcher is null
+      shieldsService,
+    );
+
+    const result = await service.completeSession("u1", 1, 5, 4);
+    await new Promise((r) => setImmediate(r));
+
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/apps/server/src/features/sessions/sessions.service.ts
+++ b/apps/server/src/features/sessions/sessions.service.ts
@@ -206,6 +206,19 @@ export class SessionsService {
     const prevDate = new Date(dates[1] + "T03:00:00Z");
     const diffDays = Math.round((todayDate.getTime() - prevDate.getTime()) / 86_400_000);
     if (diffDays !== 2) return;
-    await this.shieldsService!.tryUseShield(userId, yesterdayStr);
+    const result = await this.shieldsService!.tryUseShield(userId, yesterdayStr);
+    if (result.used && this.dispatcher && this.streaksService) {
+      void this.enqueueProtectedStreakPush(userId).catch((e) => {
+        this.logger?.error?.({ err: e, userId }, "protect-streak push enqueue failed");
+      });
+    }
+  }
+
+  private async enqueueProtectedStreakPush(userId: string): Promise<void> {
+    const streaksResult = await this.streaksService!.getStreaks(userId);
+    if (streaksResult.isErr()) return;
+    const days = streaksResult.value.currentStreak;
+    if (days < 1) return;
+    await this.dispatcher!.sendStreakProtectedNotification(userId, days);
   }
 }

--- a/apps/server/src/features/social/invitations/invitations.repository.integration.test.ts
+++ b/apps/server/src/features/social/invitations/invitations.repository.integration.test.ts
@@ -175,6 +175,46 @@ describe("InvitationsRepository (integration)", () => {
           .from(invitationAcceptance).where(eq(invitationAcceptance.inviterId, "inv-cap-1"));
         expect(audit[0]!.rt).toBe("xp");
       });
+
+      it("race-safe: two concurrent shield-pref accepts at shields=0 produce exactly one shield + one XP", async () => {
+        await insertUser("inv-race");
+        await insertUser("invi-race-A", { inviteCode: "racecodea1" });
+        await insertUser("invi-race-B", { inviteCode: "racecodeb2" });
+        // Inviter prefers shield, currently has 0 shields.
+        await db.update(user)
+          .set({ inviteRewardPreference: "shield", streakShieldsAvailable: 0 })
+          .where(eq(user.id, "inv-race"));
+
+        // Fire two concurrent accepts.
+        const [r1, r2] = await Promise.allSettled([
+          repo.acceptInvitation("inv-race", "invi-race-A"),
+          repo.acceptInvitation("inv-race", "invi-race-B"),
+        ]);
+
+        // Both should resolve (no exception thrown). The repo's transaction handles concurrency.
+        // One acceptance grants the shield; the other falls back to XP via the lt() predicate.
+        const successfuls = [r1, r2].filter((r) => r.status === "fulfilled").map((r) => (r as PromiseFulfilledResult<typeof r1 extends PromiseFulfilledResult<infer V> ? V : never>).value);
+        // Exactly 2 fulfilled (the race-safe predicate handles both; no DB-level conflict on this path).
+        expect(successfuls.length).toBe(2);
+
+        const shieldCount = successfuls.filter((s) => s.rewardType === "shield").length;
+        const xpCount = successfuls.filter((s) => s.rewardType === "xp").length;
+        expect(shieldCount).toBe(1);
+        expect(xpCount).toBe(1);
+
+        // Verify inviter state: exactly 1 shield (cap respected), exactly 100 XP (the fallback).
+        const inviter = await db.select({ xp: user.totalXp, shields: user.streakShieldsAvailable })
+          .from(user).where(eq(user.id, "inv-race"));
+        expect(inviter[0]!.shields).toBe(MAX_STREAK_SHIELDS);
+        expect(inviter[0]!.xp).toBe(100);
+
+        // Audit rows reflect actual delivered rewards.
+        const audit = await db.select({ rt: invitationAcceptance.rewardType })
+          .from(invitationAcceptance).where(eq(invitationAcceptance.inviterId, "inv-race"));
+        expect(audit.length).toBe(2);
+        const rts = audit.map((a) => a.rt).sort();
+        expect(rts).toEqual(["shield", "xp"]);
+      });
     });
 
     it("does not partially commit when friendship insert fails due to duplicate (atomicity)", async () => {

--- a/apps/server/src/features/social/invitations/invitations.repository.integration.test.ts
+++ b/apps/server/src/features/social/invitations/invitations.repository.integration.test.ts
@@ -10,6 +10,7 @@ import { user } from "@pruvi/db/schema/auth";
 import { invitationAcceptance } from "@pruvi/db/schema/invitation-acceptance";
 import { friendship } from "@pruvi/db/schema/friendship";
 import { InvitationsRepository } from "./invitations.repository";
+import { MAX_STREAK_SHIELDS } from "@pruvi/shared";
 
 describe("InvitationsRepository (integration)", () => {
   const db = getTestDb();
@@ -125,6 +126,55 @@ describe("InvitationsRepository (integration)", () => {
       expect(friendships).toHaveLength(1);
       expect(friendships[0]?.status).toBe("accepted");
       expect(friendships[0]?.requesterId).toBe("inviter-3");
+    });
+
+    describe("acceptInvitation reward semantics (Phase 2E.6)", () => {
+      it("preference=xp → +100 XP, reward_type=xp", async () => {
+        await insertUser("inv-xp-1");
+        await insertUser("invi-xp-1");
+        // Default preference is 'xp'.
+        const result = await repo.acceptInvitation("inv-xp-1", "invi-xp-1");
+        expect(result).toEqual({ rewardType: "xp", xpAwarded: 100, shieldGranted: false });
+        const inviter = await db.select({ xp: user.totalXp, shields: user.streakShieldsAvailable })
+          .from(user).where(eq(user.id, "inv-xp-1"));
+        expect(inviter[0]!.xp).toBe(100);
+        expect(inviter[0]!.shields).toBe(0);
+        const audit = await db.select({ rt: invitationAcceptance.rewardType })
+          .from(invitationAcceptance).where(eq(invitationAcceptance.inviterId, "inv-xp-1"));
+        expect(audit[0]!.rt).toBe("xp");
+      });
+
+      it("preference=shield + shields=0 → +1 shield, reward_type=shield", async () => {
+        await insertUser("inv-sh-1");
+        await insertUser("invi-sh-1");
+        await db.update(user).set({ inviteRewardPreference: "shield" }).where(eq(user.id, "inv-sh-1"));
+        const result = await repo.acceptInvitation("inv-sh-1", "invi-sh-1");
+        expect(result).toEqual({ rewardType: "shield", xpAwarded: 0, shieldGranted: true });
+        const inviter = await db.select({ xp: user.totalXp, shields: user.streakShieldsAvailable })
+          .from(user).where(eq(user.id, "inv-sh-1"));
+        expect(inviter[0]!.shields).toBe(1);
+        expect(inviter[0]!.xp).toBe(0);
+        const audit = await db.select({ rt: invitationAcceptance.rewardType })
+          .from(invitationAcceptance).where(eq(invitationAcceptance.inviterId, "inv-sh-1"));
+        expect(audit[0]!.rt).toBe("shield");
+      });
+
+      it("preference=shield + shields already at MAX → falls back to XP, reward_type=xp", async () => {
+        await insertUser("inv-cap-1");
+        await insertUser("invi-cap-1");
+        await db.update(user)
+          .set({ inviteRewardPreference: "shield", streakShieldsAvailable: MAX_STREAK_SHIELDS })
+          .where(eq(user.id, "inv-cap-1"));
+        const result = await repo.acceptInvitation("inv-cap-1", "invi-cap-1");
+        expect(result).toEqual({ rewardType: "xp", xpAwarded: 100, shieldGranted: false });
+        const inviter = await db.select({ xp: user.totalXp, shields: user.streakShieldsAvailable })
+          .from(user).where(eq(user.id, "inv-cap-1"));
+        expect(inviter[0]!.shields).toBe(MAX_STREAK_SHIELDS); // unchanged
+        expect(inviter[0]!.xp).toBe(100);
+        const audit = await db.select({ rt: invitationAcceptance.rewardType })
+          .from(invitationAcceptance).where(eq(invitationAcceptance.inviterId, "inv-cap-1"));
+        expect(audit[0]!.rt).toBe("xp");
+      });
     });
 
     it("does not partially commit when friendship insert fails due to duplicate (atomicity)", async () => {

--- a/apps/server/src/features/social/invitations/invitations.repository.ts
+++ b/apps/server/src/features/social/invitations/invitations.repository.ts
@@ -1,9 +1,10 @@
-import { eq, sql } from "drizzle-orm";
+import { and, eq, lt, sql } from "drizzle-orm";
 import type { db as DbClient } from "@pruvi/db";
 import { user } from "@pruvi/db/schema/auth";
 import { invitationAcceptance } from "@pruvi/db/schema/invitation-acceptance";
 import { friendship } from "@pruvi/db/schema/friendship";
 import { generateInviteCode } from "../invite-codes/generator";
+import { MAX_STREAK_SHIELDS } from "@pruvi/shared";
 
 type Db = typeof DbClient;
 
@@ -53,21 +54,51 @@ export class InvitationsRepository {
     return rows.length > 0;
   }
 
-  /** Atomic: record acceptance + +100 XP to inviter + upsert accepted friendship. */
-  async acceptInvitation(inviterId: string, inviteeId: string): Promise<void> {
-    await this.db.transaction(async (tx) => {
-      await tx.insert(invitationAcceptance).values({ inviterId, inviteeId });
-      await tx
-        .update(user)
-        .set({ totalXp: sql`${user.totalXp} + 100` })
-        .where(eq(user.id, inviterId));
-      // Friendship: pair-ordered to fit UNIQUE LEAST/GREATEST index.
+  /** Atomic: record acceptance + reward (XP or shield) to inviter + upsert accepted friendship. */
+  async acceptInvitation(
+    inviterId: string,
+    inviteeId: string,
+  ): Promise<{ rewardType: "xp" | "shield"; xpAwarded: number; shieldGranted: boolean }> {
+    return await this.db.transaction(async (tx) => {
+      // 1. Read inviter preference.
+      const inviter = await tx
+        .select({ pref: user.inviteRewardPreference })
+        .from(user)
+        .where(eq(user.id, inviterId))
+        .limit(1);
+      const pref = inviter[0]?.pref ?? "xp";
+
+      // 2. Attempt shield grant FIRST when preferred. Race-safe via predicate-in-WHERE.
+      let actualReward: "xp" | "shield" = "xp";
+      if (pref === "shield") {
+        const updated = await tx
+          .update(user)
+          .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} + 1` })
+          .where(and(eq(user.id, inviterId), lt(user.streakShieldsAvailable, MAX_STREAK_SHIELDS)))
+          .returning({ id: user.id });
+        if (updated.length > 0) actualReward = "shield";
+      }
+
+      // 3. XP path (either preferred or fell back from shield-cap).
+      if (actualReward === "xp") {
+        await tx
+          .update(user)
+          .set({ totalXp: sql`${user.totalXp} + 100` })
+          .where(eq(user.id, inviterId));
+      }
+
+      // 4. Audit row with the TRUTH (post-fallback).
+      await tx.insert(invitationAcceptance).values({ inviterId, inviteeId, rewardType: actualReward });
+
+      // 5. Friendship (unchanged).
       await tx.insert(friendship).values({
         requesterId: inviterId,
         recipientId: inviteeId,
         status: "accepted",
         acceptedAt: new Date(),
       });
+
+      return { rewardType: actualReward, xpAwarded: actualReward === "xp" ? 100 : 0, shieldGranted: actualReward === "shield" };
     });
   }
 }

--- a/apps/server/src/features/social/invitations/invitations.route.ts
+++ b/apps/server/src/features/social/invitations/invitations.route.ts
@@ -6,6 +6,16 @@ import { unwrapResult } from "../../../types";
 import { InvitationsRepository } from "./invitations.repository";
 import { InvitationsService } from "./invitations.service";
 
+const AcceptInvitationResponseSchema = z.object({
+  inviter: z.object({ name: z.string(), username: z.string().nullable() }),
+  reward: z.object({
+    type: z.enum(["xp", "shield"]),
+    xpAwarded: z.number().int(),
+    shieldGranted: z.boolean(),
+  }),
+  friendshipCreated: z.literal(true),
+});
+
 const repo = new InvitationsRepository(db);
 const service = new InvitationsService(repo);
 
@@ -30,7 +40,10 @@ export const invitationsRoutes: FastifyPluginAsyncZod = async (fastify) => {
     "/invitations/accept",
     {
       preHandler: [fastify.authenticate],
-      schema: { body: AcceptInvitationBodySchema },
+      schema: {
+        body: AcceptInvitationBodySchema,
+        response: { 200: z.object({ success: z.literal(true), data: AcceptInvitationResponseSchema }) },
+      },
     },
     async (request) => {
       const { code } = request.body;

--- a/apps/server/src/features/social/invitations/invitations.service.test.ts
+++ b/apps/server/src/features/social/invitations/invitations.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { InvitationsService } from "./invitations.service";
 import type { InvitationsRepository } from "./invitations.repository";
 import { NotFoundError, ValidationError } from "../../../utils/errors";

--- a/apps/server/src/features/social/invitations/invitations.service.test.ts
+++ b/apps/server/src/features/social/invitations/invitations.service.test.ts
@@ -8,7 +8,7 @@ function makeRepo(overrides?: Partial<InvitationsRepository>): InvitationsReposi
     ensureInviteCode: vi.fn().mockResolvedValue("abc12345"),
     findInviterByCode: vi.fn().mockResolvedValue(null),
     hasAccepted: vi.fn().mockResolvedValue(false),
-    acceptInvitation: vi.fn().mockResolvedValue(undefined),
+    acceptInvitation: vi.fn().mockResolvedValue({ rewardType: "xp", xpAwarded: 100, shieldGranted: false }),
     ...overrides,
   } as unknown as InvitationsRepository;
 }
@@ -94,7 +94,7 @@ describe("InvitationsService", () => {
           username: "bob",
         }),
         hasAccepted: vi.fn().mockResolvedValue(false),
-        acceptInvitation: vi.fn().mockResolvedValue(undefined),
+        acceptInvitation: vi.fn().mockResolvedValue({ rewardType: "xp", xpAwarded: 100, shieldGranted: false }),
       });
       const service = new InvitationsService(repo);
 
@@ -102,10 +102,33 @@ describe("InvitationsService", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.xpAwarded).toBe(100);
+        expect(result.value.reward.xpAwarded).toBe(100);
+        expect(result.value.reward).toEqual({ type: "xp", xpAwarded: 100, shieldGranted: false });
         expect(result.value.friendshipCreated).toBe(true);
         expect(result.value.inviter.name).toBe("Bob");
         expect(result.value.inviter.username).toBe("bob");
+      }
+    });
+
+    it("returns shield reward shape when repo grants a shield", async () => {
+      const repo = makeRepo({
+        findInviterByCode: vi.fn().mockResolvedValue({
+          id: "inviter-id",
+          name: "Bob",
+          username: "bob",
+        }),
+        hasAccepted: vi.fn().mockResolvedValue(false),
+        acceptInvitation: vi.fn().mockResolvedValue({ rewardType: "shield", xpAwarded: 0, shieldGranted: true }),
+      });
+      const service = new InvitationsService(repo);
+
+      const result = await service.acceptInvitation("abc12345", "user-2");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.reward.type).toBe("shield");
+        expect(result.value.reward).toEqual({ type: "shield", xpAwarded: 0, shieldGranted: true });
+        expect(result.value.friendshipCreated).toBe(true);
       }
     });
 

--- a/apps/server/src/features/social/invitations/invitations.service.ts
+++ b/apps/server/src/features/social/invitations/invitations.service.ts
@@ -22,7 +22,7 @@ export class InvitationsService {
     Result<
       {
         inviter: { name: string; username: string | null };
-        xpAwarded: number;
+        reward: { type: "xp" | "shield"; xpAwarded: number; shieldGranted: boolean };
         friendshipCreated: true;
       },
       AppError
@@ -35,7 +35,12 @@ export class InvitationsService {
     if (await this.repo.hasAccepted(userId))
       return err(new ValidationError("You have already accepted an invitation"));
     try {
-      await this.repo.acceptInvitation(inviter.id, userId);
+      const reward = await this.repo.acceptInvitation(inviter.id, userId);
+      return ok({
+        inviter: { name: inviter.name, username: inviter.username },
+        reward: { type: reward.rewardType, xpAwarded: reward.xpAwarded, shieldGranted: reward.shieldGranted },
+        friendshipCreated: true as const,
+      });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       if (
@@ -46,10 +51,5 @@ export class InvitationsService {
       }
       throw e;
     }
-    return ok({
-      inviter: { name: inviter.name, username: inviter.username },
-      xpAwarded: 100,
-      friendshipCreated: true as const,
-    });
   }
 }

--- a/apps/server/src/features/users/users.repository.ts
+++ b/apps/server/src/features/users/users.repository.ts
@@ -47,6 +47,15 @@ export class UsersRepository {
     return row;
   }
 
+  async updateInviteRewardPreference(userId: string, preference: "xp" | "shield") {
+    const [row] = await this.db
+      .update(user)
+      .set({ inviteRewardPreference: preference })
+      .where(eq(user.id, userId))
+      .returning({ preference: user.inviteRewardPreference });
+    return row;
+  }
+
   async deleteUser(userId: string) {
     await this.db.delete(user).where(eq(user.id, userId));
   }

--- a/apps/server/src/features/users/users.route.ts
+++ b/apps/server/src/features/users/users.route.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
-import { UpdateBasicProfileBodySchema, UpdateProfileBodySchema } from "@pruvi/shared";
+import { UpdateBasicProfileBodySchema, UpdateProfileBodySchema, InviteRewardPreferenceBodySchema, InviteRewardPreferenceResponseSchema } from "@pruvi/shared";
+import { z } from "zod";
 import { db } from "@pruvi/db";
 import { UsersRepository } from "./users.repository";
 import { UsersService } from "./users.service";
@@ -35,6 +36,23 @@ export const usersRoutes: FastifyPluginAsyncZod = async (fastify) => {
       );
       return unwrapResult(result);
     }
+  );
+
+  // PATCH /users/me/invite-reward-preference — set invite reward preference
+  fastify.patch(
+    "/users/me/invite-reward-preference",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        body: InviteRewardPreferenceBodySchema,
+        response: { 200: z.object({ success: z.literal(true), data: InviteRewardPreferenceResponseSchema }) },
+      },
+    },
+    async (request) => {
+      const { preference } = request.body;
+      const result = await service.updateInviteRewardPreference(request.userId, preference);
+      return unwrapResult(result);
+    },
   );
 
   fastify.delete(

--- a/apps/server/src/features/users/users.service.test.ts
+++ b/apps/server/src/features/users/users.service.test.ts
@@ -16,11 +16,13 @@ function makeMockRepo() {
     updateProfile: vi.fn(),
     updateUsername: vi.fn(),
     deleteUser: vi.fn(),
+    updateInviteRewardPreference: vi.fn(),
   } as unknown as UsersRepository & {
     findById: ReturnType<typeof vi.fn>;
     updateProfile: ReturnType<typeof vi.fn>;
     updateUsername: ReturnType<typeof vi.fn>;
     deleteUser: ReturnType<typeof vi.fn>;
+    updateInviteRewardPreference: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -85,6 +87,27 @@ describe("UsersService", () => {
     it("re-throws unexpected DB errors", async () => {
       repo.updateUsername.mockRejectedValue(new Error("connection reset"));
       await expect(service.updateUsername(USER_ID, "test")).rejects.toThrow("connection reset");
+    });
+  });
+
+  describe("updateInviteRewardPreference", () => {
+    it("preference='shield' → returns ok({ preference: 'shield' })", async () => {
+      const repo = makeMockRepo();
+      (repo.updateInviteRewardPreference as ReturnType<typeof vi.fn>).mockResolvedValue({ preference: "shield" });
+      const service = new UsersService(repo);
+      const result = await service.updateInviteRewardPreference("u1", "shield");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual({ preference: "shield" });
+      expect(repo.updateInviteRewardPreference).toHaveBeenCalledWith("u1", "shield");
+    });
+
+    it("preference='xp' → returns ok({ preference: 'xp' })", async () => {
+      const repo = makeMockRepo();
+      (repo.updateInviteRewardPreference as ReturnType<typeof vi.fn>).mockResolvedValue({ preference: "xp" });
+      const service = new UsersService(repo);
+      const result = await service.updateInviteRewardPreference("u1", "xp");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual({ preference: "xp" });
     });
   });
 

--- a/apps/server/src/features/users/users.service.ts
+++ b/apps/server/src/features/users/users.service.ts
@@ -49,6 +49,17 @@ export class UsersService {
     }
   }
 
+  async updateInviteRewardPreference(
+    userId: string,
+    preference: "xp" | "shield"
+  ): Promise<Result<{ preference: "xp" | "shield" }, AppError>> {
+    const row = await this.repo.updateInviteRewardPreference(userId, preference);
+    if (!row) {
+      return err(new NotFoundError("User not found"));
+    }
+    return ok({ preference: row.preference as "xp" | "shield" });
+  }
+
   async deleteAccount(userId: string): Promise<Result<true, AppError>> {
     const existing = await this.repo.findById(userId);
     if (!existing) {

--- a/docs/superpowers/plans/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push.md
@@ -1,0 +1,483 @@
+# Phase 2E.6 — Referral Shield Reward + Protect-Streak Push Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Gate C (Opus 4.7) after each task. Final Gate D before PR.
+
+**Goal:** Two small features tying off the shield mechanic from 2E.2 — (1) honor product spec's "+100 XP **or** 1 escudo de streak" by adding an inviter-side preference; (2) send "Seu escudo protegeu seu streak!" push when auto-protect fires.
+
+**Architecture:** Two new columns (`user.invite_reward_preference`, `invitation_acceptance.reward_type`). One new endpoint (`PATCH /users/me/invite-reward-preference`). Repository TX reordered to make the audit row truthful when the shield-cap fallback kicks in. New `Dispatcher.sendStreakProtectedNotification` method (sibling to existing `sendAchievementNotification`). `SessionsService.maybeProtectMissedDay` now inspects `tryUseShield`'s return value and conditionally dispatches the push.
+
+**Tech Stack:** Drizzle ORM, Fastify 5, BullMQ, neverthrow Result, real Postgres for integration tests.
+
+**Authoritative spec:** `docs/superpowers/specs/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push-design.md` (v2 post Gate A).
+
+---
+
+## Task 1 — DB migration + schema + shared zod schemas
+
+**Files:**
+- Modify: `packages/db/src/schema/auth.ts` (add `inviteRewardPreference` column to `user`)
+- Modify: `packages/db/src/schema/invitation-acceptance.ts` (add `rewardType` column)
+- Create: `packages/db/src/migrations/0011_<generated>.sql`
+- Modify: `packages/db/src/migrations/meta/_journal.json` + `0011_snapshot.json`
+- Modify: `packages/shared/src/users.ts` (or similar — find the file that already exports user-related schemas)
+- Modify: `apps/server/src/test/db-helpers.ts` — no change needed; both tables already in TRUNCATE list.
+
+- [ ] **Step 1.1: Add `inviteRewardPreference` to `user` schema**
+
+In `packages/db/src/schema/auth.ts`, alongside the existing `streakRemindersEnabled` / `achievementNotificationsEnabled` lines, add:
+
+```ts
+inviteRewardPreference: text("invite_reward_preference", { enum: ["xp", "shield"] }).notNull().default("xp"),
+```
+
+Place it near the other invite-related fields (after `inviteCode`).
+
+- [ ] **Step 1.2: Add `rewardType` to `invitation_acceptance` schema**
+
+First read `packages/db/src/schema/invitation-acceptance.ts` to confirm column ordering. Add:
+
+```ts
+rewardType: text("reward_type", { enum: ["xp", "shield"] }).notNull().default("xp"),
+```
+
+- [ ] **Step 1.3: Generate migration**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi && pnpm -F db db:generate
+```
+
+Verify the generated `0011_*.sql` contains exactly two `ALTER TABLE ... ADD COLUMN` statements with `NOT NULL DEFAULT 'xp'`. No CHECK constraint expected (Drizzle limitation, accepted). If unrelated diffs appear, STOP and report BLOCKED.
+
+- [ ] **Step 1.4: Add shared Zod schema for preference**
+
+Find where existing user PATCH schemas live (likely `packages/shared/src/users.ts`). Add:
+
+```ts
+export const InviteRewardPreferenceBodySchema = z.object({
+  preference: z.enum(["xp", "shield"]),
+});
+export type InviteRewardPreferenceBody = z.infer<typeof InviteRewardPreferenceBodySchema>;
+
+export const InviteRewardPreferenceResponseSchema = z.object({
+  preference: z.enum(["xp", "shield"]),
+});
+export type InviteRewardPreferenceResponse = z.infer<typeof InviteRewardPreferenceResponseSchema>;
+```
+
+If `users.ts` doesn't exist or is sparse, place them alongside other invite/user schemas — verify the existing pattern.
+
+- [ ] **Step 1.5: Run + commit**
+
+```bash
+cd packages/shared && bun test
+cd /Users/cesarcamillo/dev/pruvi/apps/server && bun test src/features/social/
+```
+Expected: all green (existing tests).
+
+```bash
+git add packages/db/src/schema/auth.ts packages/db/src/schema/invitation-acceptance.ts packages/db/src/migrations/ packages/shared/src/
+git commit -m "feat(db,shared): add invite_reward_preference + invitation_acceptance.reward_type columns + zod schemas"
+```
+
+---
+
+## Task 2 — Repository TX reorder (race-safe shield grant + truthful audit row)
+
+**Files:**
+- Modify: `apps/server/src/features/social/invitations/invitations.repository.ts`
+- Modify: `apps/server/src/features/social/invitations/invitations.repository.integration.test.ts`
+
+- [ ] **Step 2.1: Reorder the `acceptInvitation` TX**
+
+Per spec v2 §5.1. Replace the existing `acceptInvitation` method with the new shape:
+
+```ts
+async acceptInvitation(inviterId: string, inviteeId: string): Promise<{ rewardType: "xp" | "shield"; xpAwarded: number; shieldGranted: boolean }> {
+  return await this.db.transaction(async (tx) => {
+    // 1. Read inviter preference.
+    const inviter = await tx
+      .select({ pref: user.inviteRewardPreference })
+      .from(user)
+      .where(eq(user.id, inviterId))
+      .limit(1);
+    const pref = inviter[0]?.pref ?? "xp";
+
+    // 2. Attempt shield grant FIRST when preferred. Race-safe via predicate-in-WHERE.
+    let actualReward: "xp" | "shield" = "xp";
+    if (pref === "shield") {
+      const updated = await tx
+        .update(user)
+        .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} + 1` })
+        .where(and(eq(user.id, inviterId), lt(user.streakShieldsAvailable, MAX_STREAK_SHIELDS)))
+        .returning({ id: user.id });
+      if (updated.length > 0) actualReward = "shield";
+    }
+
+    // 3. XP path (either preferred or fell back from shield-cap).
+    if (actualReward === "xp") {
+      await tx
+        .update(user)
+        .set({ totalXp: sql`${user.totalXp} + 100` })
+        .where(eq(user.id, inviterId));
+    }
+
+    // 4. Audit row with the TRUTH (post-fallback).
+    await tx.insert(invitationAcceptance).values({ inviterId, inviteeId, rewardType: actualReward });
+
+    // 5. Friendship (unchanged).
+    await tx.insert(friendship).values({ requesterId: inviterId, recipientId: inviteeId, status: "accepted", acceptedAt: new Date() });
+
+    return { rewardType: actualReward, xpAwarded: actualReward === "xp" ? 100 : 0, shieldGranted: actualReward === "shield" };
+  });
+}
+```
+
+Imports to add: `and`, `lt` from `drizzle-orm`; `MAX_STREAK_SHIELDS` from `@pruvi/shared`.
+
+- [ ] **Step 2.2: Update integration tests**
+
+Read the existing `invitations.repository.integration.test.ts` to see the test seed pattern. Append (or update existing) tests:
+
+```ts
+describe("acceptInvitation reward semantics (Phase 2E.6)", () => {
+  it("preference=xp → +100 XP, reward_type=xp", async () => {
+    await insertUser("inv-xp-1");
+    await insertUser("invi-xp-1");
+    // Default preference is 'xp'.
+    const result = await repo.acceptInvitation("inv-xp-1", "invi-xp-1");
+    expect(result).toEqual({ rewardType: "xp", xpAwarded: 100, shieldGranted: false });
+    const inviter = await db.select({ xp: user.totalXp, shields: user.streakShieldsAvailable })
+      .from(user).where(eq(user.id, "inv-xp-1"));
+    expect(inviter[0]!.xp).toBe(100);
+    expect(inviter[0]!.shields).toBe(0);
+    const audit = await db.select({ rt: invitationAcceptance.rewardType })
+      .from(invitationAcceptance).where(eq(invitationAcceptance.inviterId, "inv-xp-1"));
+    expect(audit[0]!.rt).toBe("xp");
+  });
+
+  it("preference=shield + shields=0 → +1 shield, reward_type=shield", async () => {
+    await insertUser("inv-sh-1");
+    await insertUser("invi-sh-1");
+    await db.update(user).set({ inviteRewardPreference: "shield" }).where(eq(user.id, "inv-sh-1"));
+    const result = await repo.acceptInvitation("inv-sh-1", "invi-sh-1");
+    expect(result).toEqual({ rewardType: "shield", xpAwarded: 0, shieldGranted: true });
+    const inviter = await db.select({ xp: user.totalXp, shields: user.streakShieldsAvailable })
+      .from(user).where(eq(user.id, "inv-sh-1"));
+    expect(inviter[0]!.shields).toBe(1);
+    expect(inviter[0]!.xp).toBe(0);
+    const audit = await db.select({ rt: invitationAcceptance.rewardType })
+      .from(invitationAcceptance).where(eq(invitationAcceptance.inviterId, "inv-sh-1"));
+    expect(audit[0]!.rt).toBe("shield");
+  });
+
+  it("preference=shield + shields already at MAX → falls back to XP, reward_type=xp", async () => {
+    await insertUser("inv-cap-1");
+    await insertUser("invi-cap-1");
+    await db.update(user)
+      .set({ inviteRewardPreference: "shield", streakShieldsAvailable: 1 })
+      .where(eq(user.id, "inv-cap-1"));
+    const result = await repo.acceptInvitation("inv-cap-1", "invi-cap-1");
+    expect(result).toEqual({ rewardType: "xp", xpAwarded: 100, shieldGranted: false });
+    const inviter = await db.select({ xp: user.totalXp, shields: user.streakShieldsAvailable })
+      .from(user).where(eq(user.id, "inv-cap-1"));
+    expect(inviter[0]!.shields).toBe(1); // unchanged
+    expect(inviter[0]!.xp).toBe(100);
+    const audit = await db.select({ rt: invitationAcceptance.rewardType })
+      .from(invitationAcceptance).where(eq(invitationAcceptance.inviterId, "inv-cap-1"));
+    expect(audit[0]!.rt).toBe("xp");
+  });
+});
+```
+
+Imports the test file needs: `user`, `invitationAcceptance` from the schema; `eq` from `drizzle-orm`; `MAX_STREAK_SHIELDS` already inferred via the data.
+
+- [ ] **Step 2.3: Run + commit**
+
+```bash
+cd apps/server && bun test src/features/social/invitations/
+```
+
+Expected: existing tests still pass (the existing "default behavior = XP" test should still match because default `preference` is `"xp"`); 3 new tests pass.
+
+```bash
+git add apps/server/src/features/social/invitations/
+git commit -m "feat(invitations): race-safe shield reward with truthful audit row (gate a B4 fix)"
+```
+
+---
+
+## Task 3 — Service-layer + route for preference + accept-response shape change
+
+**Files:**
+- Modify: `apps/server/src/features/social/invitations/invitations.service.ts`
+- Modify: `apps/server/src/features/social/invitations/invitations.service.test.ts`
+- Modify: `apps/server/src/features/social/invitations/invitations.route.ts` (response shape)
+- Modify: `apps/server/src/features/users/users.route.ts` (add PATCH endpoint)
+- Modify: `apps/server/src/features/users/users.service.ts` and `users.repository.ts` if needed
+
+- [ ] **Step 3.1: Update `InvitationsService.acceptInvitation`**
+
+Replace the existing implementation (line 18–55 of `invitations.service.ts`) to capture the repo's return value:
+
+```ts
+async acceptInvitation(code: string, userId: string): Promise<Result<{
+  inviter: { name: string; username: string | null };
+  reward: { type: "xp" | "shield"; xpAwarded: number; shieldGranted: boolean };
+  friendshipCreated: true;
+}, AppError>> {
+  const inviter = await this.repo.findInviterByCode(code);
+  if (!inviter) return err(new NotFoundError("Invite code not found"));
+  if (inviter.id === userId) return err(new ValidationError("Cannot accept your own invite"));
+  if (await this.repo.hasAccepted(userId)) return err(new ValidationError("You have already accepted an invitation"));
+  try {
+    const reward = await this.repo.acceptInvitation(inviter.id, userId);
+    return ok({
+      inviter: { name: inviter.name, username: inviter.username },
+      reward: { type: reward.rewardType, xpAwarded: reward.xpAwarded, shieldGranted: reward.shieldGranted },
+      friendshipCreated: true as const,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("friendship_pair_idx") || msg.includes("invitation_acceptance")) {
+      return err(new ValidationError("Invitation already processed"));
+    }
+    throw e;
+  }
+}
+```
+
+- [ ] **Step 3.2: Update `InvitationsService` tests**
+
+In `invitations.service.test.ts`, update the existing accept-invitation test mocks to return the new shape `{ rewardType, xpAwarded, shieldGranted }` from `repo.acceptInvitation` and assert the new `reward` object on the response. Add a new test for the shield-reward path: mock the repo to return `{ rewardType: "shield", xpAwarded: 0, shieldGranted: true }` and assert the response carries `reward.type === "shield"`.
+
+- [ ] **Step 3.3: Update accept-invitation route**
+
+In `invitations.route.ts`, the response schema currently looks like `{ inviter, xpAwarded, friendshipCreated }`. Update the Zod response schema to the new shape:
+
+```ts
+const AcceptInvitationResponseSchema = z.object({
+  inviter: z.object({ name: z.string(), username: z.string().nullable() }),
+  reward: z.object({
+    type: z.enum(["xp", "shield"]),
+    xpAwarded: z.number().int(),
+    shieldGranted: z.boolean(),
+  }),
+  friendshipCreated: z.literal(true),
+});
+```
+
+Apply it to the route definition. The handler just returns `unwrapResult(...)`.
+
+- [ ] **Step 3.4: Add `PATCH /users/me/invite-reward-preference` route**
+
+First read `apps/server/src/features/users/users.route.ts` to find the existing PATCH pattern. Then add a new endpoint:
+
+```ts
+fastify.patch(
+  "/users/me/invite-reward-preference",
+  {
+    preHandler: [fastify.authenticate],
+    schema: {
+      body: InviteRewardPreferenceBodySchema,
+      response: { 200: z.object({ success: z.literal(true), data: InviteRewardPreferenceResponseSchema }) },
+    },
+  },
+  async (request) => {
+    const { preference } = request.body;
+    const result = await service.updateInviteRewardPreference(request.userId, preference);
+    return successResponse(unwrapResult(result).data);
+  },
+);
+```
+
+Add the corresponding service method `updateInviteRewardPreference(userId, preference)` and repository update method. Style: match `UsersService`'s existing PATCH methods.
+
+- [ ] **Step 3.5: Run + commit**
+
+```bash
+cd apps/server && bun test src/features/social/ src/features/users/
+```
+
+```bash
+git add apps/server/src/features/social/invitations/ apps/server/src/features/users/
+git commit -m "feat(invitations,users): accept response includes reward struct; patch invite-reward-preference endpoint"
+```
+
+---
+
+## Task 4 — Dispatcher `sendStreakProtectedNotification` + template + sessions hook
+
+**Files:**
+- Modify: `apps/server/src/features/notifications/templates.ts`
+- Modify: `apps/server/src/features/notifications/templates.test.ts`
+- Modify: `apps/server/src/features/notifications/dispatcher.ts`
+- Modify: `apps/server/src/features/notifications/dispatcher.test.ts`
+- Modify: `apps/server/src/features/sessions/sessions.service.ts`
+- Modify: `apps/server/src/features/sessions/sessions.service.test.ts`
+
+- [ ] **Step 4.1: Add the template**
+
+In `templates.ts`, append:
+
+```ts
+export function streakProtected(days: number): PushPayload {
+  return {
+    title: "Seu escudo protegeu seu streak!",
+    body: `Seu streak de ${days} dias foi salvo. Continue amanhã 💛`,
+  };
+}
+```
+
+Add a test in `templates.test.ts`:
+
+```ts
+it("streakProtected returns pt-BR copy with the day count", () => {
+  const p = streakProtected(7);
+  expect(p.title).toBe("Seu escudo protegeu seu streak!");
+  expect(p.body).toContain("7 dias");
+});
+```
+
+- [ ] **Step 4.2: Add `Dispatcher.sendStreakProtectedNotification`**
+
+In `dispatcher.ts`, alongside `sendOvertakenNotification`, add:
+
+```ts
+async sendStreakProtectedNotification(userId: string, streakDays: number): Promise<void> {
+  if (streakDays < 1) return;
+
+  const prefs = await this.deps.prefsRepo.get(userId);
+  // Reuse streakRemindersEnabled — same opt-out semantics as streak reminders.
+  if (!prefs?.streakRemindersEnabled) return;
+
+  const tokens = await this.deps.tokensService.listTokensForUser(userId);
+  if (tokens.length === 0) return;
+
+  const payload = streakProtected(streakDays);
+  for (let i = 0; i < tokens.length; i += EXPO_BATCH_SIZE) {
+    const chunk = tokens.slice(i, i + EXPO_BATCH_SIZE);
+    await this.deps.sendQueue.add("send", {
+      tokens: chunk,
+      title: payload.title,
+      body: payload.body,
+      data: { kind: "streak_protected" },
+    });
+  }
+}
+```
+
+Import `streakProtected` from `./templates`.
+
+- [ ] **Step 4.3: Test the dispatcher method**
+
+In `dispatcher.test.ts`, follow the pattern of the existing `sendOvertakenNotification` test. Add cases:
+
+1. Happy path: prefs.streakRemindersEnabled=true, tokens present → sendQueue.add called with the right payload and data.kind="streak_protected".
+2. Opt-out: prefs.streakRemindersEnabled=false → sendQueue.add NOT called.
+3. No tokens: tokens=[] → sendQueue.add NOT called.
+4. `days < 1`: returns immediately, no prefs/tokens calls (verify by inspecting mock).
+
+- [ ] **Step 4.4: Update `SessionsService.maybeProtectMissedDay`**
+
+Replace the existing line that fires-and-forgets `tryUseShield`:
+
+```ts
+// BEFORE:
+await this.shieldsService!.tryUseShield(userId, yesterdayStr);
+
+// AFTER:
+const result = await this.shieldsService!.tryUseShield(userId, yesterdayStr);
+if (result.used && this.dispatcher && this.streaksService) {
+  void this.enqueueProtectedStreakPush(userId).catch((e) => {
+    this.logger?.error?.({ err: e, userId }, "protect-streak push enqueue failed");
+  });
+}
+```
+
+Add the helper method to `SessionsService`:
+
+```ts
+private async enqueueProtectedStreakPush(userId: string): Promise<void> {
+  const streaksResult = await this.streaksService!.getStreaks(userId);
+  if (streaksResult.isErr()) return;
+  const days = streaksResult.value.currentStreak;
+  if (days < 1) return;
+  await this.dispatcher!.sendStreakProtectedNotification(userId, days);
+}
+```
+
+- [ ] **Step 4.5: Test the sessions hook**
+
+In `sessions.service.test.ts`, find the existing maybeProtect tests. Add cases:
+
+1. `tryUseShield` returns `{ used: true }` AND streaks.currentStreak > 0 → `dispatcher.sendStreakProtectedNotification` called once with the right args.
+2. `tryUseShield` returns `{ used: false }` → dispatcher NOT called.
+3. `tryUseShield` returns `{ used: true }` but `streaksService.getStreaks` returns 0 → dispatcher NOT called (days<1 guard).
+4. `tryUseShield` returns `{ used: true }` but dispatcher is null → no error thrown.
+
+- [ ] **Step 4.6: Run + commit**
+
+```bash
+cd apps/server && bun test src/features/notifications/ src/features/sessions/
+```
+
+```bash
+git add apps/server/src/features/notifications/templates.ts apps/server/src/features/notifications/templates.test.ts apps/server/src/features/notifications/dispatcher.ts apps/server/src/features/notifications/dispatcher.test.ts apps/server/src/features/sessions/sessions.service.ts apps/server/src/features/sessions/sessions.service.test.ts
+git commit -m "feat(notifications,sessions): streakProtected template + dispatcher method + sessions hook (gate a B1/B5 fix)"
+```
+
+---
+
+## Task 5 — Final typecheck, push, PR
+
+- [ ] **Step 5.1: Full repo typecheck**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi && pnpm check-types 2>&1 | grep -E "invitations|notifications|sessions|users|2e6" | head -20
+```
+
+Fix any NEW type errors in the affected files (don't worry about pre-existing errors in unrelated tests).
+
+- [ ] **Step 5.2: Test sweep**
+
+```bash
+cd /Users/cesarcamillo/dev/pruvi/apps/server && bun test src/features/social/ src/features/notifications/ src/features/sessions/ src/features/users/
+```
+
+- [ ] **Step 5.3: Push + PR**
+
+```bash
+git push -u origin feature/phase-2e6-referral-shield-and-protect-streak-push
+gh pr create --title "feat: phase 2e.6 — referral shield reward + protect-streak push" --body "$(cat <<'EOF'
+## Summary
+- Inviter can opt for "+1 escudo de streak" instead of "+100 XP" via PATCH /users/me/invite-reward-preference; default remains XP for backward compat
+- Auto-protect shield now triggers "Seu escudo protegeu seu streak!" push via existing dispatcher (reuses streakRemindersEnabled opt-out)
+- Race-safe shield grant in acceptInvitation: predicate-in-WHERE update + .returning() to confirm; falls back to XP if at MAX
+- TX order fixed so invitation_acceptance.reward_type ALWAYS reflects the delivered reward (audit-honest)
+- Two new columns (NOT NULL DEFAULT 'xp'): `user.invite_reward_preference`, `invitation_acceptance.reward_type`
+- Accept-invitation response shape changed: top-level `xpAwarded` removed; new `reward: { type, xpAwarded, shieldGranted }` object (no production clients yet)
+
+## Workflow gates
+- ✅ Gate A — spec self-review (5 blockers fixed: real Dispatcher API, existing prefs flag, service-layer wiring, TX reorder, real getStreaks API)
+- ✅ Gate B — plan self-review
+- ✅ Gate C — per-task review (Opus 4.7)
+- ✅ Gate D — final spec-coverage review
+
+## Test plan
+- [ ] Repository integration: preference=xp/shield/shield-at-cap → correct reward + audit row
+- [ ] Dispatcher unit: streak_protected enqueued only when enabled + tokens + days>=1
+- [ ] Sessions hook: tryUseShield used=true → push enqueued; used=false → no push
+- [ ] Manual: PATCH endpoint accepts xp/shield/invalid
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (post Gate B)
+
+1. **Spec coverage A1–A15:** A1/A2 → T1; A3 → T3.4; A4/A5/A6 → T2.2; A7 → T2.1 + T2.2; A8/A9 → T4.5; A10 → T4.3; A11 → T4.1; A12 → T3.1 + T3.3; A13 → T4.4 logger usage; A14 → T4.2 + T4.5; A15 → T2.1 + T2.2.
+2. **Placeholder scan:** none.
+3. **Migration safety:** both columns are NOT NULL DEFAULT 'xp' — Postgres applies default to existing rows immediately, no backfill job.
+4. **No DB CHECK constraints** — accepted Drizzle limitation; application-layer Zod enum is the guard.
+5. **Backwards-incompatible response shape:** documented in PR body as a breaking change. Justified by pre-production project status.

--- a/docs/superpowers/plans/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push.md
@@ -10,6 +10,8 @@
 
 **Authoritative spec:** `docs/superpowers/specs/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push-design.md` (v2 post Gate A).
 
+**Plan revision:** v2 post Gate B — Task 3.4 route handler returns `unwrapResult(result)` bare (no double-wrap); Task 3.3 explicitly ADDs the response schema (it doesn't exist today); Task 3.2 names line 105 of `invitations.service.test.ts` that must be updated; Task 2.2 imports and uses `MAX_STREAK_SHIELDS` constant instead of literal `1`.
+
 ---
 
 ## Task 1 — DB migration + schema + shared zod schemas
@@ -174,13 +176,13 @@ describe("acceptInvitation reward semantics (Phase 2E.6)", () => {
     await insertUser("inv-cap-1");
     await insertUser("invi-cap-1");
     await db.update(user)
-      .set({ inviteRewardPreference: "shield", streakShieldsAvailable: 1 })
+      .set({ inviteRewardPreference: "shield", streakShieldsAvailable: MAX_STREAK_SHIELDS })
       .where(eq(user.id, "inv-cap-1"));
     const result = await repo.acceptInvitation("inv-cap-1", "invi-cap-1");
     expect(result).toEqual({ rewardType: "xp", xpAwarded: 100, shieldGranted: false });
     const inviter = await db.select({ xp: user.totalXp, shields: user.streakShieldsAvailable })
       .from(user).where(eq(user.id, "inv-cap-1"));
-    expect(inviter[0]!.shields).toBe(1); // unchanged
+    expect(inviter[0]!.shields).toBe(MAX_STREAK_SHIELDS); // unchanged
     expect(inviter[0]!.xp).toBe(100);
     const audit = await db.select({ rt: invitationAcceptance.rewardType })
       .from(invitationAcceptance).where(eq(invitationAcceptance.inviterId, "inv-cap-1"));
@@ -189,7 +191,7 @@ describe("acceptInvitation reward semantics (Phase 2E.6)", () => {
 });
 ```
 
-Imports the test file needs: `user`, `invitationAcceptance` from the schema; `eq` from `drizzle-orm`; `MAX_STREAK_SHIELDS` already inferred via the data.
+Imports the test file needs: `user`, `invitationAcceptance` from the schema; `eq` from `drizzle-orm`; `MAX_STREAK_SHIELDS` from `@pruvi/shared` (use the constant, not the literal `1`, so the test stays correct if `MAX_STREAK_SHIELDS` ever changes).
 
 - [ ] **Step 2.3: Run + commit**
 
@@ -248,11 +250,15 @@ async acceptInvitation(code: string, userId: string): Promise<Result<{
 
 - [ ] **Step 3.2: Update `InvitationsService` tests**
 
-In `invitations.service.test.ts`, update the existing accept-invitation test mocks to return the new shape `{ rewardType, xpAwarded, shieldGranted }` from `repo.acceptInvitation` and assert the new `reward` object on the response. Add a new test for the shield-reward path: mock the repo to return `{ rewardType: "shield", xpAwarded: 0, shieldGranted: true }` and assert the response carries `reward.type === "shield"`.
+In `invitations.service.test.ts`, the existing accept-invitation success test (around lines 89–110) currently mocks `repo.acceptInvitation` to return `undefined` (void) and asserts `expect(result.value.xpAwarded).toBe(100)` on **line 105** (the assertion that will break after Task 3.1). Required changes:
 
-- [ ] **Step 3.3: Update accept-invitation route**
+1. Update the mock: `repo.acceptInvitation: vi.fn().mockResolvedValue({ rewardType: "xp", xpAwarded: 100, shieldGranted: false })` (was `mockResolvedValue(undefined)`).
+2. Update line 105 from `expect(result.value.xpAwarded).toBe(100)` to `expect(result.value.reward.xpAwarded).toBe(100)`. Also assert the full reward struct: `expect(result.value.reward).toEqual({ type: "xp", xpAwarded: 100, shieldGranted: false })`.
+3. ADD a new test "returns shield reward shape when repo grants a shield": mock the repo to return `{ rewardType: "shield", xpAwarded: 0, shieldGranted: true }`. Assert `result.value.reward` matches that struct and `result.value.reward.type === "shield"`.
 
-In `invitations.route.ts`, the response schema currently looks like `{ inviter, xpAwarded, friendshipCreated }`. Update the Zod response schema to the new shape:
+- [ ] **Step 3.3: Add accept-invitation response schema**
+
+`invitations.route.ts` currently has NO response schema on the `POST /invitations/accept` route — just a body schema. ADD a response schema for the new shape:
 
 ```ts
 const AcceptInvitationResponseSchema = z.object({
@@ -266,7 +272,7 @@ const AcceptInvitationResponseSchema = z.object({
 });
 ```
 
-Apply it to the route definition. The handler just returns `unwrapResult(...)`.
+Wire it into the route's `schema` block: `schema: { body: AcceptInvitationBodySchema, response: { 200: z.object({ success: z.literal(true), data: AcceptInvitationResponseSchema }) } }`. The handler stays the same shape: `return unwrapResult(result);`
 
 - [ ] **Step 3.4: Add `PATCH /users/me/invite-reward-preference` route**
 
@@ -285,10 +291,12 @@ fastify.patch(
   async (request) => {
     const { preference } = request.body;
     const result = await service.updateInviteRewardPreference(request.userId, preference);
-    return successResponse(unwrapResult(result).data);
+    return unwrapResult(result); // returns { success: true, data: { preference } }
   },
 );
 ```
+
+Matches the existing PATCH pattern in `users.route.ts` (line 25–38 of the existing file). Do NOT wrap with `successResponse(unwrapResult(result).data)` — that double-wraps the envelope.
 
 Add the corresponding service method `updateInviteRewardPreference(userId, preference)` and repository update method. Style: match `UsersService`'s existing PATCH methods.
 

--- a/docs/superpowers/specs/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push-design.md
@@ -1,6 +1,6 @@
 # Phase 2E.6 — Referral Shield Reward + Protect-Streak Push (Design Spec)
 
-**Status:** v1
+**Status:** v2 (post Gate A: real Dispatcher API, existing prefs flag, service-layer wiring, TX reorder for audit correctness, real StreaksService API)
 **Date:** 2026-05-12
 **Branch:** `feature/phase-2e6-referral-shield-and-protect-streak-push`
 **Product source:** `pruvi-freatures.md` §4 (referral reward), §5.3 (shield protection notification)
@@ -67,39 +67,37 @@ Existing rows backfill to `'xp'` (their actual historical behavior).
 
 ### 5.1 Invitation reward flow
 
-`InvitationsRepository.acceptInvitation(inviterId, inviteeId)` becomes:
+`InvitationsRepository.acceptInvitation(inviterId, inviteeId)` becomes (note the step order — the conditional UPDATE happens BEFORE the audit insert, so `reward_type` always reflects what was actually delivered):
 
 ```ts
 async acceptInvitation(inviterId: string, inviteeId: string): Promise<{ rewardType: "xp" | "shield"; xpAwarded: number; shieldGranted: boolean }> {
   return await this.db.transaction(async (tx) => {
-    // 1. Read inviter preference + current shield balance.
-    const inviter = await tx.select({
-      pref: user.inviteRewardPreference,
-      shields: user.streakShieldsAvailable,
-    }).from(user).where(eq(user.id, inviterId)).limit(1);
+    // 1. Read inviter preference.
+    const inviter = await tx.select({ pref: user.inviteRewardPreference })
+      .from(user).where(eq(user.id, inviterId)).limit(1);
     const pref = inviter[0]?.pref ?? "xp";
-    const currentShields = inviter[0]?.shields ?? 0;
 
-    // 2. Decide actual reward (shield with cap fallback).
+    // 2. Attempt shield grant FIRST if preferred (race-safe via predicate-in-WHERE).
+    //    .returning() lets us inspect whether the conditional UPDATE actually changed a row.
     let actualReward: "xp" | "shield" = "xp";
-    if (pref === "shield" && currentShields < MAX_STREAK_SHIELDS) {
-      actualReward = "shield";
+    if (pref === "shield") {
+      const updated = await tx.update(user)
+        .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} + 1` })
+        .where(and(eq(user.id, inviterId), lt(user.streakShieldsAvailable, MAX_STREAK_SHIELDS)))
+        .returning({ id: user.id });
+      if (updated.length > 0) actualReward = "shield";
+      // else: cap was already at MAX (race lost or pre-existing) — fall through to XP path.
     }
 
-    // 3. Insert acceptance with the actual reward type.
-    await tx.insert(invitationAcceptance).values({ inviterId, inviteeId, rewardType: actualReward });
-
-    // 4. Apply reward.
-    if (actualReward === "shield") {
-      // Conditional UPDATE guards against race between read-then-update.
-      await tx.update(user)
-        .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} + 1` })
-        .where(and(eq(user.id, inviterId), lt(user.streakShieldsAvailable, MAX_STREAK_SHIELDS)));
-    } else {
+    // 3. XP path (either preference="xp" OR shield-grant fell back).
+    if (actualReward === "xp") {
       await tx.update(user)
         .set({ totalXp: sql`${user.totalXp} + 100` })
         .where(eq(user.id, inviterId));
     }
+
+    // 4. NOW insert the audit row with the truthful delivered reward.
+    await tx.insert(invitationAcceptance).values({ inviterId, inviteeId, rewardType: actualReward });
 
     // 5. Friendship (unchanged).
     await tx.insert(friendship).values({ requesterId: inviterId, recipientId: inviteeId, status: "accepted", acceptedAt: new Date() });
@@ -109,18 +107,61 @@ async acceptInvitation(inviterId: string, inviteeId: string): Promise<{ rewardTy
 }
 ```
 
-`InvitationsService.acceptInvitation` returns the reward info to the route.
+`InvitationsService.acceptInvitation` MUST be updated to capture the repo's return value and propagate it into the response. Today it discards the return and hard-codes `xpAwarded: 100`:
+
+```ts
+// BEFORE (today):
+await this.repo.acceptInvitation(inviter.id, userId);
+return ok({ inviter: ..., xpAwarded: 100, friendshipCreated: true });
+
+// AFTER (this phase):
+const reward = await this.repo.acceptInvitation(inviter.id, userId);
+return ok({
+  inviter: ...,
+  reward: { type: reward.rewardType, xpAwarded: reward.xpAwarded, shieldGranted: reward.shieldGranted },
+  friendshipCreated: true,
+});
+```
 
 ### 5.2 Protect-streak push flow
 
-`SessionsService.maybeProtectMissedDay` becomes:
+**New `Dispatcher` method** (NOT a generic enqueue — the existing dispatcher follows a "one method per notification kind" pattern; see `sendAchievementNotification`, `sendOvertakenNotification`, `dispatchStreakReminder` in `dispatcher.ts`). Add:
+
+```ts
+async sendStreakProtectedNotification(userId: string, streakDays: number): Promise<void> {
+  // Defensive: only push when there's a real streak to celebrate.
+  if (streakDays < 1) return;
+
+  const prefs = await this.deps.prefsRepo.get(userId);
+  // Reuse the existing streakRemindersEnabled flag — this notification is fundamentally
+  // about streak health and shares the same user-opt-out semantics as streak reminders.
+  // No new preference column needed (Gate A B2 fix).
+  if (!prefs?.streakRemindersEnabled) return;
+
+  const tokens = await this.deps.tokensService.listTokensForUser(userId);
+  if (tokens.length === 0) return;
+
+  const payload = streakProtected(streakDays);
+  for (let i = 0; i < tokens.length; i += EXPO_BATCH_SIZE) {
+    const chunk = tokens.slice(i, i + EXPO_BATCH_SIZE);
+    await this.deps.sendQueue.add("send", {
+      tokens: chunk,
+      title: payload.title,
+      body: payload.body,
+      data: { kind: "streak_protected" },
+    });
+  }
+}
+```
+
+`SessionsService.maybeProtectMissedDay` is updated to inspect `tryUseShield`'s return value (today the result is discarded) and call the new dispatcher method when protection succeeded:
 
 ```ts
 private async maybeProtectMissedDay(userId: string): Promise<void> {
   // ... existing date-gap logic unchanged ...
   const result = await this.shieldsService!.tryUseShield(userId, yesterdayStr);
-  if (result.used) {
-    // Fire-and-forget push notification.
+  if (result.used && this.dispatcher && this.streaksService) {
+    // Fire-and-forget; do not block session completion on push delivery.
     void this.enqueueProtectedStreakPush(userId).catch((e) => {
       this.logger?.error?.({ err: e, userId }, "protect-streak push enqueue failed");
     });
@@ -128,17 +169,20 @@ private async maybeProtectMissedDay(userId: string): Promise<void> {
 }
 
 private async enqueueProtectedStreakPush(userId: string): Promise<void> {
-  if (!this.dispatcher) return;
-  const streaks = await this.streaksService!.getStreakStats(userId);
-  await this.dispatcher.enqueue(userId, "streak_protected", streakProtected(streaks.currentStreak));
+  const streaksResult = await this.streaksService!.getStreaks(userId);
+  if (streaksResult.isErr()) return;
+  const days = streaksResult.value.currentStreak;
+  if (days < 1) return;
+  await this.dispatcher!.sendStreakProtectedNotification(userId, days);
 }
 ```
 
-The `Dispatcher.enqueue(userId, kind, payload)` method already exists for other notification kinds (verify in the implementation — if signature differs, the plan will adapt). The notification kind `streak_protected` is a new value in the existing notification-kind enum and must be added to the preferences-respect filter so a user can opt out.
+Uses the existing `StreaksService.getStreaks(userId)` which returns `Result<{ currentStreak, longestStreak, totalSessions }, AppError>`. The result is unwrapped via `.isOk()`/`.value`, matching the project's neverthrow conventions.
 
 ### 5.3 Notification preferences
 
-Existing user-preference schema has per-kind opt-out flags. The plan adds `streak_protected_enabled: boolean default true` (or whatever existing pattern — verify in plan stage). If the user has opted out, the dispatcher skips the send.
+**No new preference column.** The `streakRemindersEnabled` boolean (existing on `user`, default true) gates the protect-streak push. Rationale: from the user's perspective both notifications are about streak health; collapsing them into one opt-out is the simplest UX (one switch, predictable behavior).
+
 
 ## 6. API surface
 
@@ -237,10 +281,12 @@ A6. Inviter with preference `"shield"` and shields already at MAX: an accept cal
 A7. The shield update is race-safe: two concurrent accepts on a same-inviter-preference=shield-at-shields=0 do NOT push the inviter to shields=2.
 A8. When `ShieldsService.tryUseShield` returns `{ used: true }` from the auto-protect hook in `SessionsService.maybeProtectMissedDay`, a notification of kind `"streak_protected"` is enqueued via the existing dispatcher with the user's current streak length.
 A9. When `tryUseShield` returns `{ used: false }`, no notification is enqueued.
-A10. If the user has opted out of `streak_protected` notifications (preference flag), the dispatcher skips the send (existing preference-respect mechanism).
+A10. If the user has `streakRemindersEnabled = false`, the dispatcher skips the send (the protect-streak push reuses this flag; no new preference column).
 A11. The template `streakProtected(days)` returns pt-BR strings matching §7.
 A12. The accept-invitation response includes `reward: { type, xpAwarded, shieldGranted }`. The top-level `xpAwarded` field is removed.
 A13. All errors logged via `fastify.log`/`logger.error`. No `console.error` in production paths.
+A14. The protect-streak push is suppressed when `currentStreak < 1` (defensive guard against an edge case where the shield is used but the streak computation returns 0). Tested at both the service hook and the dispatcher method.
+A15. The shield-grant in `acceptInvitation` is race-safe via predicate-in-WHERE: two concurrent accepts at `shields=0, MAX=1` produce exactly one shield (one row updated; the other falls back to XP and records `reward_type='xp'`). Audit trail reflects the actual delivered reward.
 
 ## 11. Deferred items
 

--- a/docs/superpowers/specs/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push-design.md
@@ -1,0 +1,260 @@
+# Phase 2E.6 — Referral Shield Reward + Protect-Streak Push (Design Spec)
+
+**Status:** v1
+**Date:** 2026-05-12
+**Branch:** `feature/phase-2e6-referral-shield-and-protect-streak-push`
+**Product source:** `pruvi-freatures.md` §4 (referral reward), §5.3 (shield protection notification)
+
+---
+
+## 1. Goal
+
+Wrap up two small loose ends from the shield/notification roadmap:
+
+1. **Referral shield reward**: honor the product doc's "ganha +100 XP **ou** 1 escudo de streak" by letting the inviter choose their reward type via a profile preference. Default behavior (XP) is preserved.
+2. **Protect-streak push**: when the auto-use shield protects a missed day, enqueue the notification *"Seu escudo protegeu seu streak de X dias!"* the next time the dispatcher fires.
+
+Both features build on existing infrastructure (`InvitationsRepository`, `ShieldsService.tryUseShield`, `Dispatcher`, `templates.ts`) — no new tables, just one column addition and wiring.
+
+## 2. Non-goals
+
+- **Reward-choice negotiation at accept-time.** The inviter sets the preference on their own profile; the invitee's accept call simply triggers the inviter's chosen reward. No UI on the invitee side.
+- **Retroactive reward switching.** Once an invitation is accepted, the reward is final (recorded in `invitation_acceptance.reward_type`). The inviter cannot later swap XP for a shield.
+- **Per-invite reward type.** A single user-level preference, not per-invitation. YAGNI for now.
+- **Shield-grant cap bypass.** If the inviter already has `streakShieldsAvailable >= MAX_STREAK_SHIELDS = 1`, the shield grant is silently downgraded to XP (the inviter's preference fallback). Spec §5.3 says "Máximo de 1 escudo ativo por vez — não acumula"; this respects that.
+- **Cross-feature push notification batching.** The protect-streak push is enqueued individually per shield-use event. Per-user batching is handled by the existing dispatcher.
+- **Localization beyond pt-BR.** All notification copy is Brazilian Portuguese, matching existing templates.
+
+## 3. Mechanic
+
+### 3.1 Referral shield reward
+
+- New nullable column on `user`: `invite_reward_preference text default 'xp' check (invite_reward_preference in ('xp','shield'))`.
+- New endpoint `PATCH /users/me/invite-reward-preference { preference: "xp" | "shield" }` (authenticated). Updates the column.
+- On `acceptInvitation`, the repository reads the inviter's `invite_reward_preference`:
+  - `"xp"` → existing behavior (+100 XP to inviter).
+  - `"shield"` → if `inviter.streakShieldsAvailable < MAX_STREAK_SHIELDS`, grant the shield (increment to MAX); otherwise fall back to XP. Either way, record the actual reward delivered in `invitation_acceptance.reward_type` so the audit trail is honest.
+- The `acceptInvitation` response carries `reward: { type: "xp" | "shield"; xpAwarded: number; shieldGranted: boolean }` so clients can show the right confirmation toast on the invitee side.
+
+### 3.2 Protect-streak push
+
+- The existing `ShieldsService.tryUseShield` returns `{ used: true, balanceAfter: 0 }` on successful protection. Today it's fire-and-forget from `SessionsService.maybeProtectMissedDay` with no notification follow-up.
+- When `tryUseShield` returns `used: true`, the service enqueues a notification via the existing `Dispatcher`. The push payload uses the current streak length (queried just before enqueuing).
+- The push template is new: `streakProtected(days: number) => { title: "Seu escudo protegeu seu streak!", body: "Seu streak de N dias foi salvo. Continue amanhã 💛" }`.
+- Delivery uses the existing `notifications.send` BullMQ queue (consistent with overtaken / streak-reminder notifications). The notification fires immediately — not the next day. **Rationale:** product copy says "Notificação no dia seguinte" but the shield-use happens on day N+1 (the day after the missed day), so "no dia seguinte" relative to the missed day = today, the day the protection runs. We send right away.
+
+## 4. Data model
+
+### 4.1 `user` column addition
+
+```sql
+ALTER TABLE "user" ADD COLUMN invite_reward_preference text NOT NULL DEFAULT 'xp';
+-- Drizzle text-enum at the application layer enforces ('xp','shield'); no DB CHECK due to drizzle-kit limitation.
+```
+
+Default `'xp'` preserves backwards compatibility — existing inviters keep getting XP.
+
+### 4.2 `invitation_acceptance` column addition
+
+```sql
+ALTER TABLE invitation_acceptance ADD COLUMN reward_type text NOT NULL DEFAULT 'xp';
+-- Records the actually-delivered reward (after the shield-cap fallback). Useful for analytics.
+```
+
+Existing rows backfill to `'xp'` (their actual historical behavior).
+
+## 5. Architecture
+
+### 5.1 Invitation reward flow
+
+`InvitationsRepository.acceptInvitation(inviterId, inviteeId)` becomes:
+
+```ts
+async acceptInvitation(inviterId: string, inviteeId: string): Promise<{ rewardType: "xp" | "shield"; xpAwarded: number; shieldGranted: boolean }> {
+  return await this.db.transaction(async (tx) => {
+    // 1. Read inviter preference + current shield balance.
+    const inviter = await tx.select({
+      pref: user.inviteRewardPreference,
+      shields: user.streakShieldsAvailable,
+    }).from(user).where(eq(user.id, inviterId)).limit(1);
+    const pref = inviter[0]?.pref ?? "xp";
+    const currentShields = inviter[0]?.shields ?? 0;
+
+    // 2. Decide actual reward (shield with cap fallback).
+    let actualReward: "xp" | "shield" = "xp";
+    if (pref === "shield" && currentShields < MAX_STREAK_SHIELDS) {
+      actualReward = "shield";
+    }
+
+    // 3. Insert acceptance with the actual reward type.
+    await tx.insert(invitationAcceptance).values({ inviterId, inviteeId, rewardType: actualReward });
+
+    // 4. Apply reward.
+    if (actualReward === "shield") {
+      // Conditional UPDATE guards against race between read-then-update.
+      await tx.update(user)
+        .set({ streakShieldsAvailable: sql`${user.streakShieldsAvailable} + 1` })
+        .where(and(eq(user.id, inviterId), lt(user.streakShieldsAvailable, MAX_STREAK_SHIELDS)));
+    } else {
+      await tx.update(user)
+        .set({ totalXp: sql`${user.totalXp} + 100` })
+        .where(eq(user.id, inviterId));
+    }
+
+    // 5. Friendship (unchanged).
+    await tx.insert(friendship).values({ requesterId: inviterId, recipientId: inviteeId, status: "accepted", acceptedAt: new Date() });
+
+    return { rewardType: actualReward, xpAwarded: actualReward === "xp" ? 100 : 0, shieldGranted: actualReward === "shield" };
+  });
+}
+```
+
+`InvitationsService.acceptInvitation` returns the reward info to the route.
+
+### 5.2 Protect-streak push flow
+
+`SessionsService.maybeProtectMissedDay` becomes:
+
+```ts
+private async maybeProtectMissedDay(userId: string): Promise<void> {
+  // ... existing date-gap logic unchanged ...
+  const result = await this.shieldsService!.tryUseShield(userId, yesterdayStr);
+  if (result.used) {
+    // Fire-and-forget push notification.
+    void this.enqueueProtectedStreakPush(userId).catch((e) => {
+      this.logger?.error?.({ err: e, userId }, "protect-streak push enqueue failed");
+    });
+  }
+}
+
+private async enqueueProtectedStreakPush(userId: string): Promise<void> {
+  if (!this.dispatcher) return;
+  const streaks = await this.streaksService!.getStreakStats(userId);
+  await this.dispatcher.enqueue(userId, "streak_protected", streakProtected(streaks.currentStreak));
+}
+```
+
+The `Dispatcher.enqueue(userId, kind, payload)` method already exists for other notification kinds (verify in the implementation — if signature differs, the plan will adapt). The notification kind `streak_protected` is a new value in the existing notification-kind enum and must be added to the preferences-respect filter so a user can opt out.
+
+### 5.3 Notification preferences
+
+Existing user-preference schema has per-kind opt-out flags. The plan adds `streak_protected_enabled: boolean default true` (or whatever existing pattern — verify in plan stage). If the user has opted out, the dispatcher skips the send.
+
+## 6. API surface
+
+### 6.1 `PATCH /users/me/invite-reward-preference`
+
+```ts
+InviteRewardPreferenceBodySchema = z.object({
+  preference: z.enum(["xp", "shield"]),
+});
+
+InviteRewardPreferenceResponseSchema = z.object({
+  preference: z.enum(["xp", "shield"]),
+});
+```
+
+Authenticated. Updates the user's column. Returns the new preference.
+
+### 6.2 Existing `POST /invitations/accept` response shape extended
+
+Existing response:
+```ts
+{ inviter: { name, username }, xpAwarded: number, friendshipCreated: true }
+```
+
+New response:
+```ts
+{
+  inviter: { name, username },
+  reward: { type: "xp" | "shield", xpAwarded: number, shieldGranted: boolean },
+  friendshipCreated: true,
+}
+```
+
+**Backwards compatibility:** clients still depending on the top-level `xpAwarded` field can read `reward.xpAwarded`. The old field is removed to keep the contract clean — there are no production clients yet (Phase 0 era). If we later discover real clients, we can re-add the alias.
+
+### 6.3 No new push endpoint
+
+Notifications use the existing `Dispatcher`-backed queue. No new HTTP surface for the protect-streak push.
+
+## 7. Notification template
+
+In `apps/server/src/features/notifications/templates.ts`, add:
+
+```ts
+export function streakProtected(days: number): PushPayload {
+  return {
+    title: "Seu escudo protegeu seu streak!",
+    body: `Seu streak de ${days} dias foi salvo. Continue amanhã 💛`,
+  };
+}
+```
+
+For `days === 0` or `days === 1`, the singular form is acceptable as-is — "Seu streak de 0 dias" is admittedly odd but mathematically impossible (the shield is only used when there's an active streak to protect). Defensive: if `days < 1`, the dispatcher skips. The plan must wire this guard.
+
+## 8. Migration
+
+`packages/db/src/migrations/0011_<name>.sql` (drizzle-kit-named). Two ALTER TABLE statements:
+
+```sql
+ALTER TABLE "user" ADD COLUMN "invite_reward_preference" text DEFAULT 'xp' NOT NULL;
+ALTER TABLE "invitation_acceptance" ADD COLUMN "reward_type" text DEFAULT 'xp' NOT NULL;
+```
+
+Both columns are `NOT NULL DEFAULT 'xp'` so the migration is safe on existing data.
+
+## 9. Testing strategy
+
+**Repository unit/integration:**
+- `acceptInvitation` with inviter `invite_reward_preference = "xp"` → inviter gets +100 XP, `invitation_acceptance.reward_type = 'xp'`.
+- `acceptInvitation` with inviter preference = `"shield"` and `streakShieldsAvailable = 0` → inviter gets +1 shield (now at 1), no XP, `reward_type = 'shield'`.
+- `acceptInvitation` with inviter preference = `"shield"` and `streakShieldsAvailable = 1` (at MAX) → silently falls back to XP, +100 XP awarded, `reward_type = 'xp'`.
+- Race-safe shield update: a conditional UPDATE `WHERE streakShieldsAvailable < MAX` prevents two concurrent accepts from pushing the inviter over the cap.
+
+**Service unit (`sessions.service.test.ts`):**
+- When `tryUseShield` returns `{ used: true, ... }`, the dispatcher is called once with kind `"streak_protected"` and the current streak length.
+- When `tryUseShield` returns `{ used: false, ... }`, dispatcher NOT called.
+- If `dispatcher` is null, no error; just skip.
+
+**Templates unit (`templates.test.ts`):**
+- `streakProtected(7)` returns the expected pt-BR strings.
+- `streakProtected(1)` — singular phrasing still acceptable.
+
+**Route unit/integration:**
+- `PATCH /users/me/invite-reward-preference { preference: "shield" }` → 200, profile updated.
+- `PATCH ... { preference: "invalid" }` → 400 via Zod.
+- `POST /invitations/accept` returns the new `reward: { type, xpAwarded, shieldGranted }` shape.
+
+## 10. Acceptance criteria
+
+A1. New column `user.invite_reward_preference` exists with `NOT NULL DEFAULT 'xp'`. Existing users default to `'xp'`.
+A2. New column `invitation_acceptance.reward_type` exists with `NOT NULL DEFAULT 'xp'`. Existing rows backfill to `'xp'`.
+A3. `PATCH /users/me/invite-reward-preference { preference: "xp" | "shield" }` updates the user's preference; invalid values rejected with 400.
+A4. Inviter with preference `"xp"`: an accept call awards +100 XP and writes `reward_type='xp'`.
+A5. Inviter with preference `"shield"` and shields < MAX: an accept call grants +1 shield (capped at MAX), no XP, writes `reward_type='shield'`.
+A6. Inviter with preference `"shield"` and shields already at MAX: an accept call falls back to +100 XP and writes `reward_type='xp'` (cap respected, audit honest).
+A7. The shield update is race-safe: two concurrent accepts on a same-inviter-preference=shield-at-shields=0 do NOT push the inviter to shields=2.
+A8. When `ShieldsService.tryUseShield` returns `{ used: true }` from the auto-protect hook in `SessionsService.maybeProtectMissedDay`, a notification of kind `"streak_protected"` is enqueued via the existing dispatcher with the user's current streak length.
+A9. When `tryUseShield` returns `{ used: false }`, no notification is enqueued.
+A10. If the user has opted out of `streak_protected` notifications (preference flag), the dispatcher skips the send (existing preference-respect mechanism).
+A11. The template `streakProtected(days)` returns pt-BR strings matching §7.
+A12. The accept-invitation response includes `reward: { type, xpAwarded, shieldGranted }`. The top-level `xpAwarded` field is removed.
+A13. All errors logged via `fastify.log`/`logger.error`. No `console.error` in production paths.
+
+## 11. Deferred items
+
+- Per-invite reward override (an invitee-facing UX where the invitee can request a reward type for the inviter).
+- Retroactive switching: convert past `'xp'` rewards to `'shield'` on user request.
+- A/B testing the default reward type (XP vs shield) for new users.
+- Push notification batching for users with multiple shield-use events on the same day (single user, single day → single push is already guaranteed by the auto-use mechanic — but if the rule ever changes, batching becomes relevant).
+- Localization for non-pt-BR locales.
+
+## 12. Open questions resolved during design
+
+- **Reward choice UX**: a user-level preference setting (not per-invite) is the simplest implementation honoring product spec's "ou". YAGNI rules out anything fancier.
+- **Cap behavior**: silent fallback to XP rather than rejecting the accept. Rejecting would block the invitee for an inviter-state reason, which is bad UX.
+- **Push timing**: "no dia seguinte" in the product doc is relative to the missed day, which IS the day the auto-protect runs. Send immediately. No scheduling complexity needed.
+- **Streak length source**: `StreaksService.getStreakStats(userId).currentStreak`. After the protection, the streak is intact, so the current value is the correct one to display.
+- **`reward_type` on `invitation_acceptance`**: records the **delivered** reward (after fallback), not the **requested** preference. This makes the audit useful for analytics ("how many shield-rewards were actually delivered vs fell back to XP").
+- **Backwards compatibility of accept response**: removing top-level `xpAwarded` is acceptable per the project's pre-production status. Documented as a contract change in the PR.

--- a/packages/db/src/migrations/0011_lovely_ravenous.sql
+++ b/packages/db/src/migrations/0011_lovely_ravenous.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user" ADD COLUMN "invite_reward_preference" text DEFAULT 'xp' NOT NULL;--> statement-breakpoint
+ALTER TABLE "invitation_acceptance" ADD COLUMN "reward_type" text DEFAULT 'xp' NOT NULL;

--- a/packages/db/src/migrations/meta/0011_snapshot.json
+++ b/packages/db/src/migrations/meta/0011_snapshot.json
@@ -1,0 +1,2032 @@
+{
+  "id": "a22e441c-0dd2-4053-88e9-8c717d3a6c7f",
+  "prevId": "a344d1bb-9b86-4b65-95b0-0b82a88e6756",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives": {
+          "name": "lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lives_last_regen_at": {
+          "name": "lives_last_regen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "selected_exam": {
+          "name": "selected_exam",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulties": {
+          "name": "difficulties",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "daily_study_time_minutes": {
+          "name": "daily_study_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ultra": {
+          "name": "is_ultra",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ultra_expires_at": {
+          "name": "ultra_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)"
+        },
+        "invite_reward_preference": {
+          "name": "invite_reward_preference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'xp'"
+        },
+        "notification_hour": {
+          "name": "notification_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 19
+        },
+        "streak_reminders_enabled": {
+          "name": "streak_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "achievement_notifications_enabled": {
+          "name": "achievement_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "streak_shields_available": {
+          "name": "streak_shields_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_shield_grant_at": {
+          "name": "last_shield_grant_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_event": {
+      "name": "billing_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_token": {
+          "name": "purchase_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "billing_event_provider_message_uq": {
+          "name": "billing_event_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_event_token_idx": {
+          "name": "billing_event_token_idx",
+          "columns": [
+            {
+              "expression": "purchase_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_event_unprocessed_idx": {
+          "name": "billing_event_unprocessed_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"billing_event\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_token": {
+          "name": "purchase_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_provider_token_uq": {
+          "name": "subscription_provider_token_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchase_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscription_user_idx": {
+          "name": "subscription_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscription_status_idx": {
+          "name": "subscription_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_session": {
+      "name": "daily_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_correct": {
+          "name": "questions_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastery_snapshot": {
+          "name": "mastery_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_session_user_created_idx": {
+          "name": "daily_session_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_session_user_id_user_id_fk": {
+          "name": "daily_session_user_id_user_id_fk",
+          "tableFrom": "daily_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "friendship_requester_idx": {
+          "name": "friendship_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendship_recipient_idx": {
+          "name": "friendship_recipient_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendship_requester_id_user_id_fk": {
+          "name": "friendship_requester_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_recipient_id_user_id_fk": {
+          "name": "friendship_recipient_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subject_name_unique": {
+          "name": "subject_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "subject_slug_unique": {
+          "name": "subject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopic": {
+      "name": "subtopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtopic_topic_order_idx": {
+          "name": "subtopic_topic_order_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopic_topic_id_topic_id_fk": {
+          "name": "subtopic_topic_id_topic_id_fk",
+          "tableFrom": "subtopic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtopic_topic_slug_uniq": {
+          "name": "subtopic_topic_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topic_subject_order_idx": {
+          "name": "topic_subject_order_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_subject_id_subject_id_fk": {
+          "name": "topic_subject_id_subject_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_subject_slug_uniq": {
+          "name": "topic_subject_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_option_index": {
+          "name": "correct_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_calculation": {
+          "name": "requires_calculation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtopic_id": {
+          "name": "subtopic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_subject_difficulty_idx": {
+          "name": "question_subject_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_subtopic_difficulty_idx": {
+          "name": "question_subtopic_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_subject_id_subject_id_fk": {
+          "name": "question_subject_id_subject_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_subtopic_id_subtopic_id_fk": {
+          "name": "question_subtopic_id_subtopic_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subtopic",
+          "columnsFrom": [
+            "subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_log": {
+      "name": "review_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "easiness_factor": {
+          "name": "easiness_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_log_user_next_review_idx": {
+          "name": "review_log_user_next_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_log_user_question_idx": {
+          "name": "review_log_user_question_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_log_user_id_user_id_fk": {
+          "name": "review_log_user_id_user_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_log_question_id_question_id_fk": {
+          "name": "review_log_question_id_question_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_token": {
+      "name": "push_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_token_user_idx": {
+          "name": "push_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_token_user_id_user_id_fk": {
+          "name": "push_token_user_id_user_id_fk",
+          "tableFrom": "push_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_token_token_unique": {
+          "name": "push_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_acceptance": {
+      "name": "invitation_acceptance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'xp'"
+        }
+      },
+      "indexes": {
+        "invitation_acceptance_inviter_idx": {
+          "name": "invitation_acceptance_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_acceptance_inviter_id_user_id_fk": {
+          "name": "invitation_acceptance_inviter_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_acceptance_invitee_id_user_id_fk": {
+          "name": "invitation_acceptance_invitee_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invitee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_acceptance_invitee_id_unique": {
+          "name": "invitation_acceptance_invitee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_shield_usage": {
+      "name": "streak_shield_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protected_date": {
+          "name": "protected_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "streak_shield_usage_user_date_idx": {
+          "name": "streak_shield_usage_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protected_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "streak_shield_usage_user_idx": {
+          "name": "streak_shield_usage_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "streak_shield_usage_user_id_user_id_fk": {
+          "name": "streak_shield_usage_user_id_user_id_fk",
+          "tableFrom": "streak_shield_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_simulado": {
+      "name": "weekly_simulado",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start_date": {
+          "name": "week_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions_count": {
+          "name": "questions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weekly_simulado_user_week_uq": {
+          "name": "weekly_simulado_user_week_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_simulado_user_week_idx": {
+          "name": "weekly_simulado_user_week_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_simulado_user_id_user_id_fk": {
+          "name": "weekly_simulado_user_id_user_id_fk",
+          "tableFrom": "weekly_simulado",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_simulado_question": {
+      "name": "weekly_simulado_question",
+      "schema": "",
+      "columns": {
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_index": {
+          "name": "selected_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "weekly_simulado_question_simulado_question_uq": {
+          "name": "weekly_simulado_question_simulado_question_uq",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_simulado_question_simulado_idx": {
+          "name": "weekly_simulado_question_simulado_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_simulado_question_simulado_id_weekly_simulado_id_fk": {
+          "name": "weekly_simulado_question_simulado_id_weekly_simulado_id_fk",
+          "tableFrom": "weekly_simulado_question",
+          "tableTo": "weekly_simulado",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weekly_simulado_question_question_id_question_id_fk": {
+          "name": "weekly_simulado_question_question_id_question_id_fk",
+          "tableFrom": "weekly_simulado_question",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "weekly_simulado_question_simulado_id_position_pk": {
+          "name": "weekly_simulado_question_simulado_id_position_pk",
+          "columns": [
+            "simulado_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778599774073,
       "tag": "0010_glamorous_morlocks",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778621036227,
+      "tag": "0011_lovely_ravenous",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -27,6 +27,7 @@ export const user = pgTable("user", {
   inviteCode: text("invite_code")
     .notNull()
     .default(sql`SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)`),
+  inviteRewardPreference: text("invite_reward_preference", { enum: ["xp", "shield"] }).notNull().default("xp"),
   notificationHour: integer("notification_hour").notNull().default(19),
   streakRemindersEnabled: boolean("streak_reminders_enabled").notNull().default(true),
   achievementNotificationsEnabled: boolean("achievement_notifications_enabled").notNull().default(true),

--- a/packages/db/src/schema/invitation-acceptance.ts
+++ b/packages/db/src/schema/invitation-acceptance.ts
@@ -9,6 +9,7 @@ export const invitationAcceptance = pgTable(
     inviterId: text("inviter_id").notNull().references(() => user.id, { onDelete: "cascade" }),
     inviteeId: text("invitee_id").notNull().unique().references(() => user.id, { onDelete: "cascade" }),
     acceptedAt: timestamp("accepted_at").defaultNow().notNull(),
+    rewardType: text("reward_type", { enum: ["xp", "shield"] }).notNull().default("xp"),
   },
   (table) => [index("invitation_acceptance_inviter_idx").on(table.inviterId)],
 );

--- a/packages/shared/src/users.ts
+++ b/packages/shared/src/users.ts
@@ -17,3 +17,15 @@ export const ProfileResponseSchema = z.object({
 });
 
 export type ProfileResponse = z.infer<typeof ProfileResponseSchema>;
+
+/** PATCH /users/me/invite-reward-preference — body */
+export const InviteRewardPreferenceBodySchema = z.object({
+  preference: z.enum(["xp", "shield"]),
+});
+export type InviteRewardPreferenceBody = z.infer<typeof InviteRewardPreferenceBodySchema>;
+
+/** PATCH /users/me/invite-reward-preference — response */
+export const InviteRewardPreferenceResponseSchema = z.object({
+  preference: z.enum(["xp", "shield"]),
+});
+export type InviteRewardPreferenceResponse = z.infer<typeof InviteRewardPreferenceResponseSchema>;


### PR DESCRIPTION
## Summary
- Inviter can pick "+100 XP" or "+1 escudo de streak" as their referral reward via `PATCH /users/me/invite-reward-preference`. Default: XP (backwards compat for existing users).
- Auto-protect shield (Phase 2E.2) now triggers a push notification: "Seu escudo protegeu seu streak!" — reusing the existing `streakRemindersEnabled` opt-out (no new preference column).
- Two new columns (`NOT NULL DEFAULT 'xp'`): `user.invite_reward_preference`, `invitation_acceptance.reward_type`.
- Repository TX reordered so `invitation_acceptance.reward_type` ALWAYS reflects the delivered reward (race-safe predicate-in-WHERE + audit-honest fallback to XP if shield cap was hit).
- Accept-invitation response shape changed: top-level `xpAwarded` removed, replaced by `reward: { type, xpAwarded, shieldGranted }` object.

## Workflow gates
- ✅ Gate A — spec self-review (5 blockers fixed: real Dispatcher API, existing prefs flag, service-layer wiring, TX reorder, real getStreaks API)
- ✅ Gate B — plan self-review (4 blockers fixed: no double-wrap, ADD not update response schema, named test line 105, MAX_STREAK_SHIELDS constant)
- ✅ Gate C — per-task review after every commit (4 tasks)
- ✅ Gate D — final spec-coverage review (3 testing gaps closed: race-concurrency integration test, streakProtected(1) singular, UsersService.updateInviteRewardPreference unit tests)

## Test coverage (final)
- Invitations integration: 12 tests including new race-concurrency case
- Invitations service unit: covers XP + shield reward paths
- Templates: 7 tests including singular phrasing
- Dispatcher: 4 new tests (happy/opt-out/no-tokens/days<1)
- Sessions hook: 4 new tests (used+streak/used+no-streak/not-used/no-dispatcher)
- Users service: 11 tests including updateInviteRewardPreference

## Spec & plan
- Spec v2: docs/superpowers/specs/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push-design.md
- Plan v2: docs/superpowers/plans/2026-05-12-phase-2e6-referral-shield-and-protect-streak-push.md

## Breaking change
- `POST /invitations/accept` response: top-level `xpAwarded` field removed; clients read `reward.xpAwarded` instead. No production clients yet.

## Test plan
- [ ] CI: integration tests with Postgres
- [ ] Manual: `PATCH /users/me/invite-reward-preference { preference: "shield" }` then accept an invite → inviter gets +1 shield, audit row shows `reward_type='shield'`
- [ ] Manual: complete a session that triggers auto-protect → user receives "Seu escudo protegeu seu streak!" push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streak-protected push notifications now send when a missed day is automatically protected.
  * Users can choose between XP or shields as referral rewards via a new preference setting.
  * Referral invitations now support shield rewards (with XP as fallback when the shield limit is reached).

* **Tests**
  * Added comprehensive test coverage for streak-protected notifications, referral reward preferences, and invitation acceptance logic.

* **Documentation**
  * Added design specification and implementation plan for referral shield rewards and streak-protected notifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CeCamillo/pruvi/pull/27)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->