### PR TITLE
feat: phase 2f.2 — session timer toggle preference

### DIFF
--- a/apps/server/src/features/users/session-preferences.integration.test.ts
+++ b/apps/server/src/features/users/session-preferences.integration.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import {
+  setupTestDb,
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../test/db-helpers";
+import { user } from "@pruvi/db/schema/auth";
+import { SessionPreferencesRepository } from "./session-preferences.repository";
+
+describe("SessionPreferencesRepository (integration)", () => {
+  const db = getTestDb();
+  const repo = new SessionPreferencesRepository(db);
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  it("get returns showTimer = true by default for a new user", async () => {
+    const userId = "test-session-pref-user";
+
+    await db.insert(user).values({
+      id: userId,
+      name: "Session Pref User",
+      email: `${userId}@example.com`,
+      emailVerified: false,
+      updatedAt: new Date(),
+    });
+
+    const result = await repo.get(userId);
+    expect(result).not.toBeNull();
+    expect(result?.showTimer).toBe(true);
+  });
+
+  it("update sets showTimer to false and get returns false", async () => {
+    const userId = "test-session-pref-update";
+
+    await db.insert(user).values({
+      id: userId,
+      name: "Session Pref Update",
+      email: `${userId}@example.com`,
+      emailVerified: false,
+      updatedAt: new Date(),
+    });
+
+    const updated = await repo.update(userId, { showTimer: false });
+    expect(updated).not.toBeNull();
+    expect(updated?.showTimer).toBe(false);
+
+    const row = await repo.get(userId);
+    expect(row?.showTimer).toBe(false);
+  });
+
+  it("get returns null for unknown user", async () => {
+    const result = await repo.get("non-existent-user");
+    expect(result).toBeNull();
+  });
+
+  it("update returns null for unknown user", async () => {
+    const result = await repo.update("non-existent-user", { showTimer: false });
+    expect(result).toBeNull();
+  });
+});

--- a/apps/server/src/features/users/session-preferences.repository.ts
+++ b/apps/server/src/features/users/session-preferences.repository.ts
@@ -1,0 +1,27 @@
+import { eq } from "drizzle-orm";
+import { user } from "@pruvi/db/schema/auth";
+import type { db as DbClient } from "@pruvi/db";
+
+type Db = typeof DbClient;
+
+export class SessionPreferencesRepository {
+  constructor(private db: Db) {}
+
+  async get(userId: string): Promise<{ showTimer: boolean } | null> {
+    const rows = await this.db
+      .select({ showTimer: user.showTimer })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async update(userId: string, patch: { showTimer: boolean }): Promise<{ showTimer: boolean } | null> {
+    const rows = await this.db
+      .update(user)
+      .set({ showTimer: patch.showTimer })
+      .where(eq(user.id, userId))
+      .returning({ showTimer: user.showTimer });
+    return rows[0] ?? null;
+  }
+}

--- a/apps/server/src/features/users/session-preferences.route.ts
+++ b/apps/server/src/features/users/session-preferences.route.ts
@@ -1,0 +1,48 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { UpdateSessionPreferencesBodySchema, SessionPreferencesSchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { successResponse } from "../../types";
+import { NotFoundError } from "../../utils/errors";
+import { SessionPreferencesRepository } from "./session-preferences.repository";
+
+const repo = new SessionPreferencesRepository(db);
+const TTL = 60;
+
+export const sessionPreferencesRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/users/me/session-preferences",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: SessionPreferencesSchema }) } },
+    },
+    async (request) => {
+      const cacheKey = `prefs:session:${request.userId}`;
+      const cached = await fastify.cache.get<{ showTimer: boolean }>(cacheKey);
+      if (cached) return successResponse(cached);
+      const row = await repo.get(request.userId);
+      if (!row) {
+        throw new NotFoundError("User not found");
+      }
+      await fastify.cache.set(cacheKey, row, TTL);
+      return successResponse(row);
+    },
+  );
+
+  fastify.put(
+    "/users/me/session-preferences",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        body: UpdateSessionPreferencesBodySchema,
+        response: { 200: z.object({ success: z.literal(true), data: SessionPreferencesSchema }) },
+      },
+    },
+    async (request) => {
+      const updated = await repo.update(request.userId, request.body);
+      if (!updated) throw new NotFoundError("User not found");
+      await fastify.cache.del(`prefs:session:${request.userId}`);
+      return successResponse(updated);
+    },
+  );
+};

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -24,6 +24,7 @@ import { streaksRoutes } from "./features/streaks";
 import { subjectsRoutes } from "./features/subjects";
 import { topicsRoutes } from "./features/topics";
 import { usersRoutes } from "./features/users";
+import { sessionPreferencesRoutes } from "./features/users/session-preferences.route";
 import { authPlugin } from "./plugins/auth";
 import { errorHandlerPlugin } from "./plugins/error-handler";
 import { queuePlugin } from "./plugins/queue";
@@ -85,6 +86,7 @@ export async function buildApp() {
   await app.register(topicsRoutes);
   await app.register(tokensRoutes);
   await app.register(preferencesRoutes);
+  await app.register(sessionPreferencesRoutes);
   await app.register(invitationsRoutes);
   await app.register(friendshipsRoutes);
   await app.register(rankingRoutes);

--- a/docs/superpowers/plans/2026-05-12-phase-2f2-session-timer-pref.md
+++ b/docs/superpowers/plans/2026-05-12-phase-2f2-session-timer-pref.md
@@ -1,0 +1,143 @@
+# Phase 2F.2 — Session timer toggle preference — Plan
+
+Branch: `feature/phase-2f2-session-timer-pref`. Spec: `docs/superpowers/specs/2026-05-12-phase-2f2-session-timer-pref-design.md`.
+
+## File map
+
+**Create:**
+- `apps/server/src/features/users/session-preferences.repository.ts` + `.test.ts`
+- `apps/server/src/features/users/session-preferences.route.ts`
+- `apps/server/src/features/users/session-preferences.integration.test.ts`
+- New migration `0013_*.sql` (drizzle-kit generated)
+
+**Modify:**
+- `packages/db/src/schema/auth.ts` — add `showTimer` column.
+- `packages/shared/src/users.ts` — add `SessionPreferencesSchema` + `UpdateSessionPreferencesBodySchema`.
+- `apps/server/src/server.ts` (or wherever routes register) — register the new route.
+
+## Tasks
+
+### Task 1: Schema + migration
+
+- Add `showTimer: boolean("show_timer").notNull().default(true)` to `user` in `packages/db/src/schema/auth.ts` after `notificationHour`.
+- `bun --cwd packages/db run db:generate` → produces `0013_*.sql`. Verify it has `ALTER TABLE "user" ADD COLUMN "show_timer" boolean DEFAULT true NOT NULL`.
+- `bun --cwd packages/db run db:migrate` to apply locally.
+- Update `apps/server/src/test/db-helpers.ts` only if needed (no new table — no truncation change required).
+- Commit: `feat(db): add user.show_timer column for session timer toggle`.
+
+### Task 2: Shared schemas
+
+- Append to `packages/shared/src/users.ts`:
+
+```ts
+export const SessionPreferencesSchema = z.object({
+  showTimer: z.boolean(),
+});
+export type SessionPreferences = z.infer<typeof SessionPreferencesSchema>;
+export const UpdateSessionPreferencesBodySchema = SessionPreferencesSchema;
+```
+
+- Commit: `feat(shared): add session preferences schemas`.
+
+### Task 3: Repository + tests
+
+- `session-preferences.repository.ts`:
+
+```ts
+import { eq } from "drizzle-orm";
+import { user } from "@pruvi/db/schema/auth";
+import type { db as DbClient } from "@pruvi/db";
+
+type Db = typeof DbClient;
+
+export class SessionPreferencesRepository {
+  constructor(private db: Db) {}
+
+  async get(userId: string): Promise<{ showTimer: boolean } | null> {
+    const rows = await this.db
+      .select({ showTimer: user.showTimer })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async update(userId: string, patch: { showTimer: boolean }): Promise<{ showTimer: boolean } | null> {
+    const rows = await this.db
+      .update(user)
+      .set({ showTimer: patch.showTimer })
+      .where(eq(user.id, userId))
+      .returning({ showTimer: user.showTimer });
+    return rows[0] ?? null;
+  }
+}
+```
+
+- Integration test (`session-preferences.integration.test.ts`) — seed a user, assert default `showTimer === true`, update to `false`, re-read returns `false`. Use the existing `insertUser` pattern from other integration tests.
+- Commit: `feat(users): session-preferences repository`.
+
+### Task 4: Route + caching
+
+- `session-preferences.route.ts` — mirror `notifications/preferences.route.ts` exactly:
+
+```ts
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { UpdateSessionPreferencesBodySchema, SessionPreferencesSchema } from "@pruvi/shared";
+import { db } from "@pruvi/db";
+import { successResponse, unwrapResult } from "../../types";
+import { ok, err, type Result } from "neverthrow";
+import { AppError, NotFoundError } from "../../utils/errors";
+import { SessionPreferencesRepository } from "./session-preferences.repository";
+
+const repo = new SessionPreferencesRepository(db);
+const TTL = 60;
+
+export const sessionPreferencesRoutes: FastifyPluginAsyncZod = async (fastify) => {
+  fastify.get(
+    "/users/me/session-preferences",
+    {
+      preHandler: [fastify.authenticate],
+      schema: { response: { 200: z.object({ success: z.literal(true), data: SessionPreferencesSchema }) } },
+    },
+    async (request) => {
+      const cacheKey = `prefs:session:${request.userId}`;
+      const cached = await fastify.cache.get<{ showTimer: boolean }>(cacheKey);
+      if (cached) return successResponse(cached);
+      const row = await repo.get(request.userId);
+      if (!row) {
+        // Throwing AppError so the error handler returns the right status.
+        throw new NotFoundError("User not found");
+      }
+      await fastify.cache.set(cacheKey, row, TTL);
+      return successResponse(row);
+    },
+  );
+
+  fastify.put(
+    "/users/me/session-preferences",
+    {
+      preHandler: [fastify.authenticate],
+      schema: {
+        body: UpdateSessionPreferencesBodySchema,
+        response: { 200: z.object({ success: z.literal(true), data: SessionPreferencesSchema }) },
+      },
+    },
+    async (request) => {
+      const updated = await repo.update(request.userId, request.body);
+      if (!updated) throw new NotFoundError("User not found");
+      await fastify.cache.del(`prefs:session:${request.userId}`);
+      return successResponse(updated);
+    },
+  );
+};
+```
+
+- Register the route in `apps/server/src/server.ts` (find where `preferencesRoutes` is registered and add `sessionPreferencesRoutes` alongside).
+- Commit: `feat(users): session-preferences route with cache invalidation`.
+
+## Gate D
+
+- All ACs pass.
+- Existing users get `showTimer = true` after migration.
+- PUT invalidates the cache so subsequent GET returns fresh data.

--- a/docs/superpowers/specs/2026-05-12-phase-2f2-session-timer-pref-design.md
+++ b/docs/superpowers/specs/2026-05-12-phase-2f2-session-timer-pref-design.md
@@ -1,0 +1,38 @@
+# Phase 2F.2 — Session timer toggle preference (design spec)
+
+**Date:** 2026-05-12
+**Branch:** `feature/phase-2f2-session-timer-pref`
+
+## 1. Problem
+
+`pruvi-freatures.md` §6.3 mandates a user setting to enable/disable the session timer. Currently no `show_timer` column or endpoint exists.
+
+## 2. Goal
+
+Add `showTimer: boolean default true` to `user` table; expose via `GET /users/me/session-preferences` and `PUT /users/me/session-preferences`. Cached identical to the notification-prefs pattern.
+
+## 3. Architecture
+
+- Migration `0013_*.sql`: `ALTER TABLE "user" ADD COLUMN "show_timer" boolean NOT NULL DEFAULT true`.
+- `packages/db/src/schema/auth.ts`: add `showTimer: boolean("show_timer").notNull().default(true)` next to `notificationHour`.
+- `packages/shared/src/users.ts` (or new `session-preferences.ts`): `SessionPreferencesSchema = z.object({ showTimer: z.boolean() })` + `UpdateSessionPreferencesBodySchema`.
+- `apps/server/src/features/users/session-preferences.repository.ts` — `get(userId)` + `update(userId, { showTimer })`. Direct Drizzle, no service-layer logic.
+- `apps/server/src/features/users/session-preferences.route.ts` — `GET` and `PUT`, caching `prefs:session:${userId}` for 60s with invalidation on PUT. Same shape as `preferences.route.ts`.
+- Register the new route in the server bootstrap (alongside `preferencesRoutes`).
+
+## 4. Testing
+
+- Unit test repo `get`/`update`.
+- Integration test: PUT → GET reflects new value; cache invalidated.
+
+## 5. Acceptance criteria
+
+- [ ] Migration applied. `user.show_timer` exists with default `true`.
+- [ ] `GET /users/me/session-preferences` returns `{ showTimer: boolean }`.
+- [ ] `PUT /users/me/session-preferences` accepts `{ showTimer }` and persists.
+- [ ] Cache invalidated on PUT.
+- [ ] Existing user rows have `showTimer = true` after migration.
+
+## 6. Deferred
+
+- A unified `/users/me/preferences` consolidating notifications + session + future toggles. Out of scope for v1; can refactor later.

--- a/packages/db/src/migrations/0013_freezing_kylun.sql
+++ b/packages/db/src/migrations/0013_freezing_kylun.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "show_timer" boolean DEFAULT true NOT NULL;

--- a/packages/db/src/migrations/meta/0013_snapshot.json
+++ b/packages/db/src/migrations/meta/0013_snapshot.json
@@ -1,0 +1,2165 @@
+{
+  "id": "2bb8c565-44b5-4755-a42b-26b045ff4563",
+  "prevId": "dafc6113-3a52-471d-bb3c-459f73deeb6c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives": {
+          "name": "lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "bonus_lives": {
+          "name": "bonus_lives",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lives_last_regen_at": {
+          "name": "lives_last_regen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "selected_exam": {
+          "name": "selected_exam",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulties": {
+          "name": "difficulties",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "daily_study_time_minutes": {
+          "name": "daily_study_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ultra": {
+          "name": "is_ultra",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ultra_expires_at": {
+          "name": "ultra_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)"
+        },
+        "invite_reward_preference": {
+          "name": "invite_reward_preference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'xp'"
+        },
+        "notification_hour": {
+          "name": "notification_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 19
+        },
+        "show_timer": {
+          "name": "show_timer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "streak_reminders_enabled": {
+          "name": "streak_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "achievement_notifications_enabled": {
+          "name": "achievement_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "streak_shields_available": {
+          "name": "streak_shields_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_shield_grant_at": {
+          "name": "last_shield_grant_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_event": {
+      "name": "billing_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_token": {
+          "name": "purchase_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "billing_event_provider_message_uq": {
+          "name": "billing_event_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_event_token_idx": {
+          "name": "billing_event_token_idx",
+          "columns": [
+            {
+              "expression": "purchase_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_event_unprocessed_idx": {
+          "name": "billing_event_unprocessed_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"billing_event\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_token": {
+          "name": "purchase_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_provider_token_uq": {
+          "name": "subscription_provider_token_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchase_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscription_user_idx": {
+          "name": "subscription_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscription_status_idx": {
+          "name": "subscription_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_session": {
+      "name": "daily_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "questions_answered": {
+          "name": "questions_answered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "questions_correct": {
+          "name": "questions_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastery_snapshot": {
+          "name": "mastery_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_session_user_created_idx": {
+          "name": "daily_session_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_session_user_id_user_id_fk": {
+          "name": "daily_session_user_id_user_id_fk",
+          "tableFrom": "daily_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "friendship_requester_idx": {
+          "name": "friendship_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendship_recipient_idx": {
+          "name": "friendship_recipient_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendship_requester_id_user_id_fk": {
+          "name": "friendship_requester_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_recipient_id_user_id_fk": {
+          "name": "friendship_recipient_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subject_name_unique": {
+          "name": "subject_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "subject_slug_unique": {
+          "name": "subject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopic": {
+      "name": "subtopic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtopic_topic_order_idx": {
+          "name": "subtopic_topic_order_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopic_topic_id_topic_id_fk": {
+          "name": "subtopic_topic_id_topic_id_fk",
+          "tableFrom": "subtopic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtopic_topic_slug_uniq": {
+          "name": "subtopic_topic_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topic_subject_order_idx": {
+          "name": "topic_subject_order_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_subject_id_subject_id_fk": {
+          "name": "topic_subject_id_subject_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_subject_slug_uniq": {
+          "name": "topic_subject_slug_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_option_index": {
+          "name": "correct_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_calculation": {
+          "name": "requires_calculation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtopic_id": {
+          "name": "subtopic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_subject_difficulty_idx": {
+          "name": "question_subject_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_subtopic_difficulty_idx": {
+          "name": "question_subtopic_difficulty_idx",
+          "columns": [
+            {
+              "expression": "subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_subject_id_subject_id_fk": {
+          "name": "question_subject_id_subject_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subject",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_subtopic_id_subtopic_id_fk": {
+          "name": "question_subtopic_id_subtopic_id_fk",
+          "tableFrom": "question",
+          "tableTo": "subtopic",
+          "columnsFrom": [
+            "subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_log": {
+      "name": "review_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "review_log_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "easiness_factor": {
+          "name": "easiness_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_log_user_next_review_idx": {
+          "name": "review_log_user_next_review_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_log_user_question_idx": {
+          "name": "review_log_user_question_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_log_user_id_user_id_fk": {
+          "name": "review_log_user_id_user_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_log_question_id_question_id_fk": {
+          "name": "review_log_question_id_question_id_fk",
+          "tableFrom": "review_log",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_token": {
+      "name": "push_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_token_user_idx": {
+          "name": "push_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_token_user_id_user_id_fk": {
+          "name": "push_token_user_id_user_id_fk",
+          "tableFrom": "push_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_token_token_unique": {
+          "name": "push_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_acceptance": {
+      "name": "invitation_acceptance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'xp'"
+        }
+      },
+      "indexes": {
+        "invitation_acceptance_inviter_idx": {
+          "name": "invitation_acceptance_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_acceptance_inviter_id_user_id_fk": {
+          "name": "invitation_acceptance_inviter_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_acceptance_invitee_id_user_id_fk": {
+          "name": "invitation_acceptance_invitee_id_user_id_fk",
+          "tableFrom": "invitation_acceptance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invitee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_acceptance_invitee_id_unique": {
+          "name": "invitation_acceptance_invitee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_shield_usage": {
+      "name": "streak_shield_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protected_date": {
+          "name": "protected_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "streak_shield_usage_user_date_idx": {
+          "name": "streak_shield_usage_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protected_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "streak_shield_usage_user_idx": {
+          "name": "streak_shield_usage_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "streak_shield_usage_user_id_user_id_fk": {
+          "name": "streak_shield_usage_user_id_user_id_fk",
+          "tableFrom": "streak_shield_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_simulado": {
+      "name": "weekly_simulado",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start_date": {
+          "name": "week_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions_count": {
+          "name": "questions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weekly_simulado_user_week_uq": {
+          "name": "weekly_simulado_user_week_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_simulado_user_week_idx": {
+          "name": "weekly_simulado_user_week_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_simulado_user_id_user_id_fk": {
+          "name": "weekly_simulado_user_id_user_id_fk",
+          "tableFrom": "weekly_simulado",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_simulado_question": {
+      "name": "weekly_simulado_question",
+      "schema": "",
+      "columns": {
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_index": {
+          "name": "selected_option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "weekly_simulado_question_simulado_question_uq": {
+          "name": "weekly_simulado_question_simulado_question_uq",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_simulado_question_simulado_idx": {
+          "name": "weekly_simulado_question_simulado_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_simulado_question_simulado_id_weekly_simulado_id_fk": {
+          "name": "weekly_simulado_question_simulado_id_weekly_simulado_id_fk",
+          "tableFrom": "weekly_simulado_question",
+          "tableTo": "weekly_simulado",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weekly_simulado_question_question_id_question_id_fk": {
+          "name": "weekly_simulado_question_question_id_question_id_fk",
+          "tableFrom": "weekly_simulado_question",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "weekly_simulado_question_simulado_id_position_pk": {
+          "name": "weekly_simulado_question_simulado_id_position_pk",
+          "columns": [
+            "simulado_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lives_purchase": {
+      "name": "lives_purchase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lives_granted": {
+          "name": "lives_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lives_purchase_provider_txn_uq": {
+          "name": "lives_purchase_provider_txn_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lives_purchase_user_created_idx": {
+          "name": "lives_purchase_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lives_purchase_user_id_user_id_fk": {
+          "name": "lives_purchase_user_id_user_id_fk",
+          "tableFrom": "lives_purchase",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1778630105634,
       "tag": "0012_smiling_albert_cleary",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1778632903997,
+      "tag": "0013_freezing_kylun",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -30,6 +30,7 @@ export const user = pgTable("user", {
     .default(sql`SUBSTRING(REPLACE(gen_random_uuid()::text, '-', '') FROM 1 FOR 8)`),
   inviteRewardPreference: text("invite_reward_preference", { enum: ["xp", "shield"] }).notNull().default("xp"),
   notificationHour: integer("notification_hour").notNull().default(19),
+  showTimer: boolean("show_timer").notNull().default(true),
   streakRemindersEnabled: boolean("streak_reminders_enabled").notNull().default(true),
   achievementNotificationsEnabled: boolean("achievement_notifications_enabled").notNull().default(true),
   streakShieldsAvailable: integer("streak_shields_available").notNull().default(0),

--- a/packages/shared/src/users.ts
+++ b/packages/shared/src/users.ts
@@ -29,3 +29,9 @@ export const InviteRewardPreferenceResponseSchema = z.object({
   preference: z.enum(["xp", "shield"]),
 });
 export type InviteRewardPreferenceResponse = z.infer<typeof InviteRewardPreferenceResponseSchema>;
+
+export const SessionPreferencesSchema = z.object({
+  showTimer: z.boolean(),
+});
+export type SessionPreferences = z.infer<typeof SessionPreferencesSchema>;
+export const UpdateSessionPreferencesBodySchema = SessionPreferencesSchema;


### PR DESCRIPTION
Closes §6.3 'timer ativado/desativado' gap. Adds `user.show_timer` (default true) + GET/PUT `/users/me/session-preferences` with 60s cache and invalidation on PUT. Mirrors the notification-prefs pattern exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now manage their session timer preference via dedicated endpoints (GET/PUT `/users/me/session-preferences`)
  * Session timer enabled by default for all users
  * Session preferences cached for performance optimization

* **Documentation**
  * Added design specification and implementation plan for session timer preferences feature

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CeCamillo/pruvi/pull/34)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->