### PR TITLE
feat: phase 2e.8 — google play real expiryTime via subscriptionsv2.get

### DIFF
--- a/apps/server/src/features/billing/billing-sweep.integration.test.ts
+++ b/apps/server/src/features/billing/billing-sweep.integration.test.ts
@@ -7,6 +7,7 @@ import { BillingService } from "./billing.service";
 import { BillingRepository } from "./billing.repository";
 import { UltraService } from "../ultra/ultra.service";
 import { UltraRepository } from "../ultra/ultra.repository";
+import { GooglePlayApiClient } from "./google-play.api-client";
 
 // There is no `seedUser` helper. Copy the local `insertUser(id)` pattern verbatim
 // from `billing.repository.integration.test.ts:15`:
@@ -33,7 +34,8 @@ describe("BillingService.runReconciliationSweep (integration)", () => {
     await cleanupTestDb();
     const repo = new BillingRepository();
     const ultra = new UltraService(new UltraRepository(db));   // canonical construction per billing.route.ts:16
-    svc = new BillingService(db, repo, ultra);
+    const apiClient = new GooglePlayApiClient(null);
+    svc = new BillingService(db, repo, ultra, apiClient, null);
   });
   afterAll(async () => teardownTestDb());
 

--- a/apps/server/src/features/billing/billing-sweep.service.test.ts
+++ b/apps/server/src/features/billing/billing-sweep.service.test.ts
@@ -3,6 +3,7 @@ import { BillingService } from "./billing.service";
 import type { BillingRepository, SubscriptionRow } from "./billing.repository";
 import type { UltraService } from "../ultra/ultra.service";
 import type { db as DbClient } from "@pruvi/db";
+import type { GooglePlayApiClient } from "./google-play.api-client";
 
 type FakeDb = Pick<typeof DbClient, "transaction">;
 
@@ -38,7 +39,8 @@ describe("BillingService.runReconciliationSweep", () => {
       transaction: async <T,>(fn: (tx: unknown) => Promise<T>) => fn({}),
     } as unknown as FakeDb as typeof DbClient;
 
-    const svc = new BillingService(fakeDb, repo, ultra);
+    const apiClient = { getSubscription: vi.fn() } as unknown as GooglePlayApiClient;
+    const svc = new BillingService(fakeDb, repo, ultra, apiClient, null);
     const out = await svc.runReconciliationSweep({ now });
 
     expect(out).toEqual({ scanned: 1, expired: 1, revoked: 1 });
@@ -57,7 +59,8 @@ describe("BillingService.runReconciliationSweep", () => {
     const ultra = { revoke: vi.fn(), grant: vi.fn() } as unknown as UltraService;
     const fakeDb = { transaction: async <T,>(fn: (tx: unknown) => Promise<T>) => fn({}) } as unknown as FakeDb as typeof DbClient;
 
-    const svc = new BillingService(fakeDb, repo, ultra);
+    const apiClient = { getSubscription: vi.fn() } as unknown as GooglePlayApiClient;
+    const svc = new BillingService(fakeDb, repo, ultra, apiClient, null);
     const out = await svc.runReconciliationSweep({ now });
 
     expect(out).toEqual({ scanned: 1, expired: 1, revoked: 0 });
@@ -76,7 +79,8 @@ describe("BillingService.runReconciliationSweep", () => {
     const ultra = { revoke: vi.fn(), grant: vi.fn() } as unknown as UltraService;
     const fakeDb = { transaction: async <T,>(fn: (tx: unknown) => Promise<T>) => fn({}) } as unknown as FakeDb as typeof DbClient;
 
-    const svc = new BillingService(fakeDb, repo, ultra);
+    const apiClient = { getSubscription: vi.fn() } as unknown as GooglePlayApiClient;
+    const svc = new BillingService(fakeDb, repo, ultra, apiClient, null);
     const out = await svc.runReconciliationSweep({ now });
 
     expect(out).toEqual({ scanned: 1, expired: 0, revoked: 0 });
@@ -96,7 +100,8 @@ describe("BillingService.runReconciliationSweep", () => {
     const ultra = { revoke: vi.fn(), grant: vi.fn() } as unknown as UltraService;
     const fakeDb = { transaction: async <T,>(fn: (tx: unknown) => Promise<T>) => fn({}) } as unknown as FakeDb as typeof DbClient;
 
-    const svc = new BillingService(fakeDb, repo, ultra);
+    const apiClient = { getSubscription: vi.fn() } as unknown as GooglePlayApiClient;
+    const svc = new BillingService(fakeDb, repo, ultra, apiClient, null);
     const out = await svc.runReconciliationSweep({ now });
 
     expect(out).toEqual({ scanned: 1, expired: 0, revoked: 0 });
@@ -116,7 +121,8 @@ describe("BillingService.runReconciliationSweep", () => {
     const ultra = { revoke: vi.fn().mockResolvedValue(undefined), grant: vi.fn() } as unknown as UltraService;
     const fakeDb = { transaction: txSpy } as unknown as FakeDb as typeof DbClient;
 
-    const svc = new BillingService(fakeDb, repo, ultra);
+    const apiClient = { getSubscription: vi.fn() } as unknown as GooglePlayApiClient;
+    const svc = new BillingService(fakeDb, repo, ultra, apiClient, null);
     const out = await svc.runReconciliationSweep({ now });
 
     expect(out).toEqual({ scanned: 2, expired: 2, revoked: 2 });

--- a/apps/server/src/features/billing/billing.route.ts
+++ b/apps/server/src/features/billing/billing.route.ts
@@ -11,10 +11,13 @@ import { BillingRepository } from "./billing.repository";
 import { BillingService } from "./billing.service";
 import { UltraRepository } from "../ultra/ultra.repository";
 import { UltraService } from "../ultra/ultra.service";
+import { loadServiceAccountFromEnv } from "./google-play.service-account";
+import { GooglePlayApiClient } from "./google-play.api-client";
 
 const repo = new BillingRepository();
 const ultra = new UltraService(new UltraRepository(db));
-const service = new BillingService(db, repo, ultra);
+const apiClient = new GooglePlayApiClient(loadServiceAccountFromEnv(env));
+const service = new BillingService(db, repo, ultra, apiClient, env.GOOGLE_PLAY_PACKAGE_NAME ?? null);
 
 // IMPORTANT: throw AppError subclasses so the project's error handler maps statusCode correctly.
 // Plain `throw new Error(...)` would fall through to the 500 branch regardless of reply.code().

--- a/apps/server/src/features/billing/billing.route.ts
+++ b/apps/server/src/features/billing/billing.route.ts
@@ -16,8 +16,6 @@ import { GooglePlayApiClient } from "./google-play.api-client";
 
 const repo = new BillingRepository();
 const ultra = new UltraService(new UltraRepository(db));
-const apiClient = new GooglePlayApiClient(loadServiceAccountFromEnv(env));
-const service = new BillingService(db, repo, ultra, apiClient, env.GOOGLE_PLAY_PACKAGE_NAME ?? null);
 
 // IMPORTANT: throw AppError subclasses so the project's error handler maps statusCode correctly.
 // Plain `throw new Error(...)` would fall through to the 500 branch regardless of reply.code().
@@ -54,6 +52,11 @@ async function appStorePathGuard(request: FastifyRequest) {
 }
 
 export const billingRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  // Construct the api client inside the plugin closure so fastify.log (pino) is available
+  // — pino-structured logs are required for production observability per spec §4.1.
+  const apiClient = new GooglePlayApiClient(loadServiceAccountFromEnv(env), { logger: fastify.log });
+  const service = new BillingService(db, repo, ultra, apiClient, env.GOOGLE_PLAY_PACKAGE_NAME ?? null);
+
   fastify.post(
     "/webhooks/google-play",
     {

--- a/apps/server/src/features/billing/billing.service.test.ts
+++ b/apps/server/src/features/billing/billing.service.test.ts
@@ -184,9 +184,11 @@ describe("real expiryTime override", () => {
   it("RENEWED with apiClient returning a real expiry uses that date for currentPeriodEnd and grant", async () => {
     const realExpiry = new Date("2026-06-12T15:30:00Z");
     const linked: SubscriptionRow = { id: 20, userId: "u2", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
-    const { service, repo, ultra } = buildSut({ findSubscription: linked, apiClient: makeStubApiClient(realExpiry) });
+    const apiClient = makeStubApiClient(realExpiry);
+    const { service, repo, ultra } = buildSut({ findSubscription: linked, apiClient });
     const r = await service.processGooglePlayEnvelope(buildEnvelope(2));   // RENEWED
     expect(r.isOk()).toBe(true);
+    expect(apiClient.getSubscription).toHaveBeenCalledWith("com.pruvi.app", "tok");
     expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 20, expect.objectContaining({ status: "active", currentPeriodEnd: realExpiry }));
     expect(ultra.grant).toHaveBeenCalledWith("u2", realExpiry);
   });
@@ -200,7 +202,7 @@ describe("real expiryTime override", () => {
     const call = repo.updateSubscriptionState.mock.calls[0]!;
     const end = call[2].currentPeriodEnd as Date;
     const expected = before + 30 * 24 * 60 * 60 * 1000;
-    expect(end.getTime()).toBeGreaterThanOrEqual(expected - 1000);
+    expect(end.getTime()).toBeGreaterThanOrEqual(expected);
     expect(end.getTime()).toBeLessThanOrEqual(expected + 5000);
   });
 

--- a/apps/server/src/features/billing/billing.service.test.ts
+++ b/apps/server/src/features/billing/billing.service.test.ts
@@ -206,6 +206,23 @@ describe("real expiryTime override", () => {
     expect(end.getTime()).toBeLessThanOrEqual(expected + 5000);
   });
 
+  it("empty packageName + null fallback skips API call and uses 30-day default", async () => {
+    const linked: SubscriptionRow = { id: 23, userId: "u5", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const apiClient = makeStubApiClient(new Date("2026-06-12T00:00:00Z"));
+    const { service, repo } = buildSut({ findSubscription: linked, apiClient });
+    // Build an envelope whose inner packageName is empty:
+    const innerNoPkg = { packageName: "", subscriptionNotification: { notificationType: 2, purchaseToken: "tok", version: "1.0" } };
+    const envNoPkg = { message: { messageId: "msg-no-pkg", publishTime: "2026-05-12T10:00:00Z", data: Buffer.from(JSON.stringify(innerNoPkg)).toString("base64") } };
+    const before = Date.now();
+    const r = await service.processGooglePlayEnvelope(envNoPkg);
+    expect(r.isOk()).toBe(true);
+    expect(apiClient.getSubscription).not.toHaveBeenCalled();
+    const end = repo.updateSubscriptionState.mock.calls[0]![2].currentPeriodEnd as Date;
+    const expected = before + 30 * 24 * 60 * 60 * 1000;
+    expect(end.getTime()).toBeGreaterThanOrEqual(expected);
+    expect(end.getTime()).toBeLessThanOrEqual(expected + 5000);
+  });
+
   it("non-grant events (CANCELED) do NOT call apiClient.getSubscription", async () => {
     const linked: SubscriptionRow = { id: 22, userId: "u4", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date("2026-12-01"), linkedAt: new Date() };
     const apiClient = makeStubApiClient(new Date("2026-06-12T00:00:00Z"));

--- a/apps/server/src/features/billing/billing.service.test.ts
+++ b/apps/server/src/features/billing/billing.service.test.ts
@@ -3,6 +3,13 @@ import { BillingService } from "./billing.service";
 import type { BillingRepository, SubscriptionRow, BillingEventRow } from "./billing.repository";
 import type { UltraService } from "../ultra/ultra.service";
 import type { db as DbClient } from "@pruvi/db";
+import type { GooglePlayApiClient } from "./google-play.api-client";
+
+function makeStubApiClient(realExpiry: Date | null = null): GooglePlayApiClient {
+  return {
+    getSubscription: vi.fn().mockResolvedValue(realExpiry),
+  } as unknown as GooglePlayApiClient;
+}
 
 type Mocked<T> = { [K in keyof T]: T[K] extends (...a: infer A) => infer R ? ReturnType<typeof vi.fn<(...a: A) => R>> : T[K] };
 
@@ -16,6 +23,7 @@ function buildSut(opts: {
   maxOtherEnd?: Date | null;
   upsertLinked?: { subscription: SubscriptionRow; created: boolean };
   claimOrphan?: SubscriptionRow;
+  apiClient?: GooglePlayApiClient;
 } = {}) {
   const repo = {
     insertEvent: vi.fn().mockResolvedValue(opts.insertEvent ?? { id: 1, provider: "google_play", messageId: "m1", eventType: "PURCHASED", purchaseToken: "tok", payload: {}, receivedAt: new Date(), processedAt: null, processingError: null }),
@@ -36,8 +44,9 @@ function buildSut(opts: {
   const db = {
     transaction: vi.fn(async (cb: (tx: any) => Promise<any>) => cb(repo)),
   } as unknown as typeof DbClient;
-  const service = new BillingService(db, repo as unknown as BillingRepository, ultra as unknown as UltraService);
-  return { service, repo, ultra, db };
+  const apiClient = opts.apiClient ?? makeStubApiClient(null);
+  const service = new BillingService(db, repo as unknown as BillingRepository, ultra as unknown as UltraService, apiClient, null);
+  return { service, repo, ultra, db, apiClient };
 }
 
 function buildEnvelope(notificationType: number, purchaseToken = "tok", messageId = "msg-1") {
@@ -166,6 +175,48 @@ describe("BillingService", () => {
     expect(repo.claimOrphanSubscription).toHaveBeenCalledWith(expect.anything(), 10, "u1", "p");
     expect(repo.markEventProcessed).toHaveBeenCalledWith(expect.anything(), 5);
     expect(ultra.grant).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("real expiryTime override", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("RENEWED with apiClient returning a real expiry uses that date for currentPeriodEnd and grant", async () => {
+    const realExpiry = new Date("2026-06-12T15:30:00Z");
+    const linked: SubscriptionRow = { id: 20, userId: "u2", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service, repo, ultra } = buildSut({ findSubscription: linked, apiClient: makeStubApiClient(realExpiry) });
+    const r = await service.processGooglePlayEnvelope(buildEnvelope(2));   // RENEWED
+    expect(r.isOk()).toBe(true);
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 20, expect.objectContaining({ status: "active", currentPeriodEnd: realExpiry }));
+    expect(ultra.grant).toHaveBeenCalledWith("u2", realExpiry);
+  });
+
+  it("RENEWED with apiClient returning null falls back to now + 30d", async () => {
+    const linked: SubscriptionRow = { id: 21, userId: "u3", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service, repo } = buildSut({ findSubscription: linked, apiClient: makeStubApiClient(null) });
+    const before = Date.now();
+    const r = await service.processGooglePlayEnvelope(buildEnvelope(2));
+    expect(r.isOk()).toBe(true);
+    const call = repo.updateSubscriptionState.mock.calls[0]!;
+    const end = call[2].currentPeriodEnd as Date;
+    const expected = before + 30 * 24 * 60 * 60 * 1000;
+    expect(end.getTime()).toBeGreaterThanOrEqual(expected - 1000);
+    expect(end.getTime()).toBeLessThanOrEqual(expected + 5000);
+  });
+
+  it("non-grant events (CANCELED) do NOT call apiClient.getSubscription", async () => {
+    const linked: SubscriptionRow = { id: 22, userId: "u4", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date("2026-12-01"), linkedAt: new Date() };
+    const apiClient = makeStubApiClient(new Date("2026-06-12T00:00:00Z"));
+    const { service } = buildSut({ findSubscription: linked, apiClient });
+    await service.processGooglePlayEnvelope(buildEnvelope(3));   // CANCELED
+    expect(apiClient.getSubscription).not.toHaveBeenCalled();
+  });
+
+  it("unknown notificationType does NOT call apiClient.getSubscription", async () => {
+    const apiClient = makeStubApiClient(new Date("2026-06-12T00:00:00Z"));
+    const { service } = buildSut({ apiClient });
+    await service.processGooglePlayEnvelope(buildEnvelope(99));
+    expect(apiClient.getSubscription).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/src/features/billing/billing.service.ts
+++ b/apps/server/src/features/billing/billing.service.ts
@@ -62,7 +62,7 @@ export class BillingService {
     if (decoded.kind === "subscription" && GRANT_TYPES.has(decoded.notificationTypeName)) {
       const packageName = decoded.packageName || this.packageNameFallback || null;
       if (!packageName) {
-        console.warn({ messageId: decoded.messageId, reason: "no_package_name" }, "google-play real-expiry fallback");
+        console.warn(`google-play real-expiry fallback: no_package_name messageId=${decoded.messageId}`);
       } else {
         realExpiryTime = await this.apiClient.getSubscription(packageName, decoded.purchaseToken);
       }

--- a/apps/server/src/features/billing/billing.service.ts
+++ b/apps/server/src/features/billing/billing.service.ts
@@ -8,8 +8,12 @@ import { decodeGooglePlayPubSubEnvelope } from "./google-play.decoder";
 import type { DecodedAppStoreEvent } from "./app-store.decoder";
 import { decodeAppStoreNotification } from "./app-store.decoder";
 import type { db as DbClient } from "@pruvi/db";
+import type { GooglePlayApiClient } from "./google-play.api-client";
 
 type Db = typeof DbClient;
+
+/** Google Play notification types that grant/extend an active subscription. */
+const GRANT_TYPES: ReadonlySet<string> = new Set(["PURCHASED", "RENEWED", "RECOVERED", "RESTARTED"]);
 
 /** Effect to apply AFTER the transaction commits (two-phase pattern per spec §7.6).
  *  Both `grant` and `revoke` variants carry `excludeSubscriptionId` so the post-commit
@@ -26,6 +30,8 @@ export class BillingService {
     private db: Db,
     private repo: BillingRepository,
     private ultra: UltraService,
+    private apiClient: GooglePlayApiClient,
+    private packageNameFallback: string | null,
   ) {}
 
   /** Webhook entry point. Returns the response payload; always 200 on accepted shapes.
@@ -48,6 +54,18 @@ export class BillingService {
         payload: { kind: "test" },
       });
       return ok({ messageId: decoded.messageId, kind: "test" });
+    }
+
+    // Look up real expiryTime from Google Play API BEFORE the TX (avoid holding row locks during I/O).
+    // Only performed for grant events; all other events use the existing fallback logic.
+    let realExpiryTime: Date | null = null;
+    if (decoded.kind === "subscription" && GRANT_TYPES.has(decoded.notificationTypeName)) {
+      const packageName = decoded.packageName || this.packageNameFallback || null;
+      if (!packageName) {
+        console.warn({ messageId: decoded.messageId, reason: "no_package_name" }, "google-play real-expiry fallback");
+      } else {
+        realExpiryTime = await this.apiClient.getSubscription(packageName, decoded.purchaseToken);
+      }
     }
 
     const effect = await this.db.transaction(async (tx) => {
@@ -76,7 +94,7 @@ export class BillingService {
         sub = await this.repo.createOrphanSubscription(tx, "google_play", decoded.purchaseToken);
       }
 
-      const { newStatus, newPeriodEnd, ultraEffect } = this.applyDecodedEvent(decoded, sub);
+      const { newStatus, newPeriodEnd, ultraEffect } = this.applyDecodedEvent(decoded, sub, realExpiryTime);
       await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
 
       // If subscription has no user yet, leave processed_at = NULL so link can replay.
@@ -127,6 +145,9 @@ export class BillingService {
         const fresh = await this.repo.findSubscriptionByToken(tx, "google_play", body.purchaseToken);
         if (!fresh) throw new Error("replay: subscription disappeared mid-transaction");
         sub = fresh;
+        // NOTE: replay intentionally omits realExpiryTime (3rd arg) — see spec §4.1.
+        // Reason: outbound API call inside the link TX would hold row locks for 100ms+
+        // and could deadlock. The next live webhook reconciles the period end.
         const { newStatus, newPeriodEnd, ultraEffect } = this.applyDecodedEvent(decoded, sub);
         await this.repo.updateSubscriptionState(tx, sub.id, { status: newStatus, currentPeriodEnd: newPeriodEnd });
         await this.repo.markEventProcessed(tx, event.id);
@@ -152,16 +173,19 @@ export class BillingService {
     });
   }
 
-  /** Pure state-machine: maps (event, current subscription) → next state + ultra effect. NO DB writes. */
+  /** Pure state-machine: maps (event, current subscription) → next state + ultra effect. NO DB writes.
+   *  @param realExpiryTime — when supplied (from Google Play API), grant events use this instead of now+30d. */
   applyDecodedEvent(
     decoded: DecodedGooglePlayEvent,
     sub: SubscriptionRow,
+    realExpiryTime?: Date | null,
   ): { newStatus: SubscriptionStatus; newPeriodEnd: Date | null; ultraEffect: PostCommitUltraEffect } {
     if (decoded.kind !== "subscription") {
       return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
     }
     const now = new Date();
     const defaultEnd = new Date(now.getTime() + DEFAULT_SUBSCRIPTION_PERIOD_MS);
+    const grantEnd = realExpiryTime ?? defaultEnd;
     const name = decoded.notificationTypeName;
     const grant = (end: Date): PostCommitUltraEffect =>
       sub.userId !== null
@@ -177,7 +201,7 @@ export class BillingService {
       case "RENEWED":
       case "RECOVERED":
       case "RESTARTED":
-        return { newStatus: "active", newPeriodEnd: defaultEnd, ultraEffect: grant(defaultEnd) };
+        return { newStatus: "active", newPeriodEnd: grantEnd, ultraEffect: grant(grantEnd) };
       case "IN_GRACE_PERIOD":
         return { newStatus: "in_grace", newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
       case "CANCELED":

--- a/apps/server/src/features/billing/google-play.api-client.test.ts
+++ b/apps/server/src/features/billing/google-play.api-client.test.ts
@@ -77,7 +77,7 @@ describe("GooglePlayApiClient", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(4);
   });
 
-  it("returns null on tokens endpoint 401 AND invalidates cached token", async () => {
+  it("returns null on v2 endpoint 401 AND invalidates cached token (next call re-mints)", async () => {
     fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
     fetchImpl.mockResolvedValueOnce(new Response("", { status: 401 }));
     const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });

--- a/apps/server/src/features/billing/google-play.api-client.test.ts
+++ b/apps/server/src/features/billing/google-play.api-client.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { GooglePlayApiClient } from "./google-play.api-client";
+import type { ServiceAccountCreds } from "./google-play.service-account";
+import { generateKeyPairSync } from "node:crypto";
+
+function makeCreds(): ServiceAccountCreds {
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { clientEmail: "svc@proj.iam.gserviceaccount.com", privateKey, tokenUri: "https://oauth2.googleapis.com/token" };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+function nonJsonResponse(body: string, status = 200): Response {
+  return new Response(body, { status, headers: { "content-type": "text/html" } });
+}
+
+describe("GooglePlayApiClient", () => {
+  let creds: ServiceAccountCreds;
+  let fetchImpl: ReturnType<typeof vi.fn>;
+  let logger: { warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    creds = makeCreds();
+    fetchImpl = vi.fn();
+    logger = { warn: vi.fn(), error: vi.fn() };
+  });
+
+  it("returns null without HTTP call when creds is null", async () => {
+    const client = new GooglePlayApiClient(null, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("happy path: mints token, fetches subscription, returns Date from lineItems[0].expiryTime", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ productId: "ultra_monthly", expiryTime: "2026-06-12T15:30:00Z" }] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok-1");
+    expect(r).toEqual(new Date("2026-06-12T15:30:00Z"));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    // assert URL shape
+    expect(fetchImpl.mock.calls[1]![0]).toBe(
+      "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/com.pkg/purchases/subscriptionsv2/tokens/tok-1",
+    );
+  });
+
+  it("caches the access token across calls within TTL", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-06-12T00:00:00Z" }] }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-07-12T00:00:00Z" }] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    await client.getSubscription("com.pkg", "tok-a");
+    await client.getSubscription("com.pkg", "tok-b");
+    expect(fetchImpl).toHaveBeenCalledTimes(3);   // 1 token + 2 v2 calls (NOT 4)
+  });
+
+  it("refreshes token after TTL elapses", async () => {
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    // Mint a token with expires_in=60. TOKEN_SKEW_MS is 60s, so expiresAtMs - TOKEN_SKEW_MS == now,
+    // meaning the cache check (expiresAtMs - TOKEN_SKEW_MS > now) is false immediately on next call.
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 60, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-06-12T00:00:00Z" }] }));
+    await client.getSubscription("com.pkg", "tok-a");
+
+    // The token is already past its skew window, so a second call re-mints.
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT2", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-07-12T00:00:00Z" }] }));
+    await client.getSubscription("com.pkg", "tok-b");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it("returns null on tokens endpoint 401 AND invalidates cached token", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(new Response("", { status: 401 }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    await client.getSubscription("com.pkg", "tok-a");   // primes cache, then v2 returns 401 invalidating it
+    // Now force v2 endpoint to fail with 401 — note: 401 from v2 (not tokens) invalidates the cache.
+    expect(logger.error).toHaveBeenCalled();
+    // Next call should mint fresh token
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT2", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-07-12T00:00:00Z" }] }));
+    const r = await client.getSubscription("com.pkg", "tok-b");
+    expect(r).toEqual(new Date("2026-07-12T00:00:00Z"));
+    expect(fetchImpl).toHaveBeenCalledTimes(4);   // 2 token mints + 2 v2 calls
+  });
+
+  it("returns null when tokens endpoint returns non-JSON body", async () => {
+    fetchImpl.mockResolvedValueOnce(nonJsonResponse("<html>proxy error</html>", 200));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("returns null on v2 404", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(new Response("", { status: 404 }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on v2 500", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(new Response("", { status: 500 }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on empty lineItems", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on missing expiryTime", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ productId: "ultra" }] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on network throw at tokens endpoint", async () => {
+    fetchImpl.mockRejectedValueOnce(new Error("ECONNRESET"));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on network throw at v2 endpoint", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockRejectedValueOnce(new Error("ECONNRESET"));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns past expiryTime as-is (trust google; sweep reconciles)", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2020-01-01T00:00:00Z" }] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toEqual(new Date("2020-01-01T00:00:00Z"));   // past, not null
+  });
+});

--- a/apps/server/src/features/billing/google-play.api-client.ts
+++ b/apps/server/src/features/billing/google-play.api-client.ts
@@ -1,0 +1,108 @@
+import { mintJwt, type ServiceAccountCreds } from "./google-play.service-account";
+
+type Logger = { warn: (...args: unknown[]) => void; error: (...args: unknown[]) => void };
+
+type TokenCache = { token: string; expiresAtMs: number } | null;
+
+const TOKEN_SKEW_MS = 60_000;
+const ANDROIDPUBLISHER_BASE = "https://androidpublisher.googleapis.com/androidpublisher/v3";
+
+export class GooglePlayApiClient {
+  private tokenCache: TokenCache = null;
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger: Logger;
+
+  constructor(
+    private readonly creds: ServiceAccountCreds | null,
+    opts: { fetchImpl?: typeof fetch; logger?: Logger } = {},
+  ) {
+    this.fetchImpl = opts.fetchImpl ?? ((...args: Parameters<typeof fetch>) => globalThis.fetch(...args));
+    this.logger = opts.logger ?? { warn: console.warn.bind(console), error: console.error.bind(console) };
+  }
+
+  async getSubscription(packageName: string, purchaseToken: string): Promise<Date | null> {
+    if (!this.creds) return null;
+
+    const token = await this.getAccessToken();
+    if (!token) return null;
+
+    const url = `${ANDROIDPUBLISHER_BASE}/applications/${encodeURIComponent(packageName)}/purchases/subscriptionsv2/tokens/${encodeURIComponent(purchaseToken)}`;
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, { headers: { Authorization: `Bearer ${token}`, Accept: "application/json" } });
+    } catch (e) {
+      this.logger.warn({ err: (e as Error).message, packageName }, "google-play subscriptionsv2.get network error");
+      return null;
+    }
+    if (res.status === 401) {
+      this.tokenCache = null;
+      this.logger.error({ status: 401, packageName }, "google-play subscriptionsv2.get auth failed — cache invalidated");
+      return null;
+    }
+    if (!res.ok) {
+      this.logger.warn({ status: res.status, packageName }, "google-play subscriptionsv2.get non-ok");
+      return null;
+    }
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch (e) {
+      this.logger.warn({ err: (e as Error).message, packageName }, "google-play subscriptionsv2.get non-json body");
+      return null;
+    }
+    const v2 = body as { lineItems?: Array<{ expiryTime?: string }> };
+    const expiryTime = v2.lineItems?.[0]?.expiryTime;
+    if (typeof expiryTime !== "string" || !expiryTime) {
+      this.logger.warn({ packageName }, "google-play subscriptionsv2.get missing expiryTime");
+      return null;
+    }
+    const d = new Date(expiryTime);
+    if (isNaN(d.getTime())) {
+      this.logger.warn({ expiryTime, packageName }, "google-play subscriptionsv2.get unparseable expiryTime");
+      return null;
+    }
+    return d;
+  }
+
+  private async getAccessToken(): Promise<string | null> {
+    if (!this.creds) return null;
+    const now = Date.now();
+    if (this.tokenCache && this.tokenCache.expiresAtMs - TOKEN_SKEW_MS > now) {
+      return this.tokenCache.token;
+    }
+    const jwt = mintJwt(this.creds, Math.floor(now / 1000));
+    const body = new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: jwt,
+    }).toString();
+    let res: Response;
+    try {
+      res = await this.fetchImpl(this.creds.tokenUri, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body,
+      });
+    } catch (e) {
+      this.logger.warn({ err: (e as Error).message }, "google-play token mint network error");
+      return null;
+    }
+    if (!res.ok) {
+      this.logger.error({ status: res.status }, "google-play token mint non-ok");
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch (e) {
+      this.logger.error({ err: (e as Error).message }, "google-play token mint non-json body");
+      return null;
+    }
+    const r = parsed as { access_token?: string; expires_in?: number };
+    if (!r.access_token || typeof r.expires_in !== "number") {
+      this.logger.error({}, "google-play token mint missing access_token/expires_in");
+      return null;
+    }
+    this.tokenCache = { token: r.access_token, expiresAtMs: now + r.expires_in * 1000 };
+    return r.access_token;
+  }
+}

--- a/apps/server/src/features/billing/google-play.api-client.ts
+++ b/apps/server/src/features/billing/google-play.api-client.ts
@@ -31,34 +31,34 @@ export class GooglePlayApiClient {
     try {
       res = await this.fetchImpl(url, { headers: { Authorization: `Bearer ${token}`, Accept: "application/json" } });
     } catch (e) {
-      this.logger.warn({ err: (e as Error).message, packageName }, "google-play subscriptionsv2.get network error");
+      this.logger.warn({ err: (e as Error).message, packageName, purchaseToken }, "google-play subscriptionsv2.get network error");
       return null;
     }
     if (res.status === 401) {
       this.tokenCache = null;
-      this.logger.error({ status: 401, packageName }, "google-play subscriptionsv2.get auth failed — cache invalidated");
+      this.logger.error({ status: 401, packageName, purchaseToken }, "google-play subscriptionsv2.get auth failed — cache invalidated");
       return null;
     }
     if (!res.ok) {
-      this.logger.warn({ status: res.status, packageName }, "google-play subscriptionsv2.get non-ok");
+      this.logger.warn({ status: res.status, packageName, purchaseToken }, "google-play subscriptionsv2.get non-ok");
       return null;
     }
     let body: unknown;
     try {
       body = await res.json();
     } catch (e) {
-      this.logger.warn({ err: (e as Error).message, packageName }, "google-play subscriptionsv2.get non-json body");
+      this.logger.warn({ err: (e as Error).message, packageName, purchaseToken }, "google-play subscriptionsv2.get non-json body");
       return null;
     }
     const v2 = body as { lineItems?: Array<{ expiryTime?: string }> };
     const expiryTime = v2.lineItems?.[0]?.expiryTime;
     if (typeof expiryTime !== "string" || !expiryTime) {
-      this.logger.warn({ packageName }, "google-play subscriptionsv2.get missing expiryTime");
+      this.logger.warn({ packageName, purchaseToken }, "google-play subscriptionsv2.get missing expiryTime");
       return null;
     }
     const d = new Date(expiryTime);
     if (isNaN(d.getTime())) {
-      this.logger.warn({ expiryTime, packageName }, "google-play subscriptionsv2.get unparseable expiryTime");
+      this.logger.warn({ expiryTime, packageName, purchaseToken }, "google-play subscriptionsv2.get unparseable expiryTime");
       return null;
     }
     return d;

--- a/apps/server/src/features/billing/google-play.service-account.test.ts
+++ b/apps/server/src/features/billing/google-play.service-account.test.ts
@@ -1,0 +1,88 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  parseServiceAccount,
+  loadServiceAccountFromEnv,
+  mintJwt,
+  InvalidServiceAccountError,
+  type ServiceAccountCreds,
+} from "./google-play.service-account";
+
+const FIXTURE_PRIVATE_KEY = [
+  "-----BEGIN PRIVATE KEY-----",
+  "PLACEHOLDER",
+  "-----END PRIVATE KEY-----",
+].join("\n");
+
+describe("parseServiceAccount", () => {
+  it("parses a valid JSON with embedded newlines in private_key", () => {
+    const json = JSON.stringify({
+      client_email: "svc@proj.iam.gserviceaccount.com",
+      private_key: FIXTURE_PRIVATE_KEY,
+      token_uri: "https://oauth2.googleapis.com/token",
+    });
+    const c = parseServiceAccount(json);
+    expect(c.clientEmail).toBe("svc@proj.iam.gserviceaccount.com");
+    expect(c.privateKey).toContain("BEGIN PRIVATE KEY");
+    expect(c.tokenUri).toBe("https://oauth2.googleapis.com/token");
+  });
+
+  it("throws InvalidServiceAccountError on malformed JSON", () => {
+    expect(() => parseServiceAccount("not json")).toThrow(InvalidServiceAccountError);
+  });
+
+  it("throws when client_email is missing", () => {
+    const json = JSON.stringify({ private_key: "x", token_uri: "https://oauth2.googleapis.com/token" });
+    expect(() => parseServiceAccount(json)).toThrow(InvalidServiceAccountError);
+  });
+
+  it("throws when private_key is missing", () => {
+    const json = JSON.stringify({ client_email: "a@b", token_uri: "https://oauth2.googleapis.com/token" });
+    expect(() => parseServiceAccount(json)).toThrow(InvalidServiceAccountError);
+  });
+});
+
+describe("loadServiceAccountFromEnv", () => {
+  it("returns null when env var is undefined", () => {
+    expect(loadServiceAccountFromEnv({ GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: undefined })).toBeNull();
+  });
+
+  it("returns parsed creds when env var is present", () => {
+    const json = JSON.stringify({
+      client_email: "svc@proj.iam.gserviceaccount.com",
+      private_key: FIXTURE_PRIVATE_KEY,
+      token_uri: "https://oauth2.googleapis.com/token",
+    });
+    const c = loadServiceAccountFromEnv({ GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: json });
+    expect(c).not.toBeNull();
+    expect(c!.clientEmail).toBe("svc@proj.iam.gserviceaccount.com");
+  });
+});
+
+describe("mintJwt", () => {
+  let creds: ServiceAccountCreds;
+  beforeAll(async () => {
+    const { generateKeyPairSync } = await import("node:crypto");
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+    creds = { clientEmail: "a@b.com", privateKey, tokenUri: "https://oauth2.googleapis.com/token" };
+  });
+
+  it("produces a 3-segment base64url JWT with RS256 header and expected claims", () => {
+    const now = 1747000000;
+    const jwt = mintJwt(creds, now);
+    const [h, p, s] = jwt.split(".");
+    expect(h && p && s).toBeTruthy();
+    const header = JSON.parse(Buffer.from(h!, "base64url").toString("utf-8"));
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+    const payload = JSON.parse(Buffer.from(p!, "base64url").toString("utf-8"));
+    expect(payload.iss).toBe("a@b.com");
+    expect(payload.scope).toBe("https://www.googleapis.com/auth/androidpublisher");
+    expect(payload.aud).toBe("https://oauth2.googleapis.com/token");
+    expect(payload.iat).toBe(now);
+    expect(payload.exp).toBe(now + 3600);
+    expect(Buffer.from(s!, "base64url").length).toBe(256); // RS256 over a 2048-bit key
+  });
+});

--- a/apps/server/src/features/billing/google-play.service-account.ts
+++ b/apps/server/src/features/billing/google-play.service-account.ts
@@ -1,0 +1,74 @@
+import { createSign } from "node:crypto";
+
+export class InvalidServiceAccountError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "InvalidServiceAccountError";
+  }
+}
+
+export type ServiceAccountCreds = {
+  clientEmail: string;
+  privateKey: string; // PEM-encoded RSA private key
+  tokenUri: string;
+};
+
+export function parseServiceAccount(json: string): ServiceAccountCreds {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(json);
+  } catch (e) {
+    throw new InvalidServiceAccountError(`Invalid JSON: ${(e as Error).message}`);
+  }
+  if (!obj || typeof obj !== "object") {
+    throw new InvalidServiceAccountError("Parsed value is not an object");
+  }
+  const o = obj as Record<string, unknown>;
+  if (typeof o.client_email !== "string" || !o.client_email) {
+    throw new InvalidServiceAccountError("Missing client_email");
+  }
+  if (typeof o.private_key !== "string" || !o.private_key) {
+    throw new InvalidServiceAccountError("Missing private_key");
+  }
+  const tokenUri =
+    typeof o.token_uri === "string" && o.token_uri
+      ? o.token_uri
+      : "https://oauth2.googleapis.com/token";
+  return { clientEmail: o.client_email, privateKey: o.private_key, tokenUri };
+}
+
+export function loadServiceAccountFromEnv(env: {
+  GOOGLE_PLAY_SERVICE_ACCOUNT_JSON?: string;
+}): ServiceAccountCreds | null {
+  if (!env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON) return null;
+  return parseServiceAccount(env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
+}
+
+const SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+/** Mints an RS256-signed JWT bearer assertion. `nowSeconds` allows deterministic tests. */
+export function mintJwt(
+  creds: ServiceAccountCreds,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): string {
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    iss: creds.clientEmail,
+    scope: SCOPE,
+    aud: creds.tokenUri,
+    iat: nowSeconds,
+    exp: nowSeconds + 3600,
+  };
+  const encHeader = base64url(Buffer.from(JSON.stringify(header), "utf-8"));
+  const encPayload = base64url(Buffer.from(JSON.stringify(payload), "utf-8"));
+  const signingInput = `${encHeader}.${encPayload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(creds.privateKey);
+  return `${signingInput}.${base64url(signature)}`;
+}

--- a/apps/server/src/workers/billing-sweep.worker.ts
+++ b/apps/server/src/workers/billing-sweep.worker.ts
@@ -6,6 +6,8 @@ import { BillingRepository } from "../features/billing/billing.repository";
 import { BillingService } from "../features/billing/billing.service";
 import { UltraService } from "../features/ultra/ultra.service";
 import { UltraRepository } from "../features/ultra/ultra.repository";
+import { loadServiceAccountFromEnv } from "../features/billing/google-play.service-account";
+import { GooglePlayApiClient } from "../features/billing/google-play.api-client";
 
 type BillingSweepJobData = { kind: "sweep" };
 
@@ -18,7 +20,8 @@ export function startBillingSweepWorker() {
   const connection = parseRedisUrl(env.REDIS_URL);
   const repo = new BillingRepository();
   const ultra = new UltraService(new UltraRepository(db));   // canonical construction per billing.route.ts:16
-  const service = new BillingService(db, repo, ultra);
+  const apiClient = new GooglePlayApiClient(loadServiceAccountFromEnv(env));
+  const service = new BillingService(db, repo, ultra, apiClient, env.GOOGLE_PLAY_PACKAGE_NAME ?? null);
 
   const worker = new Worker<BillingSweepJobData>(
     "billing-cron",

--- a/docs/superpowers/plans/2026-05-12-phase-2e8-google-play-real-expiry.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2e8-google-play-real-expiry.md
@@ -1,0 +1,841 @@
+# Phase 2E.8 — Google Play real `expiryTime` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` with Sonnet 4.6 implementers and Opus 4.7 reviewers. Every task ends with both spec-compliance and code-quality reviews. Branch already created: `feature/phase-2e8-google-play-real-expiry`.
+
+**Goal:** Replace the 30-day default `currentPeriodEnd` for Google Play grant events with the real `expiryTime` from `androidpublisher.purchases.subscriptionsv2.get`. Optional env var; fully backward-compatible when absent.
+
+**Architecture:** New `GooglePlayApiClient` minting OAuth2 JWT-bearer tokens + calling the v2 endpoint. `BillingService.processGooglePlayEnvelope` looks up `realExpiryTime` for grant events BEFORE the per-event TX and passes it as a new optional 3rd arg to `applyDecodedEvent`. Replay path keeps the existing 30-day fallback. All failures are logged + fall back; nothing blocks the webhook.
+
+**Tech Stack:** node:crypto (RS256), global `fetch` (Bun), Fastify pino logger, neverthrow, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-phase-2e8-google-play-real-expiry-design.md`
+
+---
+
+## File map
+
+**Create:**
+- `apps/server/src/features/billing/google-play.service-account.ts` — JSON parsing + `loadServiceAccountFromEnv`, `mintJwt`.
+- `apps/server/src/features/billing/google-play.service-account.test.ts` — pure unit.
+- `apps/server/src/features/billing/google-play.api-client.ts` — class with `getSubscription` + token cache.
+- `apps/server/src/features/billing/google-play.api-client.test.ts` — mocked-fetch unit.
+
+**Modify:**
+- `packages/env/src/server.ts` — add two optional env vars.
+- `apps/server/src/features/billing/billing.service.ts` — `BillingService` constructor (adds `apiClient` + `packageNameFallback: string | null`) + `processGooglePlayEnvelope` + `applyDecodedEvent` signature. NOTE: the service does NOT import `env` directly — `packageNameFallback` is injected at the composition root (route + worker) to keep the service env-free, consistent with the existing dependency-injection pattern (db, repo, ultra are all injected, not imported).
+- `apps/server/src/features/billing/billing.service.test.ts` — update `buildSut` to pass the new ctor args (stub api client, null fallback); add new cases for the real-expiry path.
+- `apps/server/src/features/billing/billing.route.ts` — construct + pass `apiClient` + `env.GOOGLE_PLAY_PACKAGE_NAME ?? null` into `BillingService`.
+- `apps/server/src/workers/billing-sweep.worker.ts` — same construction update (5 args: db, repo, ultra, apiClient, packageNameFallback). The sweep worker never calls `processGooglePlayEnvelope`, so it can use `new GooglePlayApiClient(null)` (no-op client) and `null` fallback — but the 4-arg signature must still be satisfied for TypeScript.
+- `apps/server/src/features/billing/billing-sweep.service.test.ts` — every inline `new BillingService(fakeDb, repo, ultra)` (5 sites — search the file) becomes the 5-arg form. Use `{ getSubscription: vi.fn() } as unknown as GooglePlayApiClient` and `null` for the new args.
+- `apps/server/src/features/billing/billing-sweep.integration.test.ts` — the `beforeEach` construction in this file becomes the 5-arg form. Use `new GooglePlayApiClient(null)` and `null`.
+
+---
+
+### Task 1: Env vars
+
+**Files:**
+- Modify: `packages/env/src/server.ts`
+
+- [ ] **Step 1: Add the two optional env vars** after `APP_STORE_WEBHOOK_TOKEN`:
+
+```ts
+GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: z.string().optional(),
+GOOGLE_PLAY_PACKAGE_NAME: z.string().optional(),
+```
+
+- [ ] **Step 2: Typecheck.**
+
+Run: `bun --cwd apps/server check-types`. No NEW errors expected — pre-existing errors in `sessions/`, `invitations/`, etc. are not your responsibility.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/env/src/server.ts
+git commit -m "feat(env): add optional google play service-account + package name vars"
+```
+
+---
+
+### Task 2: Service-account parser + JWT minter
+
+**Files:**
+- Create: `apps/server/src/features/billing/google-play.service-account.ts`
+- Create: `apps/server/src/features/billing/google-play.service-account.test.ts`
+
+- [ ] **Step 1: Write failing unit tests.**
+
+```ts
+// google-play.service-account.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  parseServiceAccount,
+  loadServiceAccountFromEnv,
+  mintJwt,
+  InvalidServiceAccountError,
+  type ServiceAccountCreds,
+} from "./google-play.service-account";
+
+const FIXTURE_PRIVATE_KEY = [
+  "-----BEGIN PRIVATE KEY-----",
+  // a real 2048-bit PKCS#8 RSA key. Generate once locally for the test fixture:
+  //   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -outform PEM
+  //   then base64-encode for safer embedding here. For this test the actual key bytes
+  //   don't matter for parseServiceAccount; only mintJwt cares (it needs RS256-signable PEM).
+  // Implementer: use `crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })` in a
+  // `beforeAll` instead and inject the resulting PEM into the fixture creds.
+  "PLACEHOLDER",
+  "-----END PRIVATE KEY-----",
+].join("\n");
+
+describe("parseServiceAccount", () => {
+  it("parses a valid JSON with embedded newlines in private_key", () => {
+    const json = JSON.stringify({
+      client_email: "svc@proj.iam.gserviceaccount.com",
+      private_key: FIXTURE_PRIVATE_KEY,
+      token_uri: "https://oauth2.googleapis.com/token",
+    });
+    const c = parseServiceAccount(json);
+    expect(c.clientEmail).toBe("svc@proj.iam.gserviceaccount.com");
+    expect(c.privateKey).toContain("BEGIN PRIVATE KEY");
+    expect(c.tokenUri).toBe("https://oauth2.googleapis.com/token");
+  });
+
+  it("throws InvalidServiceAccountError on malformed JSON", () => {
+    expect(() => parseServiceAccount("not json")).toThrow(InvalidServiceAccountError);
+  });
+
+  it("throws when client_email is missing", () => {
+    const json = JSON.stringify({ private_key: "x", token_uri: "https://oauth2.googleapis.com/token" });
+    expect(() => parseServiceAccount(json)).toThrow(InvalidServiceAccountError);
+  });
+
+  it("throws when private_key is missing", () => {
+    const json = JSON.stringify({ client_email: "a@b", token_uri: "https://oauth2.googleapis.com/token" });
+    expect(() => parseServiceAccount(json)).toThrow(InvalidServiceAccountError);
+  });
+});
+
+describe("loadServiceAccountFromEnv", () => {
+  it("returns null when env var is undefined", () => {
+    expect(loadServiceAccountFromEnv({ GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: undefined })).toBeNull();
+  });
+
+  it("returns parsed creds when env var is present", () => {
+    const json = JSON.stringify({
+      client_email: "svc@proj.iam.gserviceaccount.com",
+      private_key: FIXTURE_PRIVATE_KEY,
+      token_uri: "https://oauth2.googleapis.com/token",
+    });
+    const c = loadServiceAccountFromEnv({ GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: json });
+    expect(c).not.toBeNull();
+    expect(c!.clientEmail).toBe("svc@proj.iam.gserviceaccount.com");
+  });
+});
+
+describe("mintJwt", () => {
+  let creds: ServiceAccountCreds;
+  beforeAll(async () => {
+    const { generateKeyPairSync } = await import("node:crypto");
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+    creds = { clientEmail: "a@b.com", privateKey, tokenUri: "https://oauth2.googleapis.com/token" };
+  });
+
+  it("produces a 3-segment base64url JWT with RS256 header and expected claims", () => {
+    const now = 1747000000;
+    const jwt = mintJwt(creds, now);
+    const [h, p, s] = jwt.split(".");
+    expect(h && p && s).toBeTruthy();
+    const header = JSON.parse(Buffer.from(h!, "base64url").toString("utf-8"));
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+    const payload = JSON.parse(Buffer.from(p!, "base64url").toString("utf-8"));
+    expect(payload.iss).toBe("a@b.com");
+    expect(payload.scope).toBe("https://www.googleapis.com/auth/androidpublisher");
+    expect(payload.aud).toBe("https://oauth2.googleapis.com/token");
+    expect(payload.iat).toBe(now);
+    expect(payload.exp).toBe(now + 3600);
+    expect(Buffer.from(s!, "base64url").length).toBe(256); // RS256 over a 2048-bit key
+  });
+});
+```
+
+NOTE: Replace `FIXTURE_PRIVATE_KEY` with a real PEM generated in a `beforeAll` via `crypto.generateKeyPairSync('rsa', { modulusLength: 2048, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs8', format: 'pem' } })`. Hardcoding a key into the source tree is fine for tests but generating is cleaner. The `parseServiceAccount` cases that don't actually verify the signature can keep a literal `"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"` placeholder string.
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+Run: `bun test apps/server/src/features/billing/google-play.service-account.test.ts`
+
+- [ ] **Step 3: Implement the module.**
+
+```ts
+// google-play.service-account.ts
+import { createSign } from "node:crypto";
+
+export class InvalidServiceAccountError extends Error {
+  constructor(msg: string) { super(msg); this.name = "InvalidServiceAccountError"; }
+}
+
+export type ServiceAccountCreds = {
+  clientEmail: string;
+  privateKey: string;   // PEM-encoded RSA private key
+  tokenUri: string;
+};
+
+export function parseServiceAccount(json: string): ServiceAccountCreds {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(json);
+  } catch (e) {
+    throw new InvalidServiceAccountError(`Invalid JSON: ${(e as Error).message}`);
+  }
+  if (!obj || typeof obj !== "object") {
+    throw new InvalidServiceAccountError("Parsed value is not an object");
+  }
+  const o = obj as Record<string, unknown>;
+  if (typeof o.client_email !== "string" || !o.client_email) {
+    throw new InvalidServiceAccountError("Missing client_email");
+  }
+  if (typeof o.private_key !== "string" || !o.private_key) {
+    throw new InvalidServiceAccountError("Missing private_key");
+  }
+  const tokenUri = typeof o.token_uri === "string" && o.token_uri ? o.token_uri : "https://oauth2.googleapis.com/token";
+  return { clientEmail: o.client_email, privateKey: o.private_key, tokenUri };
+}
+
+export function loadServiceAccountFromEnv(env: { GOOGLE_PLAY_SERVICE_ACCOUNT_JSON?: string }): ServiceAccountCreds | null {
+  if (!env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON) return null;
+  return parseServiceAccount(env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
+}
+
+const SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+/** Mints an RS256-signed JWT bearer assertion. `nowSeconds` allows deterministic tests. */
+export function mintJwt(creds: ServiceAccountCreds, nowSeconds: number = Math.floor(Date.now() / 1000)): string {
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    iss: creds.clientEmail,
+    scope: SCOPE,
+    aud: creds.tokenUri,
+    iat: nowSeconds,
+    exp: nowSeconds + 3600,
+  };
+  const encHeader = base64url(Buffer.from(JSON.stringify(header), "utf-8"));
+  const encPayload = base64url(Buffer.from(JSON.stringify(payload), "utf-8"));
+  const signingInput = `${encHeader}.${encPayload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(creds.privateKey);
+  return `${signingInput}.${base64url(signature)}`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+Run: `bun test apps/server/src/features/billing/google-play.service-account.test.ts`
+
+- [ ] **Step 5: Typecheck and commit.**
+
+```bash
+bun --cwd apps/server check-types
+git add apps/server/src/features/billing/google-play.service-account.ts apps/server/src/features/billing/google-play.service-account.test.ts
+git commit -m "feat(billing): add google-play service-account parser + jwt minter"
+```
+
+---
+
+### Task 3: `GooglePlayApiClient` with mocked-fetch tests
+
+**Files:**
+- Create: `apps/server/src/features/billing/google-play.api-client.ts`
+- Create: `apps/server/src/features/billing/google-play.api-client.test.ts`
+
+- [ ] **Step 1: Write failing unit tests** in `google-play.api-client.test.ts`. Mock `fetchImpl` via the constructor — do NOT use `vi.stubGlobal`.
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { GooglePlayApiClient } from "./google-play.api-client";
+import type { ServiceAccountCreds } from "./google-play.service-account";
+import { generateKeyPairSync } from "node:crypto";
+
+function makeCreds(): ServiceAccountCreds {
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { clientEmail: "svc@proj.iam.gserviceaccount.com", privateKey, tokenUri: "https://oauth2.googleapis.com/token" };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+function nonJsonResponse(body: string, status = 200): Response {
+  return new Response(body, { status, headers: { "content-type": "text/html" } });
+}
+
+describe("GooglePlayApiClient", () => {
+  let creds: ServiceAccountCreds;
+  let fetchImpl: ReturnType<typeof vi.fn>;
+  let logger: { warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    creds = makeCreds();
+    fetchImpl = vi.fn();
+    logger = { warn: vi.fn(), error: vi.fn() };
+  });
+
+  it("returns null without HTTP call when creds is null", async () => {
+    const client = new GooglePlayApiClient(null, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("happy path: mints token, fetches subscription, returns Date from lineItems[0].expiryTime", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ productId: "ultra_monthly", expiryTime: "2026-06-12T15:30:00Z" }] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok-1");
+    expect(r).toEqual(new Date("2026-06-12T15:30:00Z"));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    // assert URL shape
+    expect(fetchImpl.mock.calls[1]![0]).toBe(
+      "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/com.pkg/purchases/subscriptionsv2/tokens/tok-1",
+    );
+  });
+
+  it("caches the access token across calls within TTL", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-06-12T00:00:00Z" }] }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-07-12T00:00:00Z" }] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    await client.getSubscription("com.pkg", "tok-a");
+    await client.getSubscription("com.pkg", "tok-b");
+    expect(fetchImpl).toHaveBeenCalledTimes(3);   // 1 token + 2 v2 calls (NOT 4)
+  });
+
+  it("refreshes token after TTL elapses", async () => {
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    // Mint a token that's already near expiry
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 60, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-06-12T00:00:00Z" }] }));
+    await client.getSubscription("com.pkg", "tok-a");
+
+    // Advance internal clock past the cached token's TTL minus skew
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 70_000);
+
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT2", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-07-12T00:00:00Z" }] }));
+    await client.getSubscription("com.pkg", "tok-b");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    vi.useRealTimers();
+  });
+
+  it("returns null on tokens endpoint 401 AND invalidates cached token", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(new Response("", { status: 401 }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    await client.getSubscription("com.pkg", "tok-a");   // primes cache
+    // Now force v2 endpoint to fail with 401 — note: 401 from v2 (not tokens) invalidates the cache.
+    expect(logger.error).toHaveBeenCalled();
+    // Next call should mint fresh token
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT2", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2026-07-12T00:00:00Z" }] }));
+    const r = await client.getSubscription("com.pkg", "tok-b");
+    expect(r).toEqual(new Date("2026-07-12T00:00:00Z"));
+    expect(fetchImpl).toHaveBeenCalledTimes(4);   // 2 token mints + 2 v2 calls
+  });
+
+  it("returns null when tokens endpoint returns non-JSON body", async () => {
+    fetchImpl.mockResolvedValueOnce(nonJsonResponse("<html>proxy error</html>", 200));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("returns null on v2 404", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(new Response("", { status: 404 }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on v2 500", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(new Response("", { status: 500 }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on empty lineItems", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on missing expiryTime", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ productId: "ultra" }] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on network throw at tokens endpoint", async () => {
+    fetchImpl.mockRejectedValueOnce(new Error("ECONNRESET"));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns null on network throw at v2 endpoint", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockRejectedValueOnce(new Error("ECONNRESET"));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toBeNull();
+  });
+
+  it("returns past expiryTime as-is (trust google; sweep reconciles)", async () => {
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ access_token: "AT1", expires_in: 3600, token_type: "Bearer" }));
+    fetchImpl.mockResolvedValueOnce(jsonResponse({ lineItems: [{ expiryTime: "2020-01-01T00:00:00Z" }] }));
+    const client = new GooglePlayApiClient(creds, { fetchImpl: fetchImpl as unknown as typeof fetch, logger });
+    const r = await client.getSubscription("com.pkg", "tok");
+    expect(r).toEqual(new Date("2020-01-01T00:00:00Z"));   // past, not null
+  });
+});
+```
+
+NOTE on the 401-invalidation test: the spec says **401 from the v2 endpoint** invalidates the cached token (the token might be valid against the auth server but rejected by the resource server — common with rotated keys). A 401 from the **tokens endpoint** is a separate flow that also returns null but where there's nothing to invalidate (no token was ever cached). Implementer: make sure both paths work and the test asserts the cache-invalidation behavior on the v2-401 path specifically.
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+Run: `bun test apps/server/src/features/billing/google-play.api-client.test.ts`
+
+- [ ] **Step 3: Implement `GooglePlayApiClient`.**
+
+```ts
+// google-play.api-client.ts
+import { mintJwt, type ServiceAccountCreds } from "./google-play.service-account";
+
+type Logger = { warn: (...args: unknown[]) => void; error: (...args: unknown[]) => void };
+
+type TokenCache = { token: string; expiresAtMs: number } | null;
+
+const TOKEN_SKEW_MS = 60_000;
+const ANDROIDPUBLISHER_BASE = "https://androidpublisher.googleapis.com/androidpublisher/v3";
+
+export class GooglePlayApiClient {
+  private tokenCache: TokenCache = null;
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger: Logger;
+
+  constructor(
+    private readonly creds: ServiceAccountCreds | null,
+    opts: { fetchImpl?: typeof fetch; logger?: Logger } = {},
+  ) {
+    this.fetchImpl = opts.fetchImpl ?? ((...args) => globalThis.fetch(...args));
+    this.logger = opts.logger ?? { warn: console.warn.bind(console), error: console.error.bind(console) };
+  }
+
+  async getSubscription(packageName: string, purchaseToken: string): Promise<Date | null> {
+    if (!this.creds) return null;
+
+    const token = await this.getAccessToken();
+    if (!token) return null;
+
+    const url = `${ANDROIDPUBLISHER_BASE}/applications/${encodeURIComponent(packageName)}/purchases/subscriptionsv2/tokens/${encodeURIComponent(purchaseToken)}`;
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, { headers: { Authorization: `Bearer ${token}`, Accept: "application/json" } });
+    } catch (e) {
+      this.logger.warn({ err: (e as Error).message, packageName }, "google-play subscriptionsv2.get network error");
+      return null;
+    }
+    if (res.status === 401) {
+      this.tokenCache = null;
+      this.logger.error({ status: 401, packageName }, "google-play subscriptionsv2.get auth failed — cache invalidated");
+      return null;
+    }
+    if (!res.ok) {
+      this.logger.warn({ status: res.status, packageName }, "google-play subscriptionsv2.get non-ok");
+      return null;
+    }
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch (e) {
+      this.logger.warn({ err: (e as Error).message, packageName }, "google-play subscriptionsv2.get non-json body");
+      return null;
+    }
+    const v2 = body as { lineItems?: Array<{ expiryTime?: string }> };
+    const expiryTime = v2.lineItems?.[0]?.expiryTime;
+    if (typeof expiryTime !== "string" || !expiryTime) {
+      this.logger.warn({ packageName }, "google-play subscriptionsv2.get missing expiryTime");
+      return null;
+    }
+    const d = new Date(expiryTime);
+    if (isNaN(d.getTime())) {
+      this.logger.warn({ expiryTime, packageName }, "google-play subscriptionsv2.get unparseable expiryTime");
+      return null;
+    }
+    return d;
+  }
+
+  private async getAccessToken(): Promise<string | null> {
+    if (!this.creds) return null;
+    const now = Date.now();
+    if (this.tokenCache && this.tokenCache.expiresAtMs - TOKEN_SKEW_MS > now) {
+      return this.tokenCache.token;
+    }
+    const jwt = mintJwt(this.creds, Math.floor(now / 1000));
+    const body = new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: jwt,
+    }).toString();
+    let res: Response;
+    try {
+      res = await this.fetchImpl(this.creds.tokenUri, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body,
+      });
+    } catch (e) {
+      this.logger.warn({ err: (e as Error).message }, "google-play token mint network error");
+      return null;
+    }
+    if (!res.ok) {
+      this.logger.error({ status: res.status }, "google-play token mint non-ok");
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch (e) {
+      this.logger.error({ err: (e as Error).message }, "google-play token mint non-json body");
+      return null;
+    }
+    const r = parsed as { access_token?: string; expires_in?: number };
+    if (!r.access_token || typeof r.expires_in !== "number") {
+      this.logger.error({ }, "google-play token mint missing access_token/expires_in");
+      return null;
+    }
+    this.tokenCache = { token: r.access_token, expiresAtMs: now + r.expires_in * 1000 };
+    return r.access_token;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+Run: `bun test apps/server/src/features/billing/google-play.api-client.test.ts`
+
+- [ ] **Step 5: Typecheck and commit.**
+
+```bash
+bun --cwd apps/server check-types
+git add apps/server/src/features/billing/google-play.api-client.ts apps/server/src/features/billing/google-play.api-client.test.ts
+git commit -m "feat(billing): add google-play api client with oauth2 token cache"
+```
+
+---
+
+### Task 4: Service integration — `BillingService` constructor + `applyDecodedEvent` signature + `processGooglePlayEnvelope` wiring
+
+**Files:**
+- Modify: `apps/server/src/features/billing/billing.service.ts`
+- Modify: `apps/server/src/features/billing/billing.service.test.ts`
+
+- [ ] **Step 1: Update `BillingService.test.ts`** to construct the service with a new 4th arg (a stub api client). This is the failing-test step — read the current test setup at `billing.service.test.ts:30-41` first.
+
+Add at the top of the test file:
+
+```ts
+import type { GooglePlayApiClient } from "./google-play.api-client";
+
+function makeStubApiClient(realExpiry: Date | null = null): GooglePlayApiClient {
+  return {
+    getSubscription: vi.fn().mockResolvedValue(realExpiry),
+  } as unknown as GooglePlayApiClient;
+}
+```
+
+Update `buildSut` to accept an optional `apiClient` override and pass it as the 4th ctor arg:
+
+```ts
+function buildSut(opts: { ...existing..., apiClient?: GooglePlayApiClient } = {}) {
+  // ... existing ...
+  const apiClient = opts.apiClient ?? makeStubApiClient(null);
+  const service = new BillingService(db, repo as unknown as BillingRepository, ultra as unknown as UltraService, apiClient);
+  return { service, repo, ultra, db, apiClient };
+}
+```
+
+Add NEW tests after the existing ones:
+
+```ts
+describe("real expiryTime override", () => {
+  it("RENEWED with apiClient returning a real expiry uses that date for currentPeriodEnd and grant", async () => {
+    const realExpiry = new Date("2026-06-12T15:30:00Z");
+    const linked: SubscriptionRow = { id: 20, userId: "u2", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service, repo, ultra } = buildSut({ findSubscription: linked, apiClient: makeStubApiClient(realExpiry) });
+    const r = await service.processGooglePlayEnvelope(buildEnvelope(2));   // RENEWED
+    expect(r.isOk()).toBe(true);
+    expect(repo.updateSubscriptionState).toHaveBeenCalledWith(expect.anything(), 20, expect.objectContaining({ status: "active", currentPeriodEnd: realExpiry }));
+    expect(ultra.grant).toHaveBeenCalledWith("u2", realExpiry);
+  });
+
+  it("RENEWED with apiClient returning null falls back to now + 30d", async () => {
+    const linked: SubscriptionRow = { id: 21, userId: "u3", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: null, linkedAt: new Date() };
+    const { service, repo } = buildSut({ findSubscription: linked, apiClient: makeStubApiClient(null) });
+    const before = Date.now();
+    const r = await service.processGooglePlayEnvelope(buildEnvelope(2));
+    expect(r.isOk()).toBe(true);
+    const call = repo.updateSubscriptionState.mock.calls[0]!;
+    const end = call[2].currentPeriodEnd as Date;
+    const expected = before + 30 * 24 * 60 * 60 * 1000;
+    expect(end.getTime()).toBeGreaterThanOrEqual(expected - 1000);
+    expect(end.getTime()).toBeLessThanOrEqual(expected + 5000);
+  });
+
+  it("non-grant events (CANCELED) do NOT call apiClient.getSubscription", async () => {
+    const linked: SubscriptionRow = { id: 22, userId: "u4", provider: "google_play", productId: "p", purchaseToken: "tok", status: "active", currentPeriodEnd: new Date("2026-12-01"), linkedAt: new Date() };
+    const apiClient = makeStubApiClient(new Date("2026-06-12T00:00:00Z"));
+    const { service } = buildSut({ findSubscription: linked, apiClient });
+    await service.processGooglePlayEnvelope(buildEnvelope(3));   // CANCELED
+    expect(apiClient.getSubscription).not.toHaveBeenCalled();
+  });
+
+  it("unknown notificationType does NOT call apiClient.getSubscription", async () => {
+    const apiClient = makeStubApiClient(new Date("2026-06-12T00:00:00Z"));
+    const { service } = buildSut({ apiClient });
+    await service.processGooglePlayEnvelope(buildEnvelope(99));
+    expect(apiClient.getSubscription).not.toHaveBeenCalled();
+  });
+});
+```
+
+Also update every existing test that constructs `BillingService` directly (search the file — there may be ad-hoc constructions outside `buildSut`). Apply the same 4-arg form.
+
+- [ ] **Step 2: Run tests to verify the failures and that the new cases also fail (because the service hasn't been updated yet).**
+
+Run: `bun test apps/server/src/features/billing/billing.service.test.ts`
+
+- [ ] **Step 3: Update `BillingService` constructor and `applyDecodedEvent`.**
+
+```ts
+// billing.service.ts top section
+import type { GooglePlayApiClient } from "./google-play.api-client";
+
+const GRANT_TYPES: ReadonlySet<string> = new Set(["PURCHASED", "RENEWED", "RECOVERED", "RESTARTED"]);
+
+export class BillingService {
+  constructor(
+    private db: Db,
+    private repo: BillingRepository,
+    private ultra: UltraService,
+    private apiClient: GooglePlayApiClient,   // NEW
+    private packageNameFallback: string | null,   // NEW — injected from env at the composition root
+  ) {}
+```
+
+NOTE: `GRANT_TYPES` is a **module-scope** constant (top of file, outside the class) so the Set is allocated once at module load, not per webhook call. Do NOT redeclare it inside `processGooglePlayEnvelope`.
+
+NOTE: do NOT `import { env } from "@pruvi/env/server"` inside `billing.service.ts`. The service layer must stay env-free. The `packageNameFallback` constructor arg supplies the value at construction time from the composition root.
+
+Then update `applyDecodedEvent` to accept the optional 3rd arg:
+
+```ts
+applyDecodedEvent(
+  decoded: DecodedGooglePlayEvent,
+  sub: SubscriptionRow,
+  realExpiryTime?: Date | null,
+): { newStatus: SubscriptionStatus; newPeriodEnd: Date | null; ultraEffect: PostCommitUltraEffect } {
+  if (decoded.kind !== "subscription") {
+    return { newStatus: sub.status, newPeriodEnd: sub.currentPeriodEnd, ultraEffect: { kind: "none" } };
+  }
+  const now = new Date();
+  const defaultEnd = new Date(now.getTime() + DEFAULT_SUBSCRIPTION_PERIOD_MS);
+  const grantEnd = realExpiryTime ?? defaultEnd;
+  const name = decoded.notificationTypeName;
+  const grant = (end: Date): PostCommitUltraEffect =>
+    sub.userId !== null
+      ? { kind: "grant", userId: sub.userId, expiresAt: end, excludeSubscriptionId: sub.id }
+      : { kind: "none" };
+  // revoke unchanged ...
+
+  switch (name) {
+    case "PURCHASED":
+    case "RENEWED":
+    case "RECOVERED":
+    case "RESTARTED":
+      return { newStatus: "active", newPeriodEnd: grantEnd, ultraEffect: grant(grantEnd) };
+    // all other cases unchanged
+  }
+}
+```
+
+- [ ] **Step 4: Update `processGooglePlayEnvelope`** to look up `realExpiryTime` BEFORE the TX for grant events.
+
+Insert this block **inside** `processGooglePlayEnvelope`, immediately after the decode + test-branch early return and BEFORE `this.db.transaction(...)`:
+
+```ts
+let realExpiryTime: Date | null = null;
+if (decoded.kind === "subscription" && GRANT_TYPES.has(decoded.notificationTypeName)) {
+  const packageName = decoded.packageName || this.packageNameFallback || null;
+  if (!packageName) {
+    console.warn({ messageId: decoded.messageId, reason: "no_package_name" }, "google-play real-expiry fallback");
+  } else {
+    realExpiryTime = await this.apiClient.getSubscription(packageName, decoded.purchaseToken);
+  }
+}
+```
+
+Then update the call to `applyDecodedEvent` inside the TX from `this.applyDecodedEvent(decoded, sub)` to `this.applyDecodedEvent(decoded, sub, realExpiryTime)`. There is exactly ONE such call in `processGooglePlayEnvelope` (around line 79 of current source — verify by reading the file). Leave the replay call in `linkGooglePlayPurchase` (around line 130) UNCHANGED — it correctly defaults to null per spec §4.1.
+
+Add a comment above the replay call:
+
+```ts
+// NOTE: replay intentionally omits realExpiryTime (3rd arg) — see spec §4.1.
+// Reason: outbound API call inside the link TX would hold row locks for 100ms+
+// and could deadlock. The next live webhook reconciles the period end.
+const { newStatus, newPeriodEnd, ultraEffect } = this.applyDecodedEvent(decoded, sub);
+```
+
+**No `env` import added to `billing.service.ts`.** The package-name fallback is read from `this.packageNameFallback` (constructor arg, set by the route/worker from `env.GOOGLE_PLAY_PACKAGE_NAME ?? null`).
+
+- [ ] **Step 5: Run all billing tests to verify they pass.**
+
+Run: `bun test apps/server/src/features/billing/`
+
+- [ ] **Step 6: Typecheck and commit.**
+
+```bash
+bun --cwd apps/server check-types
+git add apps/server/src/features/billing/billing.service.ts apps/server/src/features/billing/billing.service.test.ts
+git commit -m "feat(billing): wire google play real expiryTime through state machine"
+```
+
+---
+
+### Task 5: Wire composition roots — route + sweep worker + sweep tests
+
+**Files:**
+- Modify: `apps/server/src/features/billing/billing.route.ts`
+- Modify: `apps/server/src/workers/billing-sweep.worker.ts`
+- Modify: `apps/server/src/features/billing/billing-sweep.service.test.ts` (5 inline construction sites)
+- Modify: `apps/server/src/features/billing/billing-sweep.integration.test.ts` (1 inline construction site)
+
+- [ ] **Step 1: Construct the api client + service-account at module level**, alongside the existing `repo`/`ultra`/`service`. Insert after line 13's imports and the new imports:
+
+```ts
+import { loadServiceAccountFromEnv } from "./google-play.service-account";
+import { GooglePlayApiClient } from "./google-play.api-client";
+
+// ... existing ...
+
+const creds = loadServiceAccountFromEnv(env);
+const apiClient = new GooglePlayApiClient(creds);
+// fastify.log is not available at module-init time. The api client uses console as its
+// default logger; switching to fastify.log would require moving construction inside the
+// plugin function, which we intentionally avoid to keep service construction stable.
+```
+
+- [ ] **Step 2: Pass `apiClient` + package-name fallback to the service constructor.**
+
+```ts
+const service = new BillingService(db, repo, ultra, apiClient, env.GOOGLE_PLAY_PACKAGE_NAME ?? null);
+```
+
+- [ ] **Step 3: Update `billing-sweep.worker.ts` (same composition root pattern).** The sweep worker never processes webhooks, but its `BillingService` instance must still satisfy the 5-arg ctor for TypeScript. Add at the top of the imports:
+
+```ts
+import { loadServiceAccountFromEnv } from "../features/billing/google-play.service-account";
+import { GooglePlayApiClient } from "../features/billing/google-play.api-client";
+import { env } from "@pruvi/env/server";   // verify import path matches the file's existing style
+```
+
+Inside `startBillingSweepWorker`, after `const ultra = new UltraService(...)`:
+
+```ts
+const apiClient = new GooglePlayApiClient(loadServiceAccountFromEnv(env));
+const service = new BillingService(db, repo, ultra, apiClient, env.GOOGLE_PLAY_PACKAGE_NAME ?? null);
+```
+
+(Constructing the api client here is harmless: the sweep never calls `processGooglePlayEnvelope`, so `getSubscription` is never invoked. Keeping the construction identical to the route means any future direct sweep-side need for the client is already wired.)
+
+- [ ] **Step 4: Update `billing-sweep.service.test.ts` (5 inline constructions).** Search the file for `new BillingService(` — there are 5 occurrences inside `it(...)` blocks. Each currently reads:
+
+```ts
+const svc = new BillingService(fakeDb, repo, ultra);
+```
+
+Change each to:
+
+```ts
+const apiClient = { getSubscription: vi.fn() } as unknown as GooglePlayApiClient;
+const svc = new BillingService(fakeDb, repo, ultra, apiClient, null);
+```
+
+Add the import at top of file:
+
+```ts
+import type { GooglePlayApiClient } from "./google-play.api-client";
+```
+
+These tests assert sweep behavior, not webhook behavior; the `apiClient` stub will never be invoked. The `null` fallback is fine because sweep never reads it.
+
+- [ ] **Step 5: Update `billing-sweep.integration.test.ts` (1 construction site).** Inside `beforeEach`:
+
+```ts
+import { GooglePlayApiClient } from "./google-play.api-client";
+
+// existing:
+const ultra = new UltraService(new UltraRepository(db));
+// add:
+const apiClient = new GooglePlayApiClient(null);
+// change:
+svc = new BillingService(db, repo, ultra, apiClient, null);
+```
+
+- [ ] **Step 6: Typecheck and run server tests.**
+
+```bash
+bun --cwd apps/server check-types
+bun --cwd apps/server test
+```
+
+No NEW typecheck errors. All billing tests pass.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add apps/server/src/features/billing/billing.route.ts apps/server/src/workers/billing-sweep.worker.ts apps/server/src/features/billing/billing-sweep.service.test.ts apps/server/src/features/billing/billing-sweep.integration.test.ts
+git commit -m "feat(billing): wire google play api client into route + sweep worker"
+```
+
+---
+
+## Gate D
+
+After Task 5, the controller dispatches a final Opus 4.7 spec-coverage review against the full branch diff vs `main`, prompted to find:
+- All acceptance criteria (§9) covered.
+- §8.1, §8.2, §8.3 test cases present.
+- The replay path's intentional non-call clearly commented in code.
+- Both env vars wired with the correct fallback semantics.

--- a/docs/superpowers/specs/2026-05-12-phase-2e8-google-play-real-expiry-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2e8-google-play-real-expiry-design.md
@@ -1,0 +1,215 @@
+# Phase 2E.8 — Real `expiryTime` lookup via Google Play `subscriptionsv2.get` (design spec)
+
+**Date:** 2026-05-12
+**Branch:** `feature/phase-2e8-google-play-real-expiry`
+**Depends on:** Phase 2E.4 (Google Play billing webhook). Reuses `subscription`, `BillingRepository`, `applyDecodedEvent`.
+
+## 1. Problem
+
+`applyDecodedEvent` for grant events (PURCHASED/RENEWED/RECOVERED/RESTARTED) currently sets `currentPeriodEnd = now + 30 days` via `DEFAULT_SUBSCRIPTION_PERIOD_MS` (`billing.service.ts:164`, `:180`). This is conservative — it never under-grants — but:
+
+- Webhooks fire on `eventTimeMillis`, NOT at the exact moment of renewal. The 30-day clock starts at our webhook receipt, not at Google's renewal anchor. Over many renewals the user's `current_period_end` drifts later than reality.
+- Monthly-plan users renewing on day 28 (Google's renewal anchor) see ~3 days of free Ultra each cycle.
+- The reconciliation sweep (2E.7) uses `current_period_end < cutoff` as its trigger. A drifted-late `current_period_end` keeps a truly-expired sub in the candidate-blind zone for days past real expiry, exactly the gap the sweep was meant to close.
+
+## 2. Goal (this phase)
+
+Call `androidpublisher.purchases.subscriptionsv2.get(packageName, purchaseToken)` to fetch the real `expiryTime` (ISO 8601) for grant events. Use that timestamp as `currentPeriodEnd` and `grant.expiresAt`. Fall back to the 30-day default when the API call fails or service-account is not configured.
+
+## 3. Out of scope (deferred)
+
+- Apple side — `signedTransactionInfo.expiresDate` is already used (2E.5). No work needed.
+- Google Pub/Sub OIDC verification — separate phase (would reuse the same service-account JWT signer foundation).
+- Voided purchases API / refund detection — different endpoint.
+- One-time IAP `purchases.products.get` (lives packs §5.4) — separate phase.
+- Caching the access token across processes — in-process LRU only this phase.
+
+## 4. Architecture
+
+### 4.1 Module layout
+
+- `apps/server/src/features/billing/google-play.api-client.ts` — **new**. Thin client that:
+  - Holds the parsed service-account credentials (or `null` if not configured).
+  - Constructor accepts `(creds, opts?: { fetchImpl?: typeof fetch; logger?: { warn: (...a: unknown[]) => void; error: (...a: unknown[]) => void } })`. `fetchImpl` defaults to `globalThis.fetch`. `logger` defaults to a `console`-backed shim. Tests inject both.
+  - Mints a Google OAuth 2.0 access token via RS256-signed JWT assertion (single audience: `https://oauth2.googleapis.com/token`, scope: `https://www.googleapis.com/auth/androidpublisher`). Caches the token in-memory until 60 seconds before its `expires_in` deadline.
+  - Exposes `getSubscription(packageName, purchaseToken): Promise<Date | null>` reading `lineItems[0].expiryTime` from the v2 response. On any error returns `null` (caller decides fallback) — never throws. Past expiry timestamps are returned as-is (trust Google; the sweep will reconcile).
+- `apps/server/src/features/billing/google-play.service-account.ts` — **new**. Parses + validates the service-account JSON: `client_email`, `private_key`, `token_uri`. Pure functions. Throws `InvalidServiceAccountError` on malformed JSON; returns `null` from a `loadFromEnv()` helper when the env var is absent.
+- `apps/server/src/features/billing/billing.service.ts` — modify `processGooglePlayEnvelope`:
+  - Before opening the per-event TX, for `kind === "subscription"` events whose `notificationTypeName` is a grant type (PURCHASED/RENEWED/RECOVERED/RESTARTED): resolve `packageName = decoded.packageName || env.GOOGLE_PLAY_PACKAGE_NAME || null`. If null, log WARN with `{ messageId, reason: "no_package_name" }`, skip the API call, set `realExpiryTime = null`. Otherwise call `apiClient.getSubscription(packageName, decoded.purchaseToken)` → `realExpiryTime: Date | null`.
+  - Pass that override into `applyDecodedEvent` via a new optional 3rd argument.
+  - All other event types skip the API call.
+  - **Replay path (`linkGooglePlayPurchase`, `billing.service.ts:130`) intentionally does NOT call the API.** It re-applies parked events via `applyDecodedEvent(decoded, sub)` (no 3rd arg) so the optional param defaults to `null` and the state machine uses the 30-day fallback. Reason: an outbound network call inside the link TX would hold row locks for hundreds of ms and could deadlock under contention; the next live webhook for the same subscription will reconcile the period end. This is a deliberate trade-off — call it out in code with a comment that references this spec section.
+- `apps/server/src/features/billing/billing.service.ts` — modify `applyDecodedEvent` signature:
+  - New optional 3rd param `realExpiryTime: Date | null`.
+  - For the grant cases, use `realExpiryTime ?? defaultEnd`. All other branches unchanged.
+- `apps/server/src/features/billing/billing.route.ts:17` — actual construction site. Update from `new BillingService(db, repo, ultra)` to `new BillingService(db, repo, ultra, apiClient)`. The `apiClient` is constructed in the same route file from `loadServiceAccountFromEnv(env)` + `fastify.log` (pino-compatible logger interface). `index.ts` only re-exports the route; no change there.
+- `packages/env/src/server.ts` — add `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: z.string().optional()` and `GOOGLE_PLAY_PACKAGE_NAME: z.string().optional()` (the latter is consulted as a fallback when the envelope's `packageName` field is missing/empty; we trust the envelope first since it tells us which app fired).
+
+### 4.2 Data flow (grant event)
+
+```
+processGooglePlayEnvelope(envelope)
+  ├─ decode → DecodedGooglePlayEvent { kind: "subscription", notificationTypeName: "RENEWED", packageName, purchaseToken, ... }
+  ├─ if isGrantType(name):
+  │     const packageName = decoded.packageName || env.GOOGLE_PLAY_PACKAGE_NAME || null;
+  │     if (!packageName) {
+  │       logger.warn({ messageId: decoded.messageId, reason: "no_package_name" }, "real-expiry fallback");
+  │       realExpiryTime = null;
+  │     } else {
+  │       realExpiryTime = await apiClient.getSubscription(packageName, decoded.purchaseToken);
+  │       // → Date | null. apiClient handles its own logging on failure.
+  │     }
+  ├─ this.db.transaction(...):
+  │     insertEvent → updateSubscriptionState(sub.id, applyDecodedEvent(decoded, sub, realExpiryTime))
+  └─ applyUltraEffect(effect)  // effect already carries realExpiryTime via grant.expiresAt
+```
+
+For NON-grant events (CANCELED/EXPIRED/etc.) and for `kind !== "subscription"` events, the API call is skipped entirely — `realExpiryTime` stays `undefined` and `applyDecodedEvent` ignores it.
+
+### 4.3 Fallback strategy
+
+`realExpiryTime = null` (the API said no, threw, or credentials are absent) ⇒ `applyDecodedEvent` uses `defaultEnd = now + 30 days`. Identical to current behavior. The sweep job (2E.7) plus future webhooks will reconcile if the real expiry comes in later. This means:
+
+- Boot-time absence of `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` is a fully supported config — server boots, webhooks process with the old default.
+- Transient API outages do NOT block webhook processing.
+- We MUST log every fallback at WARN with `{ packageName, purchaseToken, reason }` so a sudden surge of fallbacks (credential rotation, scope misconfiguration) is observable.
+
+### 4.4 In-process token cache
+
+The access token Google returns has `expires_in: 3600` (1 hour). We cache it under a single class-instance field `{ token: string, expiresAt: number /* ms epoch */ }`. Before each `getSubscription` call:
+
+- If `expiresAt - 60_000 > Date.now()`, reuse the cached token.
+- Otherwise, mint a fresh JWT, exchange for a token, store the new pair.
+
+No external cache (Redis, etc.). The `BillingService` is constructed once per process, so the `GooglePlayApiClient` instance lives for the process lifetime — typically minutes-to-hours across thousands of requests.
+
+### 4.5 JWT minting (no `googleapis` SDK)
+
+Pure Node `crypto.createSign("RSA-SHA256")` over a header+payload base64url string. Avoids pulling the full Google SDK. Payload shape:
+
+```json
+{
+  "iss": "<service_account.client_email>",
+  "scope": "https://www.googleapis.com/auth/androidpublisher",
+  "aud": "https://oauth2.googleapis.com/token",
+  "iat": <now seconds>,
+  "exp": <now + 3600 seconds>
+}
+```
+
+POST to `https://oauth2.googleapis.com/token` with `application/x-www-form-urlencoded`:
+`grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<jwt>`.
+
+Response: `{ access_token, expires_in, token_type: "Bearer" }`.
+
+### 4.6 Subscription fetch
+
+```
+GET https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{packageName}/purchases/subscriptionsv2/tokens/{purchaseToken}
+Authorization: Bearer <access_token>
+Accept: application/json
+```
+
+Response (excerpt — we only consume two fields):
+
+```json
+{
+  "kind": "androidpublisher#subscriptionPurchaseV2",
+  "subscriptionState": "SUBSCRIPTION_STATE_ACTIVE",
+  "lineItems": [
+    { "productId": "ultra_monthly", "expiryTime": "2026-06-12T15:30:00Z", "autoRenewingPlan": {...} }
+  ]
+}
+```
+
+We read `lineItems[0].expiryTime` as the new `currentPeriodEnd`. If `lineItems` is empty or missing the field, return `null`.
+
+Non-200: log WARN with status code, return `null`. Network errors: same. 401: log ERROR (credentials issue), return `null` and **invalidate the cached access token** so the next call retries minting.
+
+## 5. Public surface
+
+**Internal only.** No new HTTP routes. Webhook semantics unchanged from client perspective — same 200/400 responses, same idempotency.
+
+New env vars (both optional — server boots without them and falls back to old behavior):
+
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` — full JSON contents (NOT a path). Production deploys can use Render's secret-file feature and read the file in then set the env var, or use a multi-line env var directly. `Zod` validation is `z.string().optional()` only at the env layer; the actual parse + validate happens at service construction.
+- `GOOGLE_PLAY_PACKAGE_NAME` — fallback if envelope's `packageName` is empty (defensive). Optional.
+
+## 6. State machine semantics
+
+Grant events (PURCHASED/RENEWED/RECOVERED/RESTARTED) now resolve to:
+
+```
+newPeriodEnd = realExpiryTime ?? (now + 30d)
+ultraEffect = grant(newPeriodEnd)
+```
+
+All other branches unchanged. No state-machine table change visible to the multi-sub guards (they consume `currentPeriodEnd` as an opaque timestamp).
+
+## 7. Race conditions and edge cases
+
+**Stale lookup vs. fresh webhook**: We call `subscriptionsv2.get` BEFORE the per-event TX. If between that call and the TX commit, the user upgrades/downgrades the plan, the freshly-fetched `expiryTime` is for the OLD plan. The next webhook (Google fires one for every state change) reconciles. We accept this; the alternative (fetch inside TX) holds the row lock during a 200ms+ network call — far worse.
+
+**Concurrent webhooks for same purchaseToken**: Each webhook independently calls `getSubscription` and races on the row lock. Both writes are idempotent under the predicate-in-WHERE pattern that's standard in this codebase. Idempotency on `(provider, message_id)` further guarantees only one of two identical retries reaches the state machine.
+
+**API returns 404**: indicates the purchase token is invalid or the subscription is gone. Return `null` ⇒ fallback to 30-day default. The state machine still moves the row to `active` via the webhook — this is correct: Google fired the webhook because Google thinks the sub exists, so we trust Google. A future EXPIRED webhook or sweep will clean up if needed.
+
+**Service-account credentials rotation**: If a rotated key starts returning 401, fallback engages and logs. Operator updates env var, restart process. No data loss.
+
+**Empty `lineItems`**: per Google docs this should not happen for active subscriptions but if it does, return `null` and fallback. Log at WARN.
+
+## 8. Testing strategy
+
+### 8.1 Pure unit (no I/O)
+
+- `parseServiceAccount(json)` — happy path including a realistic PEM `private_key` with embedded `\n` newlines (the JSON-encoded form Google issues); malformed JSON throws `InvalidServiceAccountError`; missing `client_email` throws; missing `private_key` throws.
+- `loadServiceAccountFromEnv(env)` — returns null when env var absent, returns parsed creds when present.
+- `mintJwt(creds, now)` — produces a 3-segment base64url string; header decodes to `{ alg: "RS256", typ: "JWT" }`; payload decodes to expected `{ iss, scope, aud, iat, exp }`; signature length matches RS256.
+
+### 8.2 `GooglePlayApiClient` with mocked `fetch`
+
+- `getAccessToken()` first call hits token endpoint, returns access token. Second call within TTL reuses without hitting the endpoint.
+- `getAccessToken()` after expiry mints again.
+- `getSubscription(pkg, token)` happy path: tokens endpoint then v2 endpoint, returns `expiryTime` as `Date`.
+- `getSubscription` returns `null` on:
+  - tokens endpoint 401 (and invalidates the cached token).
+  - tokens endpoint returns 200 with a non-JSON body (e.g., HTML error page from a proxy).
+  - v2 endpoint 404.
+  - v2 endpoint 500.
+  - v2 endpoint empty `lineItems`.
+  - v2 endpoint missing `expiryTime`.
+  - Network throw on either endpoint.
+- `getSubscription` returns the parsed `Date` AS-IS when `expiryTime` is in the past (trust Google; downstream sweep handles reconciliation). One test asserts: returned `Date` matches input ISO even when input < now.
+- Constructor with `null` credentials: `getSubscription` returns `null` without making any HTTP call (early exit).
+
+### 8.3 Service integration
+
+- `processGooglePlayEnvelope` for a RENEWED event with a stubbed `apiClient.getSubscription` returning `2026-06-12T15:30:00Z`:
+  - `updateSubscriptionState` called with `currentPeriodEnd` matching the stubbed date.
+  - `ultra.grant` called with the same date.
+- Same flow with `apiClient.getSubscription` returning `null`:
+  - `currentPeriodEnd` matches `now + 30d` (fallback to existing default).
+  - `ultra.grant` called with the same fallback date.
+- `processGooglePlayEnvelope` for a non-grant event (e.g., CANCELED): `apiClient.getSubscription` is NOT called.
+- `processGooglePlayEnvelope` for a `kind: "unknown"` event: `apiClient.getSubscription` is NOT called.
+
+### 8.4 Backwards-compatibility regression
+
+- All existing `billing.service.test.ts` Google Play cases still pass with the new optional 3rd param defaulting to `null`. No behavior change when `apiClient` is the no-op stub.
+
+## 9. Acceptance criteria
+
+- [ ] Grant events use Google's `expiryTime` when `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` is configured.
+- [ ] Grant events fall back to `now + 30 days` when env is absent OR API call fails.
+- [ ] Service boots and webhooks process correctly without the env var set.
+- [ ] Non-grant events do NOT make Google API calls.
+- [ ] Access token cached in-process across calls; refreshed only past TTL.
+- [ ] 401 invalidates the cache so next call mints fresh.
+- [ ] No new throws bubble out of webhook processing on API failures — always log + fall back.
+
+## 10. Deferred (next-phase candidates)
+
+- **Voided purchases scan** — `purchases.voidedpurchases.list` to detect refunds.
+- **Google Pub/Sub OIDC verification** — reuse the JWT verification primitives plus Google's JWKs endpoint to replace the shared-header webhook secret.
+- **Multi-app support** — currently assumes a single `packageName` per deploy; multi-tenant would need the credentials selected by package name.
+- **Background token refresh** — proactively refresh tokens before they expire; today we refresh lazily on next call.

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -22,6 +22,8 @@ export const env = createEnv({
     ADMIN_API_TOKEN: z.string().min(16).optional(),
     GOOGLE_PLAY_WEBHOOK_TOKEN: z.string().min(16).optional(),
     APP_STORE_WEBHOOK_TOKEN: z.string().min(32).optional(),
+    GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: z.string().optional(),
+    GOOGLE_PLAY_PACKAGE_NAME: z.string().optional(),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,


### PR DESCRIPTION
## Summary
Replaces the 30-day conservative default for Google Play grant events (`PURCHASED/RENEWED/RECOVERED/RESTARTED`) with the real `expiryTime` from `androidpublisher.purchases.subscriptionsv2.get`. Two new optional env vars (`GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `GOOGLE_PLAY_PACKAGE_NAME`); when absent, behavior is identical to before (30-day default). Lays the Google service-account OAuth foundation that future Pub/Sub OIDC verification will reuse.

## How it works
- `google-play.service-account.ts` — parses Google's service-account JSON; mints RS256-signed JWT assertions via `node:crypto`.
- `google-play.api-client.ts` — `getSubscription(packageName, purchaseToken): Promise<Date | null>`. OAuth2 JWT-bearer flow, in-process access token cache (refreshes 60s before expiry), pino-compatible structured logging, never throws.
- `BillingService.processGooglePlayEnvelope` looks up `realExpiryTime` BEFORE the per-event TX for grant events only, then passes it as a 3rd optional arg to `applyDecodedEvent`.
- Replay path in `linkGooglePlayPurchase` deliberately keeps the 30-day fallback (no API call inside a TX — avoids deadlocks).
- All failures (auth, network, 4xx/5xx, malformed bodies, missing fields) fall back to the existing default. 401 invalidates the access-token cache so the next call re-mints.

## Spec / plan
- Spec: `docs/superpowers/specs/2026-05-12-phase-2e8-google-play-real-expiry-design.md`
- Plan: `docs/superpowers/plans/2026-05-12-phase-2e8-google-play-real-expiry.md`
- 4-gate workflow: Gate A (7 spec blockers), Gate B (3 plan blockers incl. missing sweep-test updates), Gate C × 4 tasks (4 quality fixes), Gate D (4 gaps — pino wiring, log fields, test rename, no-pkg test).

## Test plan
- [x] `google-play.service-account.test.ts` — 7 unit tests (parse, env loader, JWT minting w/ real 2048-bit RSA key).
- [x] `google-play.api-client.test.ts` — 13 cases: happy path, null creds, cache hit/miss/refresh, v2-401-invalidates-cache, network errors, non-JSON bodies, 404/500, empty lineItems, past expiry returned-as-is.
- [x] `billing.service.test.ts` — 5 new service-integration cases (real expiry, null fallback, empty packageName, CANCELED skip, unknown skip).
- [x] Full server test suite green (312/312, 114 billing tests).
- [x] Existing webhook tests unchanged (backward compat: null-stub apiClient ⇒ 30-day default).

## Migration
Two new env vars are optional. Deploy as-is and the system keeps the old behavior until `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Play subscription expiry dates are now determined from the authoritative Google Play API, replacing the previous default calculation.

* **Chores**
  * Added two optional environment variables for Google Play configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CeCamillo/pruvi/pull/29)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->