### PR TITLE
feat: phase 2f.1 — session-completion xp bonus + enriched complete response

### DIFF
--- a/apps/server/src/features/gamification/gamification.service.test.ts
+++ b/apps/server/src/features/gamification/gamification.service.test.ts
@@ -72,4 +72,53 @@ describe("GamificationService", () => {
       expect(repo.awardXp).toHaveBeenCalledWith("user-1", 10, 1);
     });
   });
+
+  describe("awardXpForSessionCompletion", () => {
+    it("happy path: 8 correct, streak=3 → xpAwarded=90", async () => {
+      repo.getUserXp.mockResolvedValue({ totalXp: 0, currentLevel: 1 });
+      repo.awardXp.mockResolvedValue({ totalXp: 90, currentLevel: 1 });
+
+      const result = await service.awardXpForSessionCompletion("user-1", 8, 3);
+
+      expect(result.isOk()).toBe(true);
+      const value = result._unsafeUnwrap();
+      expect(value.xpAwarded).toBe(90); // (50 + 40) * 1 = 90
+      expect(repo.awardXp).toHaveBeenCalledWith("user-1", 90, expect.any(Number));
+    });
+
+    it("streak above threshold: 10 correct, streak=8 → repo.awardXp called with 110", async () => {
+      repo.getUserXp.mockResolvedValue({ totalXp: 0, currentLevel: 1 });
+      repo.awardXp.mockResolvedValue({ totalXp: 110, currentLevel: 1 });
+
+      const result = await service.awardXpForSessionCompletion("user-1", 10, 8);
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().xpAwarded).toBe(110);
+      expect(repo.awardXp).toHaveBeenCalledWith("user-1", 110, expect.any(Number));
+    });
+
+    it("streak at boundary 7: 10 correct, streak=7 → 100 (no multiplier)", async () => {
+      repo.getUserXp.mockResolvedValue({ totalXp: 0, currentLevel: 1 });
+      repo.awardXp.mockResolvedValue({ totalXp: 100, currentLevel: 1 });
+
+      const result = await service.awardXpForSessionCompletion("user-1", 10, 7);
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().xpAwarded).toBe(100); // (50 + 50) * 1 = 100
+      expect(repo.awardXp).toHaveBeenCalledWith("user-1", 100, expect.any(Number));
+    });
+
+    it("repo.awardXp returns undefined (user deleted) → returns ok with fallback totalXp, no throw", async () => {
+      repo.getUserXp.mockResolvedValue({ totalXp: 50, currentLevel: 1 });
+      repo.awardXp.mockResolvedValue(undefined);
+
+      const result = await service.awardXpForSessionCompletion("user-1", 8, 3);
+
+      expect(result.isOk()).toBe(true);
+      const value = result._unsafeUnwrap();
+      // xpAwarded is 90; totalXp falls back to 50 + 90 = 140
+      expect(value.xpAwarded).toBe(90);
+      expect(value.totalXp).toBe(140);
+    });
+  });
 });

--- a/apps/server/src/features/gamification/gamification.service.ts
+++ b/apps/server/src/features/gamification/gamification.service.ts
@@ -1,6 +1,7 @@
 import { ok, err, type Result } from "neverthrow";
 import {
   calculateXpForAnswer,
+  calculateSessionCompletionXp,
   getLevelForXp,
   xpForNextLevel,
   type Difficulty,
@@ -66,6 +67,42 @@ export class GamificationService {
       xpAwarded,
       totalXp: updated?.totalXp ?? currentXp + xpAwarded,
       currentLevel: updated?.currentLevel ?? newLevel,
+    });
+  }
+
+  /** Award XP for completing a session, with optional streak multiplier. */
+  async awardXpForSessionCompletion(
+    userId: string,
+    questionsCorrect: number,
+    streakAfter: number,
+  ): Promise<
+    Result<
+      {
+        xpAwarded: number;
+        totalXp: number;
+        currentLevel: number;
+        base: number;
+        correctBonus: number;
+        streakMultiplier: number;
+      },
+      AppError
+    >
+  > {
+    const xp = calculateSessionCompletionXp(questionsCorrect, streakAfter);
+    const current = await this.repo.getUserXp(userId);
+    const currentXp = current?.totalXp ?? 0;
+    const newLevel = getLevelForXp(currentXp + xp.total);
+    const updated = await this.repo.awardXp(userId, xp.total, newLevel);
+
+    // Null-guard: repo.awardXp returns undefined when user row not matched (deleted mid-flow).
+    // Fall back to computed values so the response shape stays consistent.
+    return ok({
+      xpAwarded: xp.total,
+      totalXp: updated?.totalXp ?? currentXp + xp.total,
+      currentLevel: updated?.currentLevel ?? newLevel,
+      base: xp.base,
+      correctBonus: xp.correctBonus,
+      streakMultiplier: xp.streakMultiplier,
     });
   }
 }

--- a/apps/server/src/features/sessions/sessions.route.ts
+++ b/apps/server/src/features/sessions/sessions.route.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
-import { StartSessionBodySchema } from "@pruvi/shared";
+import { StartSessionBodySchema, SessionCompleteResponseSchema } from "@pruvi/shared";
 import { SessionsService } from "./sessions.service";
 import { SessionsRepository } from "./sessions.repository";
 import { QuestionsRepository } from "../questions/questions.repository";
@@ -16,6 +16,8 @@ import { StreaksRepository } from "../streaks/streaks.repository";
 import { StreaksService } from "../streaks/streaks.service";
 import { ShieldsRepository } from "../shields/shields.repository";
 import { ShieldsService } from "../shields/shields.service";
+import { GamificationRepository } from "../gamification/gamification.repository";
+import { GamificationService } from "../gamification/gamification.service";
 import { db } from "@pruvi/db";
 import { successResponse, unwrapResult } from "../../types";
 
@@ -35,6 +37,8 @@ export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
   const streaksService = new StreaksService(streaksRepo);
   const shieldsRepo = new ShieldsRepository(db);
   const shieldsService = new ShieldsService(shieldsRepo);
+  const gamificationRepo = new GamificationRepository(db);
+  const gamificationService = new GamificationService(gamificationRepo);
   const dispatcher = fastify.queues.notificationsSend
     ? new Dispatcher({
         tokensService,
@@ -51,6 +55,7 @@ export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
     dispatcher,
     shieldsService,
     fastify.log,
+    gamificationService,
   );
   // POST /sessions/start
   fastify.post(
@@ -137,6 +142,9 @@ export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
             message: "questionsCorrect cannot exceed questionsAnswered",
             path: ["questionsCorrect"],
           }),
+        response: {
+          200: z.object({ success: z.literal(true), data: SessionCompleteResponseSchema }),
+        },
       },
     },
     async (request) => {
@@ -148,7 +156,7 @@ export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
         questionsAnswered,
         questionsCorrect
       );
-      const { session, transitions } = unwrapResult(result).data;
+      const { session, transitions, xpAward, streakDelta } = unwrapResult(result).data;
 
       // Invalidate caches that depend on session completion.
       // `shields:` is invalidated unconditionally: if the auto-use hook fires (fire-and-forget),
@@ -173,7 +181,13 @@ export const sessionsRoutes: FastifyPluginAsyncZod = async (fastify) => {
         );
       }
 
-      return successResponse({ session, transitions });
+      // Fastify serializes Date fields → ISO strings before the response schema validates them.
+      // The `as unknown as` cast is needed because TypeScript sees Date objects here,
+      // but the wire format (and schema) expects strings.
+      return successResponse({ session, transitions, xpAward, streakDelta }) as unknown as {
+        success: true;
+        data: import("@pruvi/shared").SessionCompleteResponse;
+      };
     }
   );
 };

--- a/apps/server/src/features/sessions/sessions.service.test.ts
+++ b/apps/server/src/features/sessions/sessions.service.test.ts
@@ -160,6 +160,8 @@ describe("SessionsService", () => {
       expect(result.isOk()).toBe(true);
       expect(result._unsafeUnwrap().session).toEqual(completedSession);
       expect(result._unsafeUnwrap().transitions).toEqual([]);
+      expect(result._unsafeUnwrap().xpAward).toBeNull();
+      expect(result._unsafeUnwrap().streakDelta).toBe(0);
       expect(repo.completeSession).toHaveBeenCalledWith(1, 10, 8);
     });
 
@@ -266,11 +268,13 @@ describe("SessionsService.completeSession returns mastery transitions", () => {
     const service = new SessionsService(sessionRepo, questionsService, topicsService);
     const result = await service.completeSession("u1", 9, 5, 4);
     expect(result.isOk()).toBe(true);
-    const { session, transitions } = result._unsafeUnwrap();
+    const { session, transitions, xpAward, streakDelta } = result._unsafeUnwrap();
     expect(session!.status).toBe("completed");
     expect(transitions).toEqual([
       { subtopicId: 7, name: "Membrana", from: "aprendendo", to: "afiado" },
     ]);
+    expect(xpAward).toBeNull();
+    expect(streakDelta).toBe(0);
   });
 
   it("returns empty transitions when snapshot is null", async () => {
@@ -285,8 +289,10 @@ describe("SessionsService.completeSession returns mastery transitions", () => {
       { computeTransitions: vi.fn().mockReturnValue([]), getCurrentMasteryAndNames: vi.fn(), snapshotMastery: vi.fn() } as any,
     );
     const result = await service.completeSession("u1", 9, 0, 0);
-    const { transitions } = result._unsafeUnwrap();
+    const { transitions, xpAward, streakDelta } = result._unsafeUnwrap();
     expect(transitions).toEqual([]);
+    expect(xpAward).toBeNull();
+    expect(streakDelta).toBe(0);
   });
 });
 
@@ -550,5 +556,68 @@ describe("SessionsService.maybeProtectMissedDay protected push hook", () => {
     await new Promise((r) => setImmediate(r));
 
     expect(result.isOk()).toBe(true);
+  });
+});
+
+describe("SessionsService.completeSession with gamificationService", () => {
+  function makeSessionRepo(userId = "u1") {
+    return {
+      findSessionById: vi.fn().mockResolvedValue({ id: 1, userId, status: "active" }),
+      completeSession: vi.fn().mockResolvedValue({ id: 1, status: "completed" }),
+      readMasterySnapshot: vi.fn().mockResolvedValue(null),
+    } as any;
+  }
+
+  function makeTopicsService() {
+    return {
+      computeTransitions: vi.fn().mockReturnValue([]),
+      getCurrentMasteryAndNames: vi.fn().mockResolvedValue({ currentMap: new Map(), namesMap: new Map() }),
+      snapshotMastery: vi.fn(),
+    } as any;
+  }
+
+  it("returns xpAward when gamificationService is provided", async () => {
+    const xpAwardValue = {
+      xpAwarded: 90,
+      totalXp: 90,
+      currentLevel: 2,
+      base: 50,
+      correctBonus: 40,
+      streakMultiplier: 1,
+    };
+    const gamificationService = {
+      awardXpForSessionCompletion: vi.fn().mockResolvedValue(ok(xpAwardValue)),
+    } as any;
+
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+      null, // no streaksService
+      null, // no dispatcher
+      undefined, // no shieldsService
+      undefined, // no logger
+      gamificationService,
+    );
+
+    const result = await service.completeSession("u1", 1, 10, 8);
+    expect(result.isOk()).toBe(true);
+    const value = result._unsafeUnwrap();
+    expect(value.xpAward).toEqual(xpAwardValue);
+    expect(value.streakDelta).toBe(0);
+  });
+
+  it("returns xpAward=null and streakDelta=0 when gamificationService is absent (legacy ctor)", async () => {
+    const service = new SessionsService(
+      makeSessionRepo(),
+      {} as any,
+      makeTopicsService(),
+    );
+
+    const result = await service.completeSession("u1", 1, 5, 4);
+    expect(result.isOk()).toBe(true);
+    const value = result._unsafeUnwrap();
+    expect(value.xpAward).toBeNull();
+    expect(value.streakDelta).toBe(0);
   });
 });

--- a/apps/server/src/features/sessions/sessions.service.ts
+++ b/apps/server/src/features/sessions/sessions.service.ts
@@ -9,6 +9,7 @@ import type { TopicsService } from "../topics/topics.service";
 import type { Dispatcher } from "../notifications/dispatcher";
 import type { StreaksService } from "../streaks/streaks.service";
 import type { ShieldsService } from "../shields/shields.service";
+import type { GamificationService } from "../gamification/gamification.service";
 
 type SessionRow = NonNullable<Awaited<ReturnType<SessionsRepository["findTodaySession"]>>>;
 type QuestionItem = { id: number; subtopicId: number; [key: string]: unknown };
@@ -22,6 +23,7 @@ export class SessionsService {
     private dispatcher: Dispatcher | null = null,
     private shieldsService?: ShieldsService,
     private logger?: FastifyBaseLogger,
+    private gamificationService?: GamificationService, // NEW — optional, 8th arg
   ) {}
 
   /** Start or resume today's session */
@@ -122,6 +124,15 @@ export class SessionsService {
       {
         session: Awaited<ReturnType<SessionsRepository["completeSession"]>>;
         transitions: import("@pruvi/shared").MasteryTransition[];
+        xpAward: {
+          xpAwarded: number;
+          totalXp: number;
+          currentLevel: number;
+          base: number;
+          correctBonus: number;
+          streakMultiplier: number;
+        } | null;
+        streakDelta: number;
       },
       AppError
     >
@@ -146,6 +157,10 @@ export class SessionsService {
     if (session.status === "completed") {
       return err(new ValidationError("Session already completed"));
     }
+
+    const streakBefore = this.streaksService
+      ? (await this.streaksService.getStreaks(userId)).map((r) => r.currentStreak).unwrapOr(0)
+      : 0;
 
     const snapshot = await this.repo.readMasterySnapshot(sessionId);
     let transitions: import("@pruvi/shared").MasteryTransition[] = [];
@@ -191,7 +206,34 @@ export class SessionsService {
       });
     }
 
-    return ok({ session: completed, transitions });
+    const streakAfter = this.streaksService
+      ? (await this.streaksService.getStreaks(userId)).map((r) => r.currentStreak).unwrapOr(streakBefore)
+      : streakBefore;
+    const streakDelta = streakAfter - streakBefore;
+
+    // Multiplier uses streakAfter — see spec §4.3 / §7.3. Rewards crossing 7→8 on the crossing day.
+    let xpAward: {
+      xpAwarded: number;
+      totalXp: number;
+      currentLevel: number;
+      base: number;
+      correctBonus: number;
+      streakMultiplier: number;
+    } | null = null;
+    if (this.gamificationService) {
+      const awardResult = await this.gamificationService.awardXpForSessionCompletion(
+        userId,
+        questionsCorrect,
+        streakAfter,
+      );
+      if (awardResult.isOk()) {
+        xpAward = awardResult.value;
+      } else {
+        this.logger?.warn?.({ userId, sessionId, err: awardResult.error.message }, "session xp award failed");
+      }
+    }
+
+    return ok({ session: completed, transitions, xpAward, streakDelta });
   }
 
   private async maybeProtectMissedDay(userId: string): Promise<void> {

--- a/docs/superpowers/plans/2026-05-12-phase-2f1-session-xp-bonus.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2f1-session-xp-bonus.md
@@ -1,0 +1,322 @@
+# Phase 2F.1 — Session-completion XP bonus + enriched response — Plan
+
+> **For agentic workers:** Use `superpowers:subagent-driven-development` (Sonnet 4.6 implementers, Opus 4.7 reviewers). Branch: `feature/phase-2f1-session-xp-bonus`.
+
+**Goal:** Add 50-XP session-completion bonus + 10% streak-multiplier (when streakAfter>7). Surface `xpAward` + `streakDelta` from `POST /sessions/:id/complete`.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-phase-2f1-session-xp-bonus-design.md`
+
+---
+
+## File map
+
+**Create:** none.
+
+**Modify:**
+- `packages/shared/src/xp.ts` — add `calculateSessionCompletionXp` pure helper + constants.
+- `packages/shared/src/xp.test.ts` — unit tests for the helper.
+- `packages/shared/src/topics.ts` — export `MasteryTransitionsSchema = z.array(MasteryTransitionSchema)`.
+- `packages/shared/src/sessions.ts` — add `SessionCompleteResponseSchema`.
+- `apps/server/src/features/gamification/gamification.service.ts` — add `awardXpForSessionCompletion`.
+- `apps/server/src/features/gamification/gamification.service.test.ts` — cover new method.
+- `apps/server/src/features/sessions/sessions.service.ts` — extend ctor (optional `gamificationService`), update `completeSession` return shape.
+- `apps/server/src/features/sessions/sessions.service.test.ts` — update test buildSut + add 2 new cases.
+- `apps/server/src/features/sessions/sessions.route.ts` — wire `gamificationService` + declare response schema.
+
+---
+
+### Task 1: Pure XP helper + MasteryTransitionsSchema
+
+- [ ] **Step 1: Add the helper + tests in `packages/shared/src/xp.ts`** and `xp.test.ts`. Constants at module scope.
+
+```ts
+// packages/shared/src/xp.ts (append)
+export const SESSION_COMPLETION_BASE_XP = 50;
+export const SESSION_PER_CORRECT_XP = 5;
+export const SESSION_STREAK_MULTIPLIER_THRESHOLD = 7;
+export const SESSION_STREAK_MULTIPLIER = 1.10;
+
+export function calculateSessionCompletionXp(
+  questionsCorrect: number,
+  streakAfter: number,
+): { base: number; correctBonus: number; streakMultiplier: number; total: number } {
+  const base = SESSION_COMPLETION_BASE_XP;
+  const correctBonus = Math.max(0, questionsCorrect) * SESSION_PER_CORRECT_XP;
+  const streakMultiplier =
+    streakAfter > SESSION_STREAK_MULTIPLIER_THRESHOLD ? SESSION_STREAK_MULTIPLIER : 1;
+  const total = Math.floor((base + correctBonus) * streakMultiplier);
+  return { base, correctBonus, streakMultiplier, total };
+}
+```
+
+Test cases (use `describe("calculateSessionCompletionXp")`):
+- 0 correct, streak=0 → `{ base: 50, correctBonus: 0, streakMultiplier: 1, total: 50 }`.
+- 8 correct, streak=3 → total 90.
+- 10 correct, streak=7 → total 100 (boundary: multiplier kicks in at `>7`, NOT `>=7`).
+- 10 correct, streak=8 → total 110.
+- 7 correct, streak=10 → total floor((50+35)*1.1) = 93 (integer floor verified).
+- Negative `questionsCorrect` (defensive) → treated as 0 → total 50.
+
+- [ ] **Step 2: `MasteryTransitionsSchema`** — add to `packages/shared/src/topics.ts`:
+
+```ts
+export const MasteryTransitionsSchema = z.array(MasteryTransitionSchema);
+```
+
+- [ ] **Step 3: Run tests + typecheck.**
+
+```bash
+bun test packages/shared/src/xp.test.ts
+bun --cwd apps/server check-types
+```
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/shared/src/xp.ts packages/shared/src/xp.test.ts packages/shared/src/topics.ts
+git commit -m "feat(shared): session-completion XP helper + MasteryTransitionsSchema"
+```
+
+---
+
+### Task 2: GamificationService.awardXpForSessionCompletion
+
+- [ ] **Step 1: Implement the method** in `gamification.service.ts`:
+
+```ts
+import { calculateSessionCompletionXp, ... existing imports } from "@pruvi/shared";
+
+async awardXpForSessionCompletion(
+  userId: string,
+  questionsCorrect: number,
+  streakAfter: number,
+): Promise<Result<
+  {
+    xpAwarded: number;
+    totalXp: number;
+    currentLevel: number;
+    base: number;
+    correctBonus: number;
+    streakMultiplier: number;
+  },
+  AppError
+>> {
+  const xp = calculateSessionCompletionXp(questionsCorrect, streakAfter);
+  const current = await this.repo.getUserXp(userId);
+  const currentXp = current?.totalXp ?? 0;
+  const newLevel = getLevelForXp(currentXp + xp.total);
+  const updated = await this.repo.awardXp(userId, xp.total, newLevel);
+
+  // Null-guard: repo.awardXp returns undefined when user row not matched (deleted mid-flow).
+  // Fall back to computed values so the response shape stays consistent.
+  return ok({
+    xpAwarded: xp.total,
+    totalXp: updated?.totalXp ?? currentXp + xp.total,
+    currentLevel: updated?.currentLevel ?? newLevel,
+    base: xp.base,
+    correctBonus: xp.correctBonus,
+    streakMultiplier: xp.streakMultiplier,
+  });
+}
+```
+
+- [ ] **Step 2: Unit tests** — append to `gamification.service.test.ts`:
+
+Cases:
+- Happy path: `awardXpForSessionCompletion("u", 8, 3)` calls `repo.awardXp("u", 90, expectedLevel)` and returns `xpAwarded: 90`.
+- Streak above threshold: `(uid, 10, 8)` → `repo.awardXp` called with `110`.
+- Streak at boundary 7: `(uid, 10, 7)` → `100` (no multiplier).
+- `repo.awardXp` returns `undefined` (user deleted) → service still returns ok with `totalXp = currentXp + xp.total` fallback; no throw.
+
+- [ ] **Step 3: Run gamification tests + typecheck + commit.**
+
+```bash
+bun test apps/server/src/features/gamification/
+bun --cwd apps/server check-types
+git add apps/server/src/features/gamification/gamification.service.ts apps/server/src/features/gamification/gamification.service.test.ts
+git commit -m "feat(gamification): awardXpForSessionCompletion with streak multiplier"
+```
+
+---
+
+### Task 3: SessionsService — integrate streak reads + XP award
+
+- [ ] **Step 1: Update the ctor** to accept an optional `gamificationService`. Mirror the existing pattern used for `dispatcher` and `shieldsService`:
+
+```ts
+constructor(
+  private repo: SessionsRepository,
+  private questionsService: QuestionsService,
+  private topicsService: TopicsService,
+  private streaksService: StreaksService | null = null,
+  private dispatcher: Dispatcher | null = null,
+  private shieldsService?: ShieldsService,
+  private logger?: FastifyBaseLogger,
+  private gamificationService?: GamificationService,   // NEW — optional, 8th arg
+) {}
+```
+
+Update return type of `completeSession`:
+
+```ts
+Promise<Result<{
+  session: ...;
+  transitions: MasteryTransition[];
+  xpAward: {
+    xpAwarded: number; totalXp: number; currentLevel: number;
+    base: number; correctBonus: number; streakMultiplier: number;
+  } | null;
+  streakDelta: number;
+}, AppError>>
+```
+
+- [ ] **Step 2: Modify the `completeSession` body** to read streaks before/after and call the new XP method. Place after existing validation, BEFORE the `repo.completeSession` line:
+
+```ts
+const streakBefore = this.streaksService
+  ? (await this.streaksService.getStreaks(userId)).map((r) => r.currentStreak).unwrapOr(0)
+  : 0;
+```
+
+After `const completed = await this.repo.completeSession(...)`:
+
+```ts
+const streakAfter = this.streaksService
+  ? (await this.streaksService.getStreaks(userId)).map((r) => r.currentStreak).unwrapOr(streakBefore)
+  : streakBefore;
+const streakDelta = streakAfter - streakBefore;
+
+// Multiplier uses streakAfter — see spec §4.3 / §7.3. Rewards crossing 7→8 on the crossing day.
+let xpAward: ReturnType<typeof toXpAwardOk> | null = null;
+if (this.gamificationService) {
+  const awardResult = await this.gamificationService.awardXpForSessionCompletion(
+    userId, questionsCorrect, streakAfter,
+  );
+  if (awardResult.isOk()) {
+    xpAward = awardResult.value;
+  } else {
+    this.logger?.warn?.({ userId, sessionId, err: awardResult.error.message }, "session xp award failed");
+  }
+}
+
+return ok({ session: completed, transitions, xpAward, streakDelta });
+```
+
+Helper type `toXpAwardOk` is just the awardResult.value shape; inline it if cleaner.
+
+Verify (use the neverthrow Result API correctly — `getStreaks` already returns `Result<Streaks, AppError>`; trace existing usages and copy the pattern).
+
+- [ ] **Step 3: Update test setup.** In `sessions.service.test.ts`, every `new SessionsService(repo, questionsService, topicsService, ...)` call works unchanged because the new arg is optional. Add 2 NEW cases:
+
+  - `completeSession returns xpAward when gamificationService is provided`: mock the gamification service to return `{ xpAwarded: 90, totalXp: 90, currentLevel: 2, base: 50, correctBonus: 40, streakMultiplier: 1 }`; assert the response shape includes that exact `xpAward`.
+  - `completeSession returns xpAward=null and streakDelta=0 when gamificationService is absent`: legacy 3-arg ctor; assert the legacy callers still work.
+
+- [ ] **Step 4: Run sessions tests + typecheck + commit.**
+
+```bash
+bun test apps/server/src/features/sessions/
+bun --cwd apps/server check-types
+git add apps/server/src/features/sessions/sessions.service.ts apps/server/src/features/sessions/sessions.service.test.ts
+git commit -m "feat(sessions): xp award + streak delta on session complete"
+```
+
+---
+
+### Task 4: Route wiring + response schema
+
+- [ ] **Step 1: `SessionCompleteResponseSchema`** in `packages/shared/src/sessions.ts`:
+
+```ts
+import { MasteryTransitionsSchema } from "./topics";
+
+export const SessionCompleteResponseSchema = z.object({
+  session: z.object({
+    id: z.number().int(),
+    userId: z.string(),
+    status: z.enum(["active", "completed"]),
+    questionsAnswered: z.number().int().nonnegative(),
+    questionsCorrect: z.number().int().nonnegative(),
+    masterySnapshot: z.record(z.string(), z.string()).nullable(),
+    // Fastify serializes Date → ISO string before response-schema validation runs,
+    // so the schema MUST be `z.string()` not `z.date()` (see simulados route pattern).
+    completedAt: z.string().nullable(),
+    createdAt: z.string(),
+  }),
+  transitions: MasteryTransitionsSchema,
+  xpAward: z.object({
+    xpAwarded: z.number().int().nonnegative(),
+    totalXp: z.number().int().nonnegative(),
+    currentLevel: z.number().int().min(1),
+    base: z.literal(50),
+    correctBonus: z.number().int().nonnegative(),
+    streakMultiplier: z.union([z.literal(1), z.literal(1.10)]),
+  }).nullable(),
+  streakDelta: z.number().int(),
+});
+```
+
+NOTE: confirm column names against `apps/server/src/features/sessions/sessions.repository.ts:36-52` — they are `questionsAnswered/questionsCorrect/masterySnapshot/completedAt/createdAt`. Do NOT use `questionCount`/`correctCount`.
+
+- [ ] **Step 2: Wire `GamificationService` into the route.** In `sessions.route.ts`, alongside the existing service construction:
+
+```ts
+import { GamificationRepository } from "../gamification/gamification.repository";
+import { GamificationService } from "../gamification/gamification.service";
+
+const gamificationRepo = new GamificationRepository(db);
+const gamificationService = new GamificationService(gamificationRepo);
+// existing: const service = new SessionsService(...)
+// Add gamificationService as the 8th arg.
+```
+
+Add the response schema to the `POST /sessions/:id/complete` schema block:
+
+```ts
+schema: {
+  params: ...,
+  body: ...,
+  response: { 200: z.object({ success: z.literal(true), data: SessionCompleteResponseSchema }) },
+},
+```
+
+- [ ] **Step 2b: Update the route handler body** to destructure and re-return the new fields. Replace:
+
+```ts
+const { session, transitions } = unwrapResult(result).data;
+// ...existing cache + queue + return...
+return successResponse({ session, transitions });
+```
+
+with:
+
+```ts
+const { session, transitions, xpAward, streakDelta } = unwrapResult(result).data;
+// ...existing cache + queue logic unchanged...
+return successResponse({ session, transitions, xpAward, streakDelta });
+```
+
+Without this update, the new fields will be silently dropped from the HTTP response even though the schema declares them.
+
+- [ ] **Step 3: Run full server tests + typecheck.**
+
+```bash
+bun --cwd apps/server check-types
+bun test apps/server/src/features/
+```
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/shared/src/sessions.ts apps/server/src/features/sessions/sessions.route.ts
+git commit -m "feat(sessions): expose xpAward + streakDelta on /complete; lock response schema"
+```
+
+---
+
+## Gate D
+
+After Task 4, dispatch a final Opus spec-coverage review against the branch diff:
+- §8 acceptance criteria all covered.
+- Multiplier triggers on `streakAfter > 7`.
+- Response schema column names match the repo's actual return.
+- `xpAward: null` path works when gamification service is absent (legacy ctor).

--- a/docs/superpowers/specs/2026-05-12-phase-2f1-session-xp-bonus-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2f1-session-xp-bonus-design.md
@@ -1,0 +1,154 @@
+# Phase 2F.1 — Session-completion XP bonus + enriched complete response (design spec)
+
+**Date:** 2026-05-12
+**Branch:** `feature/phase-2f1-session-xp-bonus`
+**Depends on:** Phase 2C (lives), Phase 2A (mastery transitions), Phase 2D (streak). Reuses `GamificationService`, `StreaksService`.
+
+## 1. Problem
+
+`pruvi-freatures.md` §3.1 mandates THREE XP mechanics:
+1. Per-answer XP (already shipped — difficulty-based 10/20/35).
+2. **50 XP flat for completing a session** — not implemented.
+3. **+10% multiplier when streak > 7 days** — not implemented.
+
+§2.5 also mandates the session-encerramento screen show `xpDelta` (XP gained THIS session) and `streakDelta` (did the streak advance today?). The current `POST /sessions/:id/complete` returns only `{ session, transitions }`. The client has to call `GET /gamification/xp` AND `GET /streaks` separately to assemble the encerramento — two extra round-trips on a critical UX path.
+
+## 2. Goal
+
+1. Add `GamificationService.awardXpForSessionCompletion(userId, questionsCorrect, currentStreak): Promise<Result<SessionXpAward>>` that grants:
+   - **Base:** 50 XP flat for any completed session.
+   - **Correct bonus:** +5 XP per correct answer (per §3.1 — additive on top of the per-answer XP already granted during answering).
+   - **Streak multiplier:** if `currentStreak > 7`, multiply (base + correct bonus) by 1.10. Floor to integer XP.
+2. Wire the call into `SessionsService.completeSession` AFTER `repo.completeSession` (so the daily session is recorded — which is what makes the streak advance today).
+3. Compute `xpDelta = sessionBonus` and `streakDelta = streakAfter - streakBefore`.
+4. Return `{ session, transitions, xpAward, streakDelta }` from the service; expose at the route.
+
+## 3. Out of scope
+
+- Changing the per-answer XP formula (10/20/35 per difficulty stays).
+- A backfill of XP for sessions completed before this phase ships.
+- Animating the encerramento (frontend phase).
+
+## 4. Architecture
+
+### 4.1 Module changes
+
+- `packages/shared/src/xp.ts` — new pure helper `calculateSessionCompletionXp(questionsCorrect: number, currentStreak: number): { base: 50, correctBonus: number, streakMultiplier: 1 | 1.1, total: number }`. Unit-testable, no I/O.
+- `packages/shared/src/topics.ts` — add `export const MasteryTransitionsSchema = z.array(MasteryTransitionSchema)` (current exports only the singular `MasteryTransitionSchema`).
+- `packages/shared/src/sessions.ts` — new `SessionCompleteResponseSchema` Zod schema (the route's response shape becomes typed). Includes `xpAward: { xpAwarded, totalXp, currentLevel, base, correctBonus, streakMultiplier }` and `streakDelta: number`. **The `session` sub-schema must mirror the exact column names returned by `SessionsRepository.completeSession`** — verify by reading the repo before writing the schema. If the repo returns `questionsAnswered`/`questionsCorrect`, the schema must use those names (NOT `questionCount`/`correctCount`).
+- `apps/server/src/features/gamification/gamification.service.ts` — new method `awardXpForSessionCompletion(userId, questionsCorrect, currentStreak)`. Reuses `repo.awardXp + getLevelForXp`.
+- `apps/server/src/features/sessions/sessions.service.ts` — `completeSession` integrates the new flow:
+  - Read streak BEFORE completion (so `streakDelta` is meaningful).
+  - After `repo.completeSession`, read streak AFTER (this is where today's session counts toward the streak).
+  - Call `gamificationService.awardXpForSessionCompletion`.
+  - Return enriched payload.
+  - `GamificationService` added to ctor as an **OPTIONAL** dependency (mirroring `dispatcher` and `shieldsService` patterns). When absent, return `xpAward: null` and `streakDelta: 0`. This preserves backward compat for the ~8 inline `new SessionsService(...)` test constructions that pass 3 args.
+- `apps/server/src/features/sessions/sessions.route.ts` — wire `gamificationService` into the service construction; declare the response schema.
+
+### 4.2 XP formula (pure, deterministic)
+
+```ts
+const BASE_SESSION_XP = 50;
+const PER_CORRECT_XP = 5;
+const STREAK_MULTIPLIER_THRESHOLD = 7;
+const STREAK_MULTIPLIER = 1.10;
+
+function calculateSessionCompletionXp(correct: number, streak: number) {
+  const base = BASE_SESSION_XP;
+  const correctBonus = correct * PER_CORRECT_XP;
+  const multiplier = streak > STREAK_MULTIPLIER_THRESHOLD ? STREAK_MULTIPLIER : 1;
+  const total = Math.floor((base + correctBonus) * multiplier);
+  return { base, correctBonus, streakMultiplier: multiplier, total };
+}
+```
+
+Examples:
+- 8 correct, streak=3 → `floor((50 + 40) * 1.0) = 90`.
+- 10 correct, streak=8 → `floor((50 + 50) * 1.1) = 110`.
+- 6 correct, streak=30 → `floor((50 + 30) * 1.1) = 88`.
+
+### 4.3 Streak read ordering
+
+Streak is computed from `daily_session` rows. The session-complete TX (`repo.completeSession`) is what makes the row reach `status='completed'`, which in turn is what the streak query counts. So:
+
+- `streakBefore = (await streaksService.getStreaks(userId)).currentStreak` (BEFORE `repo.completeSession`).
+- `repo.completeSession(...)` runs.
+- `streakAfter = (await streaksService.getStreaks(userId)).currentStreak` (AFTER).
+
+**No new method needed.** `StreaksService.getStreaks` calls `repo.getCompletedSessionDates` directly — there is NO in-service cache. The `streaks:${userId}` Redis cache lives in the route handler, not in the service, so service-internal reads bypass it naturally. Both calls hit the DB and reflect the true state at their moment.
+
+`streakDelta = streakAfter - streakBefore`. Expected values:
+- `1` — first session of a new day, streak advanced.
+- `0` — user already had a completed session today; second-of-day session does not move the streak.
+- Anything else is anomalous; log WARN.
+
+### 4.4 Response shape
+
+```ts
+SessionCompleteResponseSchema = z.object({
+  session: z.object({ /* existing — id, status, questionCount, correctCount, completedAt */ }),
+  transitions: MasteryTransitionsSchema,
+  xpAward: z.object({
+    xpAwarded: z.number().int().nonnegative(),    // total = base + correctBonus, multiplied
+    totalXp: z.number().int().nonnegative(),       // user's totalXp AFTER this award
+    currentLevel: z.number().int().min(1),
+    base: z.literal(50),
+    correctBonus: z.number().int().nonnegative(),
+    streakMultiplier: z.union([z.literal(1), z.literal(1.10)]),
+  }),
+  streakDelta: z.number().int(),                   // 0 or 1 in normal flow
+})
+```
+
+## 5. Public surface
+
+- `POST /sessions/:id/complete` — same URL + body; **response shape extended** (additive — old clients ignore new fields).
+- No new env vars, no migration.
+
+## 6. Failure modes
+
+| Cause | Response | Side effect |
+|---|---|---|
+| Existing failure paths (session not found / not owned / already completed) | Same as today | None |
+| `streakBefore` read fails | Treat as 0; log WARN | Award proceeds with default multiplier (no streak bonus) |
+| `awardXpForSessionCompletion` fails (e.g., user row gone — `repo.awardXp` returns `undefined`) | Return `xpAward: null` in the response (200) | Service explicitly null-guards the `awardXp` return: `const updated = await repo.awardXp(...); if (!updated) return { ...empty award }`. Log WARN with `{ userId, sessionId }`. |
+
+## 7. Testing strategy
+
+### 7.1 Pure unit — `calculateSessionCompletionXp`
+- 8 correct + streak=3 → 90.
+- 10 correct + streak=8 → 110.
+- 10 correct + streak=7 → 100 (boundary — multiplier kicks in at streak > 7, NOT >=).
+- 10 correct + streak=8 → 110.
+- 0 correct + streak=0 → 50.
+- 0 correct + streak=100 → 55.
+- Integer floor: 7 correct + streak=10 → floor((50 + 35) * 1.1) = floor(93.5) = 93.
+
+### 7.2 GamificationService unit
+- `awardXpForSessionCompletion(uid, 8, 3)` calls `repo.awardXp(uid, 90, expectedLevel)` and returns the award shape.
+- Streak above threshold path: `awardXpForSessionCompletion(uid, 10, 8)` calls `repo.awardXp(uid, 110, ...)`.
+
+### 7.3 SessionsService unit (mocked repos)
+- `completeSession` calls `streaksService.getStreaks` twice (before + after `repo.completeSession`), captures `streakDelta` correctly.
+- The returned `xpAward.total` equals `calculateSessionCompletionXp(correct, streakAfter).total` — **use `streakAfter` for the multiplier** (the post-completion streak). This rewards a user crossing 7→8 on the day they cross. Document with a code comment referencing this spec §.
+- `streakDelta` equals 1 when this completes the first session-of-day; 0 when it's the second-of-day.
+- When `gamificationService` is absent (legacy 3-arg ctor), `xpAward` is `null` and `streakDelta` is `0`.
+
+### 7.4 Route integration
+- `POST /sessions/:id/complete` returns the new payload shape end-to-end with a fresh test user.
+
+## 8. Acceptance criteria
+
+- [ ] `calculateSessionCompletionXp` is a pure function exported from `@pruvi/shared`.
+- [ ] `GamificationService.awardXpForSessionCompletion` reuses existing `repo.awardXp`.
+- [ ] `SessionsService.completeSession` reads streak before and after `repo.completeSession`, computes `streakDelta`.
+- [ ] Streak multiplier uses `streakAfter` (the post-completion streak) — comment documents this.
+- [ ] `POST /sessions/:id/complete` response includes `xpAward` + `streakDelta`.
+- [ ] Response shape locked by `SessionCompleteResponseSchema` declared on the Fastify route.
+- [ ] Existing tests pass; new tests cover the formula + the orchestration.
+
+## 9. Deferred
+
+- Backfill XP for historical completed sessions.
+- Variable per-difficulty multipliers (medium = 1.5x correct bonus etc.).
+- Daily-cap on XP earned.

--- a/packages/shared/src/sessions.ts
+++ b/packages/shared/src/sessions.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MasteryTransitionsSchema } from "./topics";
 
 /** POST /sessions/start — request body */
 export const StartSessionBodySchema = z.object({
@@ -7,3 +8,31 @@ export const StartSessionBodySchema = z.object({
 });
 
 export type StartSessionBody = z.infer<typeof StartSessionBodySchema>;
+
+/** POST /sessions/:id/complete — response body */
+export const SessionCompleteResponseSchema = z.object({
+  session: z.object({
+    id: z.number().int(),
+    userId: z.string(),
+    status: z.enum(["active", "completed"]),
+    questionsAnswered: z.number().int().nonnegative().nullable(),
+    questionsCorrect: z.number().int().nonnegative().nullable(),
+    masterySnapshot: z.record(z.string(), z.string()).nullable(),
+    // Fastify serializes Date → ISO string before response-schema validation runs,
+    // so the schema MUST be `z.string()` not `z.date()` (see simulados route pattern).
+    completedAt: z.string().nullable(),
+    createdAt: z.string(),
+  }),
+  transitions: MasteryTransitionsSchema,
+  xpAward: z.object({
+    xpAwarded: z.number().int().nonnegative(),
+    totalXp: z.number().int().nonnegative(),
+    currentLevel: z.number().int().min(1),
+    base: z.literal(50),
+    correctBonus: z.number().int().nonnegative(),
+    streakMultiplier: z.union([z.literal(1), z.literal(1.10)]),
+  }).nullable(),
+  streakDelta: z.number().int(),
+});
+
+export type SessionCompleteResponse = z.infer<typeof SessionCompleteResponseSchema>;

--- a/packages/shared/src/topics.ts
+++ b/packages/shared/src/topics.ts
@@ -62,8 +62,11 @@ export const MasteryTransitionSchema = z.object({
   to: MasteryStateSchema,
 });
 
+export const MasteryTransitionsSchema = z.array(MasteryTransitionSchema);
+
 export type MasteryListItem = z.infer<typeof MasteryListItemSchema>;
 export type SubtopicMastery = z.infer<typeof SubtopicMasterySchema>;
 export type TrilhaResponse = z.infer<typeof TrilhaResponseSchema>;
 export type TopicDetailResponse = z.infer<typeof TopicDetailResponseSchema>;
 export type MasteryTransition = z.infer<typeof MasteryTransitionSchema>;
+export type MasteryTransitions = z.infer<typeof MasteryTransitionsSchema>;

--- a/packages/shared/src/xp.test.ts
+++ b/packages/shared/src/xp.test.ts
@@ -5,6 +5,7 @@ import {
   xpForNextLevel,
   XP_PER_DIFFICULTY,
   LEVEL_THRESHOLDS,
+  calculateSessionCompletionXp,
 } from "./xp";
 
 describe("calculateXpForAnswer", () => {
@@ -55,5 +56,45 @@ describe("xpForNextLevel", () => {
 
   it("returns 0 at max level", () => {
     expect(xpForNextLevel(999999)).toBe(0);
+  });
+});
+
+describe("calculateSessionCompletionXp", () => {
+  it("0 correct, streak=0 → base 50, no bonus, multiplier 1, total 50", () => {
+    expect(calculateSessionCompletionXp(0, 0)).toEqual({
+      base: 50,
+      correctBonus: 0,
+      streakMultiplier: 1,
+      total: 50,
+    });
+  });
+
+  it("8 correct, streak=3 → total 90", () => {
+    const result = calculateSessionCompletionXp(8, 3);
+    expect(result.total).toBe(90); // (50 + 40) * 1 = 90
+  });
+
+  it("10 correct, streak=7 → total 100 (boundary: multiplier NOT applied at 7)", () => {
+    const result = calculateSessionCompletionXp(10, 7);
+    expect(result.streakMultiplier).toBe(1);
+    expect(result.total).toBe(100); // (50 + 50) * 1 = 100
+  });
+
+  it("10 correct, streak=8 → total 110 (multiplier applied above 7)", () => {
+    const result = calculateSessionCompletionXp(10, 8);
+    expect(result.streakMultiplier).toBe(1.10);
+    expect(result.total).toBe(110); // floor((50 + 50) * 1.1) = 110
+  });
+
+  it("7 correct, streak=10 → total 93 (floor applied)", () => {
+    const result = calculateSessionCompletionXp(7, 10);
+    expect(result.streakMultiplier).toBe(1.10);
+    expect(result.total).toBe(93); // floor((50 + 35) * 1.1) = floor(93.5) = 93
+  });
+
+  it("negative questionsCorrect treated as 0 (defensive) → total 50", () => {
+    const result = calculateSessionCompletionXp(-5, 0);
+    expect(result.correctBonus).toBe(0);
+    expect(result.total).toBe(50);
   });
 });

--- a/packages/shared/src/xp.ts
+++ b/packages/shared/src/xp.ts
@@ -55,3 +55,22 @@ export const XpResponseSchema = z.object({
 });
 
 export type XpResponse = z.infer<typeof XpResponseSchema>;
+
+// ─── Session-completion XP bonus ──────────────────────────────────────────────
+
+export const SESSION_COMPLETION_BASE_XP = 50;
+export const SESSION_PER_CORRECT_XP = 5;
+export const SESSION_STREAK_MULTIPLIER_THRESHOLD = 7;
+export const SESSION_STREAK_MULTIPLIER = 1.10;
+
+export function calculateSessionCompletionXp(
+  questionsCorrect: number,
+  streakAfter: number,
+): { base: number; correctBonus: number; streakMultiplier: number; total: number } {
+  const base = SESSION_COMPLETION_BASE_XP;
+  const correctBonus = Math.max(0, questionsCorrect) * SESSION_PER_CORRECT_XP;
+  const streakMultiplier =
+    streakAfter > SESSION_STREAK_MULTIPLIER_THRESHOLD ? SESSION_STREAK_MULTIPLIER : 1;
+  const total = Math.floor((base + correctBonus) * streakMultiplier);
+  return { base, correctBonus, streakMultiplier, total };
+}


### PR DESCRIPTION
## Summary
Implements `pruvi-freatures.md` §3.1's missing XP mechanics and §2.5's encerramento payload. Every completed session now grants a 50-XP base bonus + 5 XP per correct answer, multiplied by 1.10 when `streakAfter > 7`. The `/sessions/:id/complete` response now carries `xpAward` and `streakDelta` so the client can animate the encerramento screen without extra round-trips.

## How it works
- `calculateSessionCompletionXp(questionsCorrect, streakAfter)` — pure helper in `@pruvi/shared`. Boundary at `streak > 7` (strict). Integer-floored total.
- `GamificationService.awardXpForSessionCompletion` — reuses existing `repo.awardXp` with a null-guard for user-deleted mid-flow.
- `SessionsService.completeSession` reads streak before + after `repo.completeSession` (no cache between them — `getStreaks` is uncached at the service layer), computes `streakDelta`, then awards XP using the post-completion streak (rewards crossing 7→8 on the crossing day).
- `gamificationService` is an OPTIONAL 8th ctor arg — backward-compatible with the 8+ existing 3-arg test constructions.
- Response shape locked by new `SessionCompleteResponseSchema` (dates as `z.string()` since Fastify serializes Date→ISO before validation).

## Spec / plan
- Spec: `docs/superpowers/specs/2026-05-12-phase-2f1-session-xp-bonus-design.md`
- Plan: `docs/superpowers/plans/2026-05-12-phase-2f1-session-xp-bonus.md`
- 4-gate workflow: Gate A (6 catches), Gate B (2 blockers — `z.date()` would have broken every response; route handler wasn't destructuring the new fields), Gate D (all ACs pass).

## Test plan
- [x] `xp.test.ts` — 6 new boundary cases (streak=7 vs 8, integer floor)
- [x] `gamification.service.test.ts` — 4 new cases incl. null-guard
- [x] `sessions.service.test.ts` — 2 new cases incl. legacy 3-arg ctor backward compat
- [x] Full sessions + gamification suite: 41/41 pass

## Tracker
- Feature 3.1 (XP + streak multiplier): ✅
- Feature 2.5 (encerramento payload): ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session completion now awards XP based on correct answers and streak performance
  * `POST /sessions/:id/complete` API response now includes XP award details and streak delta information

* **Tests**
  * Added comprehensive test coverage for gamification and session completion scenarios

* **Documentation**
  * Added design specification and implementation plan for session XP reward system

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CeCamillo/pruvi/pull/33)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->